### PR TITLE
Remove `default` from api

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -627,19 +627,19 @@ components:
         Le format de chaque entrée est composé de
         - l'identifiant de la matière (pour avoir la liste, utiliser l'API de liste d'ingrédients)
         - sa masse **exprimée en grammes**
-        - un éventuel mode de production alternatif à utiliser (ex: `organic` pour du bio, `default` pour du conventionnel)
+        - un éventuel mode de production alternatif à utiliser (ex: `organic` pour du bio, laisser vide pour du conventionnel)
         - un éventuel code de pays d'origine (ex: `BR` pour le Brésil)
         - un éventuel transport par avion *uniquement si c'est un [ingrédient de catégorie "HORS EUROPE-MAGHREB (AVION)"](https://fabrique-numerique.gitbook.io/ecobalyse/alimentaire/transport#circuits-consideres)* (valeurs possible: `default`, `byPlane`, `noPlane`)
 
         - `milk;268` signifie *268g de lait*;
         - `carrot;30;organic` signifie *30g de carrotes bio*;
-        - `tomato;123;default;ES` signifie *123g de tomates conventionnelles en provenance d'Espagne*;
-        - `mango;123;default` signifie *123g de mangues en provenance de son origine par défaut (hors Europe-Maghreb, transport par avion)*;
-        - `mango;123;default;default;noPlane` signifie *123g de mangues en provenance de son origine par défaut (hors Europe-Maghreb), par bateau*;
-        - `mango;123;default;BR` signifie *123g de mangues en provenance du Brésil, par avion*;
-        - `mango;123;default;BR;byPlane` signifie de la même manière *123g de mangues en provenance du Brésil, par avion*;
-        - `mango;123;default;BR;default` signifie toujours *123g de mangues en provenance du Brésil, par avion*;
-        - `mango;123;default;BR;noPlane` signifie *123g de mangues en provenance du Brésil, par bateau (pas par avion)*;
+        - `tomato;123;;ES` signifie *123g de tomates conventionnelles en provenance d'Espagne*;
+        - `mango;123` signifie *123g de mangues en provenance de son origine par défaut (hors Europe-Maghreb, transport par avion)*;
+        - `mango;123;;default;noPlane` signifie *123g de mangues en provenance de son origine par défaut (hors Europe-Maghreb), par bateau*;
+        - `mango;123;;BR` signifie *123g de mangues en provenance du Brésil, par avion*;
+        - `mango;123;;BR;byPlane` signifie de la même manière *123g de mangues en provenance du Brésil, par avion*;
+        - `mango;123;;BR;default` signifie toujours *123g de mangues en provenance du Brésil, par avion*;
+        - `mango;123;;BR;noPlane` signifie *123g de mangues en provenance du Brésil, par bateau (pas par avion)*;
  
         > Par exemple, les paramètres à passer pour une recette à base de 268g de lait et 30g de carrotes bio d'espagne sont :
         >
@@ -664,13 +664,13 @@ components:
           value: ["milk;268", "carrot;30;organic", "egg;149"]
         fourIngredients:
           summary: Lait, carrotes bio, oeuf, tomates d'espagne
-          value: ["milk;268", "carrot;30;organic", "egg;149", "tomato;123;default;ES"]
+          value: ["milk;268", "carrot;30;organic", "egg;149", "tomato;123;;ES"]
         byPlane:
           summary: Mangue du Brésil par avion
-          value: ["mango;123;default;BR"]
+          value: ["mango;123;;BR"]
         noPlane:
           summary: Mangue du Brésil par bateau
-          value: ["mango;123;default;BR;noPlane"]
+          value: ["mango;123;;BR;noPlane"]
     packagingParam:
       name: "packaging[]"
       in: query

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -635,7 +635,7 @@ components:
         - `carrot;30;organic` signifie *30g de carrotes bio*;
         - `tomato;123;;ES` signifie *123g de tomates conventionnelles en provenance d'Espagne*;
         - `mango;123` signifie *123g de mangues en provenance de son origine par défaut (hors Europe-Maghreb, transport par avion)*;
-        - `mango;123;;default;noPlane` signifie *123g de mangues en provenance de son origine par défaut (hors Europe-Maghreb), par bateau*;
+        - `mango;123;;;noPlane` signifie *123g de mangues en provenance de son origine par défaut (hors Europe-Maghreb), par bateau*;
         - `mango;123;;BR` signifie *123g de mangues en provenance du Brésil, par avion*;
         - `mango;123;;BR;byPlane` signifie de la même manière *123g de mangues en provenance du Brésil, par avion*;
         - `mango;123;;BR;default` signifie toujours *123g de mangues en provenance du Brésil, par avion*;

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -629,7 +629,7 @@ components:
         - sa masse **exprimée en grammes**
         - un éventuel mode de production alternatif à utiliser (ex: `organic` pour du bio, laisser vide pour du conventionnel)
         - un éventuel code de pays d'origine (ex: `BR` pour le Brésil)
-        - un éventuel transport par avion *uniquement si c'est un [ingrédient de catégorie "HORS EUROPE-MAGHREB (AVION)"](https://fabrique-numerique.gitbook.io/ecobalyse/alimentaire/transport#circuits-consideres)* (valeurs possible: `default`, `byPlane`, `noPlane`)
+        - un éventuel transport par avion *uniquement si c'est un [ingrédient de catégorie "HORS EUROPE-MAGHREB (AVION)"](https://fabrique-numerique.gitbook.io/ecobalyse/alimentaire/transport#circuits-consideres)* (valeurs possible: ``, `byPlane`, `noPlane`)
 
         - `milk;268` signifie *268g de lait*;
         - `carrot;30;organic` signifie *30g de carrotes bio*;
@@ -638,7 +638,6 @@ components:
         - `mango;123;;;noPlane` signifie *123g de mangues en provenance de son origine par défaut (hors Europe-Maghreb), par bateau*;
         - `mango;123;;BR` signifie *123g de mangues en provenance du Brésil, par avion*;
         - `mango;123;;BR;byPlane` signifie de la même manière *123g de mangues en provenance du Brésil, par avion*;
-        - `mango;123;;BR;default` signifie toujours *123g de mangues en provenance du Brésil, par avion*;
         - `mango;123;;BR;noPlane` signifie *123g de mangues en provenance du Brésil, par bateau (pas par avion)*;
  
         > Par exemple, les paramètres à passer pour une recette à base de 268g de lait et 30g de carrotes bio d'espagne sont :

--- a/src/Data/Food/Builder/Query.elm
+++ b/src/Data/Food/Builder/Query.elm
@@ -35,7 +35,7 @@ import Url.Parser as Parser exposing (Parser)
 
 
 type Variant
-    = Default
+    = DefaultVariant
     | Organic
 
 
@@ -99,28 +99,28 @@ carrotCake =
         [ { id = Ingredient.idFromString "egg"
           , name = "Oeuf"
           , mass = Mass.grams 120
-          , variant = Default
+          , variant = DefaultVariant
           , country = Nothing
           , planeTransport = Ingredient.PlaneNotApplicable
           }
         , { id = Ingredient.idFromString "wheat"
           , name = "Blé tendre"
           , mass = Mass.grams 140
-          , variant = Default
+          , variant = DefaultVariant
           , country = Nothing
           , planeTransport = Ingredient.PlaneNotApplicable
           }
         , { id = Ingredient.idFromString "milk"
           , name = "Lait"
           , mass = Mass.grams 60
-          , variant = Default
+          , variant = DefaultVariant
           , country = Nothing
           , planeTransport = Ingredient.PlaneNotApplicable
           }
         , { id = Ingredient.idFromString "carrot"
           , name = "Carotte"
           , mass = Mass.grams 225
-          , variant = Default
+          , variant = DefaultVariant
           , country = Nothing
           , planeTransport = Ingredient.PlaneNotApplicable
           }
@@ -353,7 +353,7 @@ variantFromString : String -> Result String Variant
 variantFromString string =
     case string of
         "default" ->
-            Ok Default
+            Ok DefaultVariant
 
         "organic" ->
             Ok Organic
@@ -365,7 +365,7 @@ variantFromString string =
 variantToString : Variant -> String
 variantToString variant =
     case variant of
-        Default ->
+        DefaultVariant ->
             "default"
 
         Organic ->

--- a/src/Data/Food/Builder/Query.elm
+++ b/src/Data/Food/Builder/Query.elm
@@ -352,7 +352,7 @@ updateDistribution distribution query =
 variantFromString : String -> Result String Variant
 variantFromString string =
     case string of
-        "default" ->
+        "" ->
             Ok DefaultVariant
 
         "organic" ->
@@ -366,7 +366,7 @@ variantToString : Variant -> String
 variantToString variant =
     case variant of
         DefaultVariant ->
-            "default"
+            ""
 
         Organic ->
             "organic"

--- a/src/Data/Food/Builder/Recipe.elm
+++ b/src/Data/Food/Builder/Recipe.elm
@@ -531,7 +531,7 @@ getTransformedIngredientsVolume recipe =
 getRecipeIngredientProcess : RecipeIngredient -> Process
 getRecipeIngredientProcess { ingredient, variant } =
     case variant of
-        BuilderQuery.Default ->
+        BuilderQuery.DefaultVariant ->
             ingredient.default
 
         BuilderQuery.Organic ->
@@ -570,7 +570,7 @@ ingredientQueryFromIngredient ingredient =
     { id = ingredient.id
     , name = ingredient.name
     , mass = Mass.grams 100
-    , variant = BuilderQuery.Default
+    , variant = BuilderQuery.DefaultVariant
     , country = Nothing
     , planeTransport = Ingredient.byPlaneByDefault ingredient
     }
@@ -671,7 +671,7 @@ transformFromQuery { processes } query =
 variantToString : BuilderQuery.Variant -> String
 variantToString variant =
     case variant of
-        BuilderQuery.Default ->
+        BuilderQuery.DefaultVariant ->
             "default"
 
         BuilderQuery.Organic ->

--- a/src/Page/Food/Builder.elm
+++ b/src/Page/Food/Builder.elm
@@ -502,13 +502,13 @@ updateIngredientFormView { excluded, db, ingredient, impact, transportImpact } =
                     let
                         newVariant =
                             case ingredientQuery.variant of
-                                Query.Default ->
-                                    Query.Default
+                                Query.DefaultVariant ->
+                                    Query.DefaultVariant
 
                                 Query.Organic ->
                                     if newIngredient.variants.organic == Nothing then
                                         -- Fallback to "Default" if the new ingredient doesn't have an "organic" variant
-                                        Query.Default
+                                        Query.DefaultVariant
 
                                     else
                                         Query.Organic
@@ -574,7 +574,7 @@ updateIngredientFormView { excluded, db, ingredient, impact, transportImpact } =
                                         Query.Organic
 
                                     else
-                                        Query.Default
+                                        Query.DefaultVariant
                             }
                     )
                 ]

--- a/src/Server/Query.elm
+++ b/src/Server/Query.elm
@@ -238,7 +238,7 @@ validateBool str =
 validateByPlaneValue : String -> Ingredient -> Result String Ingredient.PlaneTransport
 validateByPlaneValue str ingredient =
     case str of
-        "default" ->
+        "" ->
             Ok (Ingredient.byPlaneByDefault ingredient)
 
         "byPlane" ->
@@ -248,7 +248,7 @@ validateByPlaneValue str ingredient =
             Ok Ingredient.NoPlane
 
         _ ->
-            Err "La valeur ne peut être que parmi les choix suivants: 'default', 'byPlane', 'noPlane'."
+            Err "La valeur ne peut être que parmi les choix suivants: '', 'byPlane', 'noPlane'."
 
 
 validateCountry : String -> Scope -> List Country -> Result String Country.Code

--- a/src/Server/Query.elm
+++ b/src/Server/Query.elm
@@ -168,7 +168,7 @@ variantParser variant =
 
 foodCountryParser : List Country -> String -> Result String (Maybe Country.Code)
 foodCountryParser countries countryStr =
-    if countryStr == "default" then
+    if countryStr == "" then
         Ok Nothing
 
     else

--- a/src/Server/Query.elm
+++ b/src/Server/Query.elm
@@ -156,7 +156,7 @@ ingredientParser { countries, ingredients } string =
 variantParser : String -> Result String BuilderQuery.Variant
 variantParser variant =
     case variant of
-        "default" ->
+        "" ->
             Ok BuilderQuery.DefaultVariant
 
         "organic" ->

--- a/src/Server/Query.elm
+++ b/src/Server/Query.elm
@@ -90,7 +90,7 @@ ingredientParser { countries, ingredients } string =
                 |> RE.andMap (Result.map .id ingredient)
                 |> RE.andMap (Result.map .name ingredient)
                 |> RE.andMap (validateMass mass)
-                |> RE.andMap (Ok BuilderQuery.Default)
+                |> RE.andMap (Ok BuilderQuery.DefaultVariant)
                 |> RE.andMap (Ok Nothing)
                 |> RE.andMap (Result.map Ingredient.byPlaneByDefault ingredient)
 
@@ -157,7 +157,7 @@ variantParser : String -> Result String BuilderQuery.Variant
 variantParser variant =
     case variant of
         "default" ->
-            Ok BuilderQuery.Default
+            Ok BuilderQuery.DefaultVariant
 
         "organic" ->
             Ok BuilderQuery.Organic

--- a/tests/Data/Food/Builder/RecipeTest.elm
+++ b/tests/Data/Food/Builder/RecipeTest.elm
@@ -104,14 +104,14 @@ suite =
                         [ { id = Ingredient.idFromString "egg"
                           , name = "Oeuf"
                           , mass = Mass.grams 120
-                          , variant = Query.Default
+                          , variant = Query.DefaultVariant
                           , country = Nothing
                           , planeTransport = Ingredient.PlaneNotApplicable
                           }
                         , { id = Ingredient.idFromString "wheat"
                           , name = "Blé tendre"
                           , mass = Mass.grams 140
-                          , variant = Query.Default
+                          , variant = Query.DefaultVariant
                           , country = Nothing
                           , planeTransport = Ingredient.PlaneNotApplicable
                           }
@@ -155,7 +155,7 @@ suite =
                     { id = Ingredient.idFromString "mango"
                     , name = "Mangue"
                     , mass = Mass.grams 120
-                    , variant = Query.Default
+                    , variant = Query.DefaultVariant
                     , country = Nothing
                     , planeTransport = Ingredient.ByPlane
                     }
@@ -173,7 +173,7 @@ suite =
                         [ { id = Ingredient.idFromString "egg"
                           , name = "Oeuf"
                           , mass = Mass.grams 120
-                          , variant = Query.Default
+                          , variant = Query.DefaultVariant
                           , country = Nothing
                           , planeTransport = Ingredient.PlaneNotApplicable
                           }

--- a/tests/Server/RouteTest.elm
+++ b/tests/Server/RouteTest.elm
@@ -82,17 +82,17 @@ foodEndpoints db =
             |> Maybe.andThen (Dict.get "ingredients")
             |> Expect.equal (Just "Format de variant invalide : invalidVariant")
             |> asTest "should validate that an ingredient variant is valid"
-        , getEndpoint db "GET" "/food/recipe?ingredients[]=egg;1;default;invalidCountry"
+        , getEndpoint db "GET" "/food/recipe?ingredients[]=egg;1;;invalidCountry"
             |> Maybe.andThen extractFoodErrors
             |> Maybe.andThen (Dict.get "ingredients")
             |> Expect.equal (Just "Code pays invalide: invalidCountry.")
             |> asTest "should validate that an ingredient country is valid"
-        , getEndpoint db "GET" "/food/recipe?ingredients[]=egg;1;default;FR;byPlane"
+        , getEndpoint db "GET" "/food/recipe?ingredients[]=egg;1;;FR;byPlane"
             |> Maybe.andThen extractFoodErrors
             |> Maybe.andThen (Dict.get "ingredients")
             |> Expect.equal (Just "Impossible de spécifier un acheminement par avion pour cet ingrédient, son origine par défaut ne le permet pas.")
             |> asTest "should validate that an ingredient can be transported by plane"
-        , getEndpoint db "GET" "/food/recipe?ingredients[]=egg;1;default;BD"
+        , getEndpoint db "GET" "/food/recipe?ingredients[]=egg;1;;BD"
             |> Maybe.andThen extractFoodErrors
             |> Maybe.andThen (Dict.get "ingredients")
             |> Expect.equal (Just "Le code pays BD n'est pas utilisable dans un contexte Alimentaire.")

--- a/tests/e2e-food.json
+++ b/tests/e2e-food.json
@@ -302,7 +302,7 @@
   {
     "name": "Mango from default origin, but by boat",
     "query": [
-      "ingredients[]=mango;120;;default;noPlane",
+      "ingredients[]=mango;120;;;noPlane",
       "category=fruitsAndVegetables"
     ],
     "impacts": {

--- a/tests/e2e-food.json
+++ b/tests/e2e-food.json
@@ -412,62 +412,6 @@
     }
   },
   {
-    "name": "Mango by plane from Brazil (by default, explicitely)",
-    "query": [
-      "ingredients[]=mango;120;;BR;default",
-      "distribution=ambient"
-    ],
-    "impacts": {
-      "acd": 0.005745310013858694,
-      "bvi": 0.020745336217080003,
-      "cch": 1.12970804581349,
-      "ecs": 74.56228379327935,
-      "etf": 16.451745758794985,
-      "fru": 16.425312076489565,
-      "fwe": 0.00003549018539140605,
-      "htc": 5.292396093418527e-10,
-      "htn": 4.16041130491672e-9,
-      "ior": 0.10010366480346873,
-      "ldu": 4.826604020737742,
-      "mru": 3.646406029367058e-7,
-      "ozd": 2.613870409696903e-7,
-      "pco": 0.005555317281817316,
-      "pef": 85.80958790699027,
-      "pma": 2.22038319184303e-8,
-      "swe": 0.0018601584743411798,
-      "tre": 0.021198598074634287,
-      "wtu": 0.05669063733013506
-    },
-    "scoring": {
-      "category": "Toutes les catégories",
-      "all": {
-        "impact": 621.3523649439946,
-        "letter": "D",
-        "outOf100": 37
-      },
-      "climate": {
-        "impact": 244.90522799652092,
-        "letter": "D",
-        "outOf100": 37
-      },
-      "biodiversity": {
-        "impact": 486.45153459042695,
-        "letter": "D",
-        "outOf100": 37
-      },
-      "health": {
-        "impact": 302.54420154379795,
-        "letter": "D",
-        "outOf100": 37
-      },
-      "resources": {
-        "impact": 105.62944661857613,
-        "letter": "D",
-        "outOf100": 37
-      }
-    }
-  },
-  {
     "name": "Mango by plane from Brazil (explicitely)",
     "query": [
       "ingredients[]=mango;120;;BR;byPlane",
@@ -582,10 +526,10 @@
   {
     "name": "Carrot cake, organic, China, default 'by plane' value",
     "query": [
-      "ingredients[]=egg;120;organic;CN;default",
-      "ingredients[]=wheat;140;organic;CN;default",
-      "ingredients[]=milk;60;organic;CN;default",
-      "ingredients[]=carrot;225;organic;CN;default",
+      "ingredients[]=egg;120;organic;CN",
+      "ingredients[]=wheat;140;organic;CN",
+      "ingredients[]=milk;60;organic;CN",
+      "ingredients[]=carrot;225;organic;CN",
       "transform=aded2490573207ec7ad5a3813978f6a4;545",
       "packaging[]=23b2754e5943bc77916f8f871edc53b6;105",
       "distribution=ambient"

--- a/tests/e2e-food.json
+++ b/tests/e2e-food.json
@@ -63,10 +63,10 @@
   {
     "name": "Carrot cake, conventional, China",
     "query": [
-      "ingredients[]=egg;120;default;CN",
-      "ingredients[]=wheat;140;default;CN",
-      "ingredients[]=milk;60;default;CN",
-      "ingredients[]=carrot;225;default;CN",
+      "ingredients[]=egg;120;;CN",
+      "ingredients[]=wheat;140;;CN",
+      "ingredients[]=milk;60;;CN",
+      "ingredients[]=carrot;225;;CN",
       "transform=aded2490573207ec7ad5a3813978f6a4;545",
       "packaging[]=23b2754e5943bc77916f8f871edc53b6;105",
       "distribution=ambient"
@@ -302,7 +302,7 @@
   {
     "name": "Mango from default origin, but by boat",
     "query": [
-      "ingredients[]=mango;120;default;default;noPlane",
+      "ingredients[]=mango;120;;default;noPlane",
       "category=fruitsAndVegetables"
     ],
     "impacts": {
@@ -358,7 +358,7 @@
   {
     "name": "Mango by plane from Brazil (by default)",
     "query": [
-      "ingredients[]=mango;120;default;BR",
+      "ingredients[]=mango;120;;BR",
       "distribution=ambient"
     ],
     "impacts": {
@@ -414,7 +414,7 @@
   {
     "name": "Mango by plane from Brazil (by default, explicitely)",
     "query": [
-      "ingredients[]=mango;120;default;BR;default",
+      "ingredients[]=mango;120;;BR;default",
       "distribution=ambient"
     ],
     "impacts": {
@@ -470,7 +470,7 @@
   {
     "name": "Mango by plane from Brazil (explicitely)",
     "query": [
-      "ingredients[]=mango;120;default;BR;byPlane",
+      "ingredients[]=mango;120;;BR;byPlane",
       "distribution=ambient"
     ],
     "impacts": {
@@ -526,7 +526,7 @@
   {
     "name": "Mango by boat from Brazil",
     "query": [
-      "ingredients[]=mango;120;default;BR;noPlane",
+      "ingredients[]=mango;120;;BR;noPlane",
       "distribution=ambient"
     ],
     "impacts": {

--- a/tests/server.spec.js
+++ b/tests/server.spec.js
@@ -325,7 +325,7 @@ describe("API", () => {
 
       it("should validate an ingredient country code", async () => {
         expectFieldErrorMessage(
-          await makeRequest("/api/food/recipe", ["ingredients[]=carrot;123;default;BadCountryCode"]),
+          await makeRequest("/api/food/recipe", ["ingredients[]=carrot;123;;BadCountryCode"]),
           "ingredients",
           /Code pays invalide: BadCountryCode/,
         );
@@ -333,7 +333,7 @@ describe("API", () => {
 
       it("should validate an ingredient transport by plane value", async () => {
         expectFieldErrorMessage(
-          await makeRequest("/api/food/recipe", ["ingredients[]=mango;123;default;BR;badValue"]),
+          await makeRequest("/api/food/recipe", ["ingredients[]=mango;123;;BR;badValue"]),
           "ingredients",
           /La valeur ne peut être que parmi les choix suivants: 'default', 'byPlane', 'noPlane'./,
         );
@@ -341,7 +341,7 @@ describe("API", () => {
 
       it("should validate an ingredient transport by plane", async () => {
         expectFieldErrorMessage(
-          await makeRequest("/api/food/recipe", ["ingredients[]=carrot;123;default;BR;byPlane"]),
+          await makeRequest("/api/food/recipe", ["ingredients[]=carrot;123;;BR;byPlane"]),
           "ingredients",
           /Impossible de spécifier un acheminement par avion pour cet ingrédient, son origine par défaut ne le permet pas./,
         );

--- a/tests/server.spec.js
+++ b/tests/server.spec.js
@@ -335,7 +335,7 @@ describe("API", () => {
         expectFieldErrorMessage(
           await makeRequest("/api/food/recipe", ["ingredients[]=mango;123;;BR;badValue"]),
           "ingredients",
-          /La valeur ne peut être que parmi les choix suivants: 'default', 'byPlane', 'noPlane'./,
+          /La valeur ne peut être que parmi les choix suivants: '', 'byPlane', 'noPlane'./,
         );
       });
 


### PR DESCRIPTION
After some discussion on mattermost, we decided that it made more sense to just leave an value empty in the API instead of explicitly using `default`.