### PR TITLE
Allow disabling the transport by plane even from default origin

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -634,6 +634,7 @@ components:
         - `carrot;30;organic` signifie *30g de carrotes bio*;
         - `tomato;123;default;ES` signifie *123g de tomates bio en provenance d'Espagne*;
         - `mango;123;default` signifie *123g de mangues en provenance de son origine par défaut (hors Europe-Maghreb, transport par avion)*;
+        - `mango;123;default;default;noPlane` signifie *123g de mangues en provenance de son origine par défaut (hors Europe-Maghreb), par bateau*;
         - `mango;123;default;BR` signifie *123g de mangues en provenance du Brésil, par avion*;
         - `mango;123;default;BR;byPlane` signifie de la même manière *123g de mangues en provenance du Brésil, par avion*;
         - `mango;123;default;BR;default` signifie toujours *123g de mangues en provenance du Brésil, par avion*;

--- a/src/Data/Food/Builder/Recipe.elm
+++ b/src/Data/Food/Builder/Recipe.elm
@@ -299,7 +299,7 @@ computeIngredientTransport db { ingredient, country, mass, byPlane } =
                 -- Otherwise retrieve ingredient's default origin transport data
                 Nothing ->
                     ingredient.defaultOrigin
-                        |> Ingredient.getDefaultOriginTransport db.impacts
+                        |> Ingredient.getDefaultOriginTransport db.impacts byPlane
 
         transport =
             baseTransport

--- a/src/Data/Food/Ingredient.elm
+++ b/src/Data/Food/Ingredient.elm
@@ -122,8 +122,8 @@ findByID id ingredients =
         |> Result.fromMaybe ("Ingrédient introuvable par id : " ++ idToString id)
 
 
-getDefaultOriginTransport : List Impact.Definition -> Origin -> Transport
-getDefaultOriginTransport defs origin =
+getDefaultOriginTransport : List Impact.Definition -> Maybe Bool -> Origin -> Transport
+getDefaultOriginTransport defs byPlane origin =
     let
         default =
             Transport.default (Impact.impactsFromDefinitons defs)
@@ -139,7 +139,11 @@ getDefaultOriginTransport defs origin =
             { default | road = Length.kilometers 2500, sea = Length.kilometers 18000 }
 
         Origin.OutOfEuropeAndMaghrebByPlane ->
-            { default | road = Length.kilometers 2500, air = Length.kilometers 18000 }
+            if byPlane == Just True then
+                { default | road = Length.kilometers 2500, air = Length.kilometers 18000 }
+
+            else
+                { default | road = Length.kilometers 2500, sea = Length.kilometers 18000 }
 
 
 linkProcess : Dict String Process -> Decoder Process

