### PR TITLE
Exclude packaging mass from impacts/kg of product computations.

### DIFF
--- a/src/Data/Food/Builder/Recipe.elm
+++ b/src/Data/Food/Builder/Recipe.elm
@@ -66,6 +66,7 @@ type alias Recipe =
 
 type alias Results =
     { total : Impacts
+    , perKg : Impacts
     , totalMass : Mass
     , recipe :
         { total : Impacts
@@ -140,6 +141,12 @@ compute db =
                             , ingredientsTransport.impacts
                             ]
 
+                    impactsPerKg =
+                        -- Note: Product impacts per kg is computed against transformed
+                        --       ingredients mass, excluding packaging
+                        recipeImpacts
+                            |> Impact.perKg (getTransformedIngredientsMass recipe)
+
                     packagingImpacts =
                         packaging
                             |> List.map (computeProcessImpacts db.impacts)
@@ -149,6 +156,7 @@ compute db =
                 , { total =
                         Impact.sumImpacts db.impacts
                             [ recipeImpacts, packagingImpacts ]
+                  , perKg = impactsPerKg
 
                   -- XXX: For now, we stop at packaging step
                   , totalMass = getMassAtPackaging recipe
@@ -279,6 +287,7 @@ encodeResults defs results =
     in
     Encode.object
         [ ( "total", encodeImpacts results.total )
+        , ( "perKg", encodeImpacts results.perKg )
         , ( "totalMass", results.totalMass |> Mass.inKilograms |> Encode.float )
         , ( "recipe"
           , Encode.object

--- a/src/Data/Food/Builder/Recipe.elm
+++ b/src/Data/Food/Builder/Recipe.elm
@@ -141,10 +141,14 @@ compute db =
                             , ingredientsTransport.impacts
                             ]
 
+                    totalImpacts =
+                        Impact.sumImpacts db.impacts
+                            [ recipeImpacts, packagingImpacts ]
+
                     impactsPerKg =
                         -- Note: Product impacts per kg is computed against transformed
                         --       ingredients mass, excluding packaging
-                        recipeImpacts
+                        totalImpacts
                             |> Impact.perKg (getTransformedIngredientsMass recipe)
 
                     packagingImpacts =
@@ -153,9 +157,7 @@ compute db =
                             |> updateImpacts
                 in
                 ( recipe
-                , { total =
-                        Impact.sumImpacts db.impacts
-                            [ recipeImpacts, packagingImpacts ]
+                , { total = totalImpacts
                   , perKg = impactsPerKg
 
                   -- XXX: For now, we stop at packaging step

--- a/src/Data/Impact.elm
+++ b/src/Data/Impact.elm
@@ -405,14 +405,13 @@ getAggregatedScoreData defs getter =
         []
 
 
-getAggregatedScoreOutOf100 : Definition -> Mass -> Impacts -> Int
-getAggregatedScoreOutOf100 { trigram } totalMass impacts =
+getAggregatedScoreOutOf100 : Definition -> Impacts -> Int
+getAggregatedScoreOutOf100 { trigram } impactsPerKg =
     let
         ln =
             logBase e
     in
-    impacts
-        |> perKg totalMass
+    impactsPerKg
         |> getImpact trigram
         |> Unit.impactToFloat
         |> (\value ->

--- a/src/Page/Food/Builder.elm
+++ b/src/Page/Food/Builder.elm
@@ -812,8 +812,8 @@ sidebarView session db model results =
                 if Impact.isAggregate model.impact then
                     let
                         score =
-                            results.total
-                                |> Impact.getAggregatedScoreOutOf100 model.impact results.totalMass
+                            results.perKg
+                                |> Impact.getAggregatedScoreOutOf100 model.impact
 
                         scoreLetter =
                             score
@@ -836,8 +836,8 @@ sidebarView session db model results =
             , body =
                 [ div [ class "d-flex flex-column m-auto gap-1 px-2 text-center text-nowrap" ]
                     [ div [ class "display-3 lh-1" ]
-                        [ results.total
-                            |> Format.formatFoodSelectedImpactPerKg model.impact results.totalMass
+                        [ results.perKg
+                            |> Format.formatFoodSelectedImpactPerKg model.impact
                         ]
                     ]
                 ]

--- a/src/Views/Comparator.elm
+++ b/src/Views/Comparator.elm
@@ -140,13 +140,13 @@ foodComparatorView { session } { comparisonUnit, switchComparisonUnit } =
                 foodQuery
                     |> Recipe.compute builderDb
                     |> Result.map
-                        (\( _, { total, totalMass } ) ->
+                        (\( _, { total, perKg } ) ->
                             case comparisonUnit of
                                 PerItem ->
                                     ( label, total )
 
                                 PerKgOfProduct ->
-                                    ( label, Impact.perKg totalMass total )
+                                    ( label, perKg )
                         )
                     |> Just
 

--- a/src/Views/Format.elm
+++ b/src/Views/Format.elm
@@ -55,10 +55,9 @@ formatFoodSelectedImpact { trigram, unit, decimals } =
         >> formatRichFloat decimals unit
 
 
-formatFoodSelectedImpactPerKg : Impact.Definition -> Mass -> Impacts -> Html msg
-formatFoodSelectedImpactPerKg { trigram, unit, decimals } totalMass =
-    Impact.perKg totalMass
-        >> Impact.getImpact trigram
+formatFoodSelectedImpactPerKg : Impact.Definition -> Impacts -> Html msg
+formatFoodSelectedImpactPerKg { trigram, unit, decimals } =
+    Impact.getImpact trigram
         >> Unit.impactToFloat
         >> formatRichFloat decimals (unit ++ "/kg")
 

--- a/tests/Data/ImpactTest.elm
+++ b/tests/Data/ImpactTest.elm
@@ -98,23 +98,17 @@ suite =
               describe "getAggregatedScoreOutOf100"
                 [ defaultBuilderImpacts
                     |> Impact.updateImpact (Impact.trg "ecs") (Unit.impact 1)
-                    |> Impact.getAggregatedScoreOutOf100
-                        ecsDefinition
-                        (Mass.kilograms 1)
+                    |> Impact.getAggregatedScoreOutOf100 ecsDefinition
                     |> Expect.equal 100
                     |> asTest "should return a score of 100 for a very low impact"
                 , defaultBuilderImpacts
                     |> Impact.updateImpact (Impact.trg "ecs") (Unit.impact 10000)
-                    |> Impact.getAggregatedScoreOutOf100
-                        ecsDefinition
-                        (Mass.kilograms 1)
+                    |> Impact.getAggregatedScoreOutOf100 ecsDefinition
                     |> Expect.equal 0
                     |> asTest "should return a score of 0 for a very high impact"
                 , defaultBuilderImpacts
                     |> Impact.updateImpact (Impact.trg "ecs") (Unit.impact 200)
-                    |> Impact.getAggregatedScoreOutOf100
-                        ecsDefinition
-                        (Mass.kilograms 1)
+                    |> Impact.getAggregatedScoreOutOf100 ecsDefinition
                     |> Expect.equal 68
                     |> asTest "should return a medium score for a medium impact"
                 ]


### PR DESCRIPTION
[User Story](https://www.notion.so/Ne-pas-prendre-en-compte-l-emballage-dans-la-masse-permettant-de-calculer-le-score-kg-4dad80072fa34aaf8285351033144ed5)