### PR TITLE
Shorten impact unit.

### DIFF
--- a/public/data/impacts.json
+++ b/public/data/impacts.json
@@ -10,7 +10,7 @@
     "unit_en": "impact µPts",
     "description_en": "Aggregated impact: sum of the weighted and normalized impact of all environmental impact categories according to the Ecobalyse methodology, including Biodiversity.",
     "description_fr": "Impact *agrégé* : somme des impacts **normalisés** et **pondérés** de chaque catégorie d'impact selon la méthode Ecobalyse, incluant l'impact sur la biodiversité.\n\nCet indicateur n'a **pas de dimension**, il se mesure en **Points** (`Pt`), en **milliPoints** (`mPt`) ou en **microPoints** (`µPt`) avec `1 Pt = 1 000 mPt = 1 000 000 µPt`. `1 Pt` correspond à l'impact total d'un européen sur une année.",
-    "short_unit": "µPts d'impact",
+    "short_unit": "µPts",
     "decimals": 2,
     "quality": null,
     "pef": null,


### PR DESCRIPTION
[User Story](https://www.notion.so/Correction-bug-d-affichage-chiffre-100-microPts-ou-1000-microPts-a389211c063e42eeb76e77c659d412ce)

TL;DR: `µPts d'impact` was too long and broke some layout on smaller viewports. `µPts` is enough.