--- a/src/Data/Food/Ingredient.elm
+++ b/src/Data/Food/Ingredient.elm
@@ -1,6 +1,7 @@
 module Data.Food.Ingredient exposing
     ( Id
     , Ingredient
+    , PlaneTransport(..)
     , byPlaneAllowed
     , byPlaneByDefault
     , decodeId
@@ -39,22 +40,28 @@ type Id
     = Id String
 
 
-byPlaneAllowed : Maybe Bool -> Ingredient -> Result String (Maybe Bool)
-byPlaneAllowed maybeByPlane ingredient =
-    if byPlaneByDefault ingredient == Nothing && maybeByPlane /= Nothing then
+type PlaneTransport
+    = PlaneNotApplicable
+    | ByPlane
+    | NoPlane
+
+
+byPlaneAllowed : PlaneTransport -> Ingredient -> Result String PlaneTransport
+byPlaneAllowed planeTransport ingredient =
+    if byPlaneByDefault ingredient == PlaneNotApplicable && planeTransport /= PlaneNotApplicable then
         Err byPlaneErrorMessage
 
     else
-        Ok maybeByPlane
+        Ok planeTransport
 
 
-byPlaneByDefault : Ingredient -> Maybe Bool
+byPlaneByDefault : Ingredient -> PlaneTransport
 byPlaneByDefault ingredient =
     if ingredient.defaultOrigin == Origin.OutOfEuropeAndMaghrebByPlane then
-        Just True
+        ByPlane
 
     else
-        Nothing
+        PlaneNotApplicable
 
 
 byPlaneErrorMessage : String
@@ -122,8 +129,8 @@ findByID id ingredients =
         |> Result.fromMaybe ("Ingrédient introuvable par id : " ++ idToString id)
 
 
-getDefaultOriginTransport : List Impact.Definition -> Maybe Bool -> Origin -> Transport
-getDefaultOriginTransport defs byPlane origin =
+getDefaultOriginTransport : List Impact.Definition -> PlaneTransport -> Origin -> Transport
+getDefaultOriginTransport defs planeTransport origin =
     let
         default =
             Transport.default (Impact.impactsFromDefinitons defs)
@@ -139,7 +146,7 @@ getDefaultOriginTransport defs byPlane origin =
             { default | road = Length.kilometers 2500, sea = Length.kilometers 18000 }
 
         Origin.OutOfEuropeAndMaghrebByPlane ->
-            if byPlane == Just True then
+            if planeTransport == ByPlane then
                 { default | road = Length.kilometers 2500, air = Length.kilometers 18000 }
 
             else

--- a/src/Page/Food/Builder.elm
+++ b/src/Page/Food/Builder.elm
@@ -595,7 +595,6 @@ updateIngredientFormView { excluded, db, ingredient, impact, transportImpact } =
                         , class "form-check-input no-outline"
                         , attribute "role" "switch"
                         , checked <| ingredientQuery.byPlane == Just True
-                        , disabled <| ingredient.country == Nothing
                         , onCheck
                             (\checked ->
                                 event { ingredientQuery | byPlane = Just checked }

--- a/src/Page/Food/Builder.elm
+++ b/src/Page/Food/Builder.elm
@@ -466,7 +466,7 @@ updateIngredientFormView { excluded, db, ingredient, impact, transportImpact } =
             , mass = ingredient.mass
             , variant = ingredient.variant
             , country = ingredient.country |> Maybe.map .code
-            , byPlane = ingredient.byPlane
+            , planeTransport = ingredient.planeTransport
             }
 
         event =
@@ -513,7 +513,7 @@ updateIngredientFormView { excluded, db, ingredient, impact, transportImpact } =
                             , name = newIngredient.name
                             , variant = newVariant
                             , country = Nothing
-                            , byPlane = Ingredient.byPlaneByDefault newIngredient
+                            , planeTransport = Ingredient.byPlaneByDefault newIngredient
                         }
                 )
         , db.countries
