### PR TITLE
Add a loading spinner to Food PoC page.

### DIFF
--- a/src/Page/Food/Simulator.elm
+++ b/src/Page/Food/Simulator.elm
@@ -24,6 +24,7 @@ import Views.CountrySelect
 import Views.Format as Format
 import Views.Impact exposing (impactSelector)
 import Views.RangeSlider as RangeSlider
+import Views.Spinner as Spinner
 
 
 type alias CurrentProductInfo =
@@ -339,7 +340,7 @@ view ({ foodDb, db } as session) { currentProductInfo, selectedProduct, impact, 
                     ]
 
                 _ ->
-                    [ text "Loading" ]
+                    [ Spinner.view ]
             )
       ]
     )


### PR DESCRIPTION
We can't track JSON db download progress because elm-http [doesn't allow tracking with task based requests](https://package.elm-lang.org/packages/elm/http/latest/Http#task), so [neither does remotedata-http](https://github.com/ohanhi/remotedata-http/issues/7).

So we're left with just a rolling spinner materializing the (long) loading stage, which is still better than nothing.