### PR TITLE
Fix final weight calculation (an original recipe's final weight is always 1kg)

### DIFF
--- a/src/Data/Food/Product.elm
+++ b/src/Data/Food/Product.elm
@@ -17,6 +17,7 @@ module Data.Food.Product exposing
     , emptyProducts
     , findProductByName
     , formatItem
+    , getAmountRatio
     , getMainItemComment
     , getStepImpact
     , getStepTransports
@@ -596,17 +597,23 @@ removeMaterial itemToRemove ({ plant } as product) =
         |> updateProductAmounts originalWeight
 
 
+getAmountRatio : Float -> Product -> Float
+getAmountRatio originalWeight currentProduct =
+    let
+        updatedWeight =
+            getWeightAtPlant currentProduct.plant
+    in
+    -- We need the new "ratio" between the original product and the updated one,
+    -- to change the amount for all the other processes (but the plant materials).
+    updatedWeight
+        / originalWeight
+
+
 updateProductAmounts : Float -> Product -> Product
 updateProductAmounts originalWeight ({ consumer, supermarket, distribution, packaging, plant } as product) =
     let
-        updatedWeight =
-            getWeightAtPlant plant
-
-        -- We need the new "ratio" between the original product and the updated one,
-        -- to change the amount for all the other processes (but the plant materials).
         amountRatio =
-            updatedWeight
-                / originalWeight
+            getAmountRatio originalWeight product
     in
     { product
         | consumer = updateStepAmounts amountRatio consumer

--- a/src/Page/Food/Simulator.elm
+++ b/src/Page/Food/Simulator.elm
@@ -292,11 +292,10 @@ viewSidebar session { definition, trigram, totalImpact } { original, product } =
             { header = []
             , body =
                 [ div [ class "d-flex flex-column m-auto gap-1 px-2" ]
-                    ([ h2 [ class "h5 m-0" ] [ text "Impact par kg de produit" ]
-                     , div [ class "display-4 lh-1 text-center text-nowrap" ]
-                        [ Format.formatImpactFloat definition 2 impactPerKg ]
-                     ]
-                        ++ totalImpactDisplay
+                    (h2 [ class "h5 m-0" ] [ text "Impact par kg de produit" ]
+                        :: div [ class "display-4 lh-1 text-center text-nowrap" ]
+                            [ Format.formatImpactFloat definition 2 impactPerKg ]
+                        :: totalImpactDisplay
                     )
                 ]
             , footer = []

--- a/src/Page/Food/Simulator.elm
+++ b/src/Page/Food/Simulator.elm
@@ -350,14 +350,15 @@ view ({ foodDb, db } as session) ({ selectedProduct, impact, selectedItem, selec
                                 ]
                                 [ text "Réinitialiser" ]
                             , viewSteps itemViewDataConfig product
-                            , div [ class "mb-3" ]
-                                [ div [ class "d-flex align-items-center fs-7" ]
-                                    [ span [ class "w-50 text-end p-2" ]
-                                        [ finalWeight
-                                            |> Format.formatRichFloat 3 "kg"
-                                        ]
-                                    , span [ class "text-center" ]
-                                        [ DownArrow.large ]
+                            , DownArrow.standard
+                            , div [ class "d-flex justify-content-center fs-7 mb-3" ]
+                                [ span
+                                    [ class "d-flex justify-content-center align-items-center border rounded-circle shadow-sm"
+                                    , style "width" "70px"
+                                    , style "height" "70px"
+                                    ]
+                                    [ finalWeight
+                                        |> Format.formatRichFloat 3 "kg"
                                     ]
                                 ]
                             ]

--- a/src/Page/Food/Simulator.elm
+++ b/src/Page/Food/Simulator.elm
@@ -309,7 +309,7 @@ view : Session -> Model -> ( String, List (Html Msg) )
 view ({ foodDb, db } as session) ({ selectedProduct, impact, selectedItem, selectedCountry } as model) =
     ( "Simulateur de recettes"
     , [ case model.currentProductInfo of
-            Just ({ product } as currentProductInfo) ->
+            Just ({ original, product } as currentProductInfo) ->
                 let
                     totalImpact =
                         Product.getTotalImpact impact product
@@ -324,6 +324,12 @@ view ({ foodDb, db } as session) ({ selectedProduct, impact, selectedItem, selec
                         , trigram = impact
                         , definition = definition
                         }
+
+                    originalWeight =
+                        Product.getWeightAtPlant original.plant
+
+                    finalWeight =
+                        Product.getAmountRatio originalWeight product
                 in
                 Container.centered []
                     [ div [ class "row gap-3 gap-lg-0" ]
@@ -345,6 +351,16 @@ view ({ foodDb, db } as session) ({ selectedProduct, impact, selectedItem, selec
                                 ]
                                 [ text "Réinitialiser" ]
                             , viewSteps itemViewDataConfig product
+                            , div [ class "mb-3" ]
+                                [ div [ class "d-flex align-items-center fs-7" ]
+                                    [ span [ class "w-50 text-end p-2" ]
+                                        [ finalWeight
+                                            |> Format.formatRichFloat 3 "kg"
+                                        ]
+                                    , span [ class "text-center" ]
+                                        [ DownArrow.large ]
+                                    ]
+                                ]
                             ]
                         ]
                     ]
@@ -768,7 +784,7 @@ viewSteps itemViewDataConfig product =
         -- Exclude the first Recipe step
         |> List.drop 1
         |> List.map (\( label, step ) -> viewStep label itemViewDataConfig step)
-        |> div [ class "mb-3" ]
+        |> div []
 
 
 viewStep : String -> ItemViewDataConfig -> Product.Step -> Html Msg

--- a/src/Page/Food/Simulator.elm
+++ b/src/Page/Food/Simulator.elm
@@ -239,11 +239,20 @@ update ({ foodDb, db } as session) msg ({ currentProductInfo } as model) =
 
 
 viewSidebar : Session -> ItemViewDataConfig -> CurrentProductInfo -> Html Msg
-viewSidebar session { definition, trigram, totalImpact } { product } =
+viewSidebar session { definition, trigram, totalImpact } { original, product } =
     let
-        finalWeight =
-            Product.getWeightAtStep product.consumer
+        originalWeight =
+            Product.getWeightAtPlant original.plant
 
+        amountRatio =
+            Product.getAmountRatio originalWeight product
+
+        -- The final weight is always 1kg when the recipe isn't modified...
+        -- then apply the ratio for the modified recipe
+        finalWeight =
+            1 * amountRatio
+
+        -- Product.getWeightAtStep product.consumer
         impactPerKg =
             totalImpact / finalWeight
     in
@@ -268,16 +277,16 @@ viewSidebar session { definition, trigram, totalImpact } { product } =
                     [ h2 [ class "h5 m-0" ] [ text "Impact par kg de produit" ]
                     , div [ class "display-4 lh-1 text-center text-nowrap" ]
                         [ Format.formatImpactFloat definition 2 impactPerKg ]
-                    , h3 [ class "h6 m-0 mt-2" ] [ text "Impact total" ]
-                    , div [ class "display-5 lh-1 text-center text-nowrap" ]
-                        [ Format.formatImpactFloat definition 2 totalImpact ]
-                    , div [ class "fs-7 text-end" ]
-                        [ text " pour un poids total chez le consommateur de "
+                    , h3 [ class "h6 m-0 mt-2" ]
+                        [ text "Impact pour "
                         , strong []
                             [ finalWeight
                                 |> Format.formatRichFloat 3 "kg"
                             ]
+                        , text " de produit"
                         ]
+                    , div [ class "display-5 lh-1 text-center text-nowrap" ]
+                        [ Format.formatImpactFloat definition 2 totalImpact ]
                     ]
                 ]
             , footer = []

--- a/src/Page/Food/Simulator.elm
+++ b/src/Page/Food/Simulator.elm
@@ -248,13 +248,31 @@ viewSidebar session { definition, trigram, totalImpact } { original, product } =
             Product.getAmountRatio originalWeight product
 
         -- The final weight is always 1kg when the recipe isn't modified...
-        -- then apply the ratio for the modified recipe
+        -- then apply the ratio for the modified recipe :
+        --    modified recipe's final weight = original final weight * modified recipe amount ratio
         finalWeight =
-            1 * amountRatio
+            amountRatio
 
         -- Product.getWeightAtStep product.consumer
         impactPerKg =
             totalImpact / finalWeight
+
+        totalImpactDisplay =
+            if amountRatio /= 1 then
+                [ h3 [ class "h6 m-0 mt-2" ]
+                    [ text "Impact pour "
+                    , strong []
+                        [ finalWeight
+                            |> Format.formatRichFloat 3 "kg"
+                        ]
+                    , text " de produit"
+                    ]
+                , div [ class "display-5 lh-1 text-center text-nowrap" ]
+                    [ Format.formatImpactFloat definition 2 totalImpact ]
+                ]
+
+            else
+                []
     in
     div
         [ class "d-flex flex-column gap-3 mb-3 sticky-md-top"
@@ -274,20 +292,12 @@ viewSidebar session { definition, trigram, totalImpact } { original, product } =
             { header = []
             , body =
                 [ div [ class "d-flex flex-column m-auto gap-1 px-2" ]
-                    [ h2 [ class "h5 m-0" ] [ text "Impact par kg de produit" ]
-                    , div [ class "display-4 lh-1 text-center text-nowrap" ]
+                    ([ h2 [ class "h5 m-0" ] [ text "Impact par kg de produit" ]
+                     , div [ class "display-4 lh-1 text-center text-nowrap" ]
                         [ Format.formatImpactFloat definition 2 impactPerKg ]
-                    , h3 [ class "h6 m-0 mt-2" ]
-                        [ text "Impact pour "
-                        , strong []
-                            [ finalWeight
-                                |> Format.formatRichFloat 3 "kg"
-                            ]
-                        , text " de produit"
-                        ]
-                    , div [ class "display-5 lh-1 text-center text-nowrap" ]
-                        [ Format.formatImpactFloat definition 2 totalImpact ]
-                    ]
+                     ]
+                        ++ totalImpactDisplay
+                    )
                 ]
             , footer = []
             }


### PR DESCRIPTION
An original recipe's final weight is always 1kg (eaten), so the impact "per kg" and "total" on an original recipe should always be the same.

When displaying an original recipe, don't display the "total impact" as it's redundant.

https://user-images.githubusercontent.com/167767/191928563-067427af-da2c-4fa8-b238-3f6fddeabd23.mov

Also display the final weight after the "at consumer" step

<img width="1349" alt="Capture d’écran 2022-09-23 à 11 24 16" src="https://user-images.githubusercontent.com/167767/191931288-6b646f72-2bb4-41ae-9731-988f3f5b46d8.png">