@@ -586,7 +586,7 @@ updateIngredientFormView { excluded, db, ingredient, impact, transportImpact } =
             [ Icon.trash ]
         , span [ class "text-muted IngredientTransportLabel fs-7" ]
             [ text "Transport pour cet ingrédient"
-            , if ingredient.byPlane /= Nothing then
+            , if ingredient.planeTransport /= Ingredient.PlaneNotApplicable then
                 label
                     [ class "PlaneCheckbox ps-2" ]
                     [ text "("
@@ -594,10 +594,18 @@ updateIngredientFormView { excluded, db, ingredient, impact, transportImpact } =
                         [ type_ "checkbox"
                         , class "form-check-input no-outline"
                         , attribute "role" "switch"
-                        , checked <| ingredientQuery.byPlane == Just True
+                        , checked <| ingredientQuery.planeTransport == Ingredient.ByPlane
                         , onCheck
                             (\checked ->
-                                event { ingredientQuery | byPlane = Just checked }
+                                event
+                                    { ingredientQuery
+                                        | planeTransport =
+                                            if checked then
+                                                Ingredient.ByPlane
+
+                                            else
+                                                Ingredient.NoPlane
+                                    }
                             )
                         ]
                         []

--- a/src/Server/Query.elm
+++ b/src/Server/Query.elm
@@ -117,11 +117,7 @@ ingredientParser { countries, ingredients } string =
                 |> RE.andMap (Result.map .name ingredient)
                 |> RE.andMap (validateMass mass)
                 |> RE.andMap (variantParser variant)
-                |> RE.andMap
-                    (countries
-                        |> validateCountry countryCode Scope.Food
-                        |> Result.map Just
-                    )
+                |> RE.andMap (foodCountryParser countries countryCode)
                 |> RE.andMap (Result.map Ingredient.byPlaneByDefault ingredient)
 
         [ id, mass, variant, countryCode, byPlane ] ->
@@ -135,11 +131,7 @@ ingredientParser { countries, ingredients } string =
                 |> RE.andMap (Result.map .name ingredient)
                 |> RE.andMap (validateMass mass)
                 |> RE.andMap (variantParser variant)
-                |> RE.andMap
-                    (countries
-                        |> validateCountry countryCode Scope.Food
-                        |> Result.map Just
-                    )
+                |> RE.andMap (foodCountryParser countries countryCode)
                 |> RE.andMap
                     (ingredient
                         |> Result.andThen
@@ -170,6 +162,17 @@ variantParser variant =
 
         _ ->
             Err <| "Format de variant invalide : " ++ variant
+
+
+foodCountryParser : List Country -> String -> Result String (Maybe Country.Code)
+foodCountryParser countries countryStr =
+    if countryStr == "default" then
+        Ok Nothing
+
+    else
+        countries
+            |> validateCountry countryStr Scope.Food
+            |> Result.map Just
 
 
 foodProcessCodeParser : List FoodProcess.Process -> String -> Result String FoodProcess.Code

--- a/src/Server/Query.elm
+++ b/src/Server/Query.elm
@@ -233,17 +233,17 @@ validateBool str =
             Err "La valeur ne peut être que true ou false."
 
 
-validateByPlaneValue : String -> Ingredient -> Result String (Maybe Bool)
+validateByPlaneValue : String -> Ingredient -> Result String Ingredient.PlaneTransport
 validateByPlaneValue str ingredient =
     case str of
         "default" ->
             Ok (Ingredient.byPlaneByDefault ingredient)
 
         "byPlane" ->
-            Ok (Just True)
+            Ok Ingredient.ByPlane
 
         "noPlane" ->
-            Ok (Just False)
+            Ok Ingredient.NoPlane
 
         _ ->
             Err "La valeur ne peut être que parmis les choix suivants: 'default', 'byPlane', 'noPlane'."

--- a/src/Server/Query.elm
+++ b/src/Server/Query.elm
@@ -246,7 +246,7 @@ validateByPlaneValue str ingredient =
             Ok Ingredient.NoPlane
 
         _ ->
-            Err "La valeur ne peut être que parmis les choix suivants: 'default', 'byPlane', 'noPlane'."
+            Err "La valeur ne peut être que parmi les choix suivants: 'default', 'byPlane', 'noPlane'."
 
 
 validateCountry : String -> Scope -> List Country -> Result String Country.Code

--- a/styles.scss
+++ b/styles.scss
@@ -673,10 +673,7 @@ blockquote {
     grid-template-areas:
       "massInputWrapper ingredientSelector impactDisplay impactDisplay"
       "countrySelector countrySelector bioCheckbox ingredientDelete"
-      "transportDistances transportDistances transportImpact transportImpact";
-    .IngredientTransportLabel {
-      display: none;
-    }
+      "transportLabel transportDistances transportImpact transportImpact";
   }
 }
 

--- a/tests/Data/Food/Builder/RecipeTest.elm
+++ b/tests/Data/Food/Builder/RecipeTest.elm
@@ -42,11 +42,11 @@ suite =
                 , { carrotCake
                     | ingredients =
                         carrotCake.ingredients
-                            |> List.map (\ingredient -> { ingredient | byPlane = Just True })
+                            |> List.map (\ingredient -> { ingredient | planeTransport = Ingredient.ByPlane })
                   }
                     |> Recipe.fromQuery builderDb
                     |> Expect.err
-                    |> asTest "should return an Err for an invalid 'byPlane' value for an ingredient without a default origin by plane"
+                    |> asTest "should return an Err for an invalid 'planeTransport' value for an ingredient without a default origin by plane"
                 ]
             , describe "compute"
                 (let
@@ -105,14 +105,14 @@ suite =
                           , mass = Mass.grams 120
                           , variant = Query.Default
                           , country = Nothing
-                          , byPlane = Nothing
+                          , planeTransport = Ingredient.PlaneNotApplicable
                           }
                         , { id = Ingredient.idFromString "wheat"
                           , name = "Blé tendre"
                           , mass = Mass.grams 140
                           , variant = Query.Default
                           , country = Nothing
-                          , byPlane = Nothing
+                          , planeTransport = Ingredient.PlaneNotApplicable
                           }
                         ]
                   , transform = Nothing
@@ -155,7 +155,7 @@ suite =
                     , mass = Mass.grams 120
                     , variant = Query.Default
                     , country = Nothing
-                    , byPlane = Just True
+                    , planeTransport = Ingredient.ByPlane
                     }
 
                 firstIngredientAirDistance ( recipe, _ ) =
@@ -173,7 +173,7 @@ suite =
                           , mass = Mass.grams 120
                           , variant = Query.Default
                           , country = Nothing
-                          , byPlane = Nothing
+                          , planeTransport = Ingredient.PlaneNotApplicable
                           }
                         ]
                   , transform = Nothing
@@ -193,7 +193,7 @@ suite =
                     |> Result.map firstIngredientAirDistance
                     |> Expect.equal (Ok (Just 18000))
                     |> asTest "should have air transport for mango from its default origin"
-                , { ingredients = [ { mango | country = Just (Country.codeFromString "CN"), byPlane = Just True } ]
+                , { ingredients = [ { mango | country = Just (Country.codeFromString "CN"), planeTransport = Ingredient.ByPlane } ]
                   , transform = Nothing
                   , packaging = []
                   , category = Nothing
@@ -201,8 +201,8 @@ suite =
                     |> Recipe.compute builderDb
                     |> Result.map firstIngredientAirDistance
                     |> Expect.equal (Ok (Just 8189))
-                    |> asTest "should always have air transport for mango even from other countries if 'byPlane' is true"
-                , { ingredients = [ { mango | country = Just (Country.codeFromString "CN"), byPlane = Just False } ]
+                    |> asTest "should always have air transport for mango even from other countries if 'planeTransport' is 'byPlane'"
+                , { ingredients = [ { mango | country = Just (Country.codeFromString "CN"), planeTransport = Ingredient.NoPlane } ]
                   , transform = Nothing
                   , packaging = []
                   , category = Nothing
@@ -210,7 +210,7 @@ suite =
                     |> Recipe.compute builderDb
                     |> Result.map firstIngredientAirDistance
                     |> Expect.equal (Ok (Just 0))
-                    |> asTest "should not have air transport for mango from other countries if 'byPlane' is false"
+                    |> asTest "should not have air transport for mango from other countries if 'planeTransport' is 'noPlane'"
                 ]
             ]
         )

--- a/tests/e2e-food.json
+++ b/tests/e2e-food.json
@@ -299,6 +299,62 @@
       }
     }
   },
+{
+    "name": "Mango from default origin, but by boat",
+    "query": [
+      "ingredients[]=mango;120;default;default;noPlane",
+      "category=fruitsAndVegetables"
+    ],
+    "impacts": {
+      "acd": 0.0011227450298807874,
+      "bvi": 0.0184327220928,
+      "cch": 0.09236084921055261,
+      "ecs": 15.21858902787425,
+      "etf": 8.920723640583978,
+      "fru": 1.3012302163863143,
+      "fwe": 0.000012162231000542987,
+      "htc": 3.335906998462397e-11,
+      "htn": 1.21512034338846e-9,
+      "ior": 0.007233195154793269,
+      "ldu": 3.093716559959329,
+      "mru": 3.1310443535462777e-7,
+      "ozd": 1.873757528288525e-8,
+      "pco": 0.0006491685949547814,
+      "pef": 13.42870166944949,
+      "pma": 7.194870711061988e-9,
+      "swe": 0.00021821827229339476,
+      "tre": 0.0031751023712426087,
+      "wtu": 0.01637983670307674
+    },
+    "scoring": {
+      "category": "Fruits et légumes",
+      "all": {
+        "impact": 126.82157523228543,
+        "letter": "C",
+        "outOf100": 46
+      },
+      "climate": {
+        "impact": 20.022566819531256,
+        "letter": "C",
+        "outOf100": 57
+      },
+      "biodiversity": {
+        "impact": 109.61473918869413,
+        "letter": "D",
+        "outOf100": 35
+      },
+      "health": {
+        "impact": 27.18083747114541,
+        "letter": "C",
+        "outOf100": 57
+      },
+      "resources": {
+        "impact": 11.618892424306784,
+        "letter": "B",
+        "outOf100": 62
+      }
+    }
+  },
   {
     "name": "Mango by plane from Brazil (by default)",
     "query": [

--- a/tests/server.spec.js
+++ b/tests/server.spec.js
@@ -334,7 +334,7 @@ describe("API", () => {
         expectFieldErrorMessage(
           await makeRequest("/api/food/recipe", ["ingredients[]=mango;123;default;BR;badValue"]),
           "ingredients",
-          /La valeur ne peut être que parmis les choix suivants: 'default', 'byPlane', 'noPlane'./,
+          /La valeur ne peut être que parmi les choix suivants: 'default', 'byPlane', 'noPlane'./,
         );
       });
 


### PR DESCRIPTION
[user story](https://www.notion.so/fd0068a7db8348c584cd53a3eea399f2?v=90c1a9d44ff845c090b6f491065ba2ef&p=2786364aac184ee88a14b480045ebe61&pm=s)

Follows on #220 by allowing the disabling of the transport by plane for category 4 ingredients (default origin by plane) even from their default origin.