### PR TITLE
Reset bonuses when swapping ingredients.

### DIFF
--- a/src/Data/Food/Builder/Query.elm
+++ b/src/Data/Food/Builder/Query.elm
@@ -18,6 +18,7 @@ module Data.Food.Builder.Query exposing
     , serialize
     , setDistribution
     , setTransform
+    , updateBonusesFromVariant
     , updateDistribution
     , updateIngredient
     , updatePackaging
@@ -28,7 +29,7 @@ module Data.Food.Builder.Query exposing
 import Base64
 import Data.Country as Country
 import Data.Food.Category as Category
-import Data.Food.Ingredient as Ingredient
+import Data.Food.Ingredient as Ingredient exposing (Ingredient)
 import Data.Food.Preparation as Preparation
 import Data.Food.Process as Process
 import Data.Food.Retail as Retail
@@ -397,6 +398,19 @@ updateDistribution distribution query =
                 |> Result.withDefault Retail.ambient
                 |> Just
     }
+
+
+updateBonusesFromVariant : List Ingredient -> Ingredient.Id -> Variant -> Ingredient.Bonuses
+updateBonusesFromVariant ingredients ingredientId variant =
+    case variant of
+        Organic ->
+            ingredients
+                |> Ingredient.findByID ingredientId
+                |> Result.map Ingredient.getDefaultOrganicBonuses
+                |> Result.withDefault Ingredient.defaultBonuses
+
+        DefaultVariant ->
+            Ingredient.defaultBonuses
 
 
 variantFromString : String -> Result String Variant

--- a/src/Page/Food/Builder.elm
+++ b/src/Page/Food/Builder.elm
@@ -576,6 +576,9 @@ updateIngredientFormView { excluded, db, ingredient, impact, selectedImpact, tra
                             , variant = newVariant
                             , country = Nothing
                             , planeTransport = Ingredient.byPlaneByDefault newIngredient
+                            , bonuses =
+                                newVariant
+                                    |> Query.updateBonusesFromVariant db.ingredients newIngredient.id
                         }
                 )
         , db.countries


### PR DESCRIPTION
Requested in [this card](https://www.notion.so/CORRECTIFS-ACV-Pr-parer-l-introduction-des-impacts-n-gatifs-IAE-diversit-interface-mod-le-de-cd6e6379e85a48c5baa4584e43857e0b):

> Retour aux % par défaut lorsque l’on change d’ingrédient. Aujourd’hui, on bascule sur les % par défaut lorsque l’on passe de bio à “pas bio”. En revanche, si les % ont bougé, ils sont conservés lorsque l’on change le choix d’ingrédient. Il faudrait idéalement qu’ils reviennent sur le % par défaut du nouvel ingrédient choisi.