### PR TITLE
Use the selected knitting process' waste

### DIFF
--- a/src/Data/Textile/Product.elm
+++ b/src/Data/Textile/Product.elm
@@ -15,8 +15,9 @@ module Data.Textile.Product exposing
 
 import Data.Split as Split exposing (Split)
 import Data.Textile.DyeingMedium as DyeingMedium exposing (DyeingMedium)
+import Data.Textile.Knitting exposing (Knitting)
 import Data.Textile.MakingComplexity as MakingComplexity exposing (MakingComplexity)
-import Data.Textile.Process as Process exposing (Process)
+import Data.Textile.Process as Process exposing (Process, WellKnown)
 import Data.Unit as Unit
 import Duration exposing (Duration)
 import Json.Decode as Decode exposing (Decoder)
@@ -81,11 +82,16 @@ type Id
     = Id String
 
 
-getFabricProcess : Product -> Process
-getFabricProcess { fabric } =
+getFabricProcess : Maybe Knitting -> Product -> WellKnown -> Process
+getFabricProcess maybeKnittingProcess { fabric } wellknown =
     case fabric of
         Knitted process ->
-            process
+            case maybeKnittingProcess of
+                Just knittingProcess ->
+                    Process.getKnittingProcess knittingProcess wellknown
+
+                Nothing ->
+                    process
 
         Weaved process ->
             process

--- a/src/Data/Textile/Step.elm
+++ b/src/Data/Textile/Step.elm
@@ -318,7 +318,14 @@ updateFromInputs { processes } inputs ({ label, country } as step) =
                 , processInfo =
                     { defaultProcessInfo
                         | countryElec = Just country.electricityProcess.name
-                        , fabric = Just (Product.getFabricProcess inputs.product |> .name)
+                        , fabric =
+                            processes
+                                |> Process.loadWellKnown
+                                |> Result.map
+                                    (Product.getFabricProcess inputs.knittingProcess inputs.product
+                                        >> .name
+                                    )
+                                |> Result.toMaybe
                     }
             }
 

--- a/src/Views/Textile/Step.elm
+++ b/src/Views/Textile/Step.elm
@@ -16,6 +16,7 @@ import Data.Textile.Inputs as Inputs exposing (Inputs)
 import Data.Textile.Knitting as Knitting exposing (Knitting)
 import Data.Textile.MakingComplexity as MakingComplexity exposing (MakingComplexity)
 import Data.Textile.Printing as Printing exposing (Printing)
+import Data.Textile.Process as Process
 import Data.Textile.Product as Product exposing (Product)
 import Data.Textile.Step as Step exposing (Step)
 import Data.Textile.Step.Label as Label exposing (Label)
@@ -403,17 +404,17 @@ makingComplexityField ({ inputs, updateMakingComplexity } as config) =
 
 
 makingWasteField : Config msg -> Html msg
-makingWasteField { current, inputs, updateMakingWaste } =
+makingWasteField { current, db, inputs, updateMakingWaste } =
     let
         processName =
-            if Product.isKnitted inputs.product then
-                inputs.knittingProcess
-                    |> Maybe.withDefault Knitting.Mix
-                    |> Knitting.toString
-
-            else
-                Product.getFabricProcess inputs.product
-                    |> .name
+            db.processes
+                |> Process.loadWellKnown
+                |> Result.map
+                    (Product.getFabricProcess inputs.knittingProcess inputs.product
+                        >> .name
+                    )
+                |> Result.toMaybe
+                |> Maybe.withDefault "process not found"
     in
     span
         [ title <| "Taux personnalisé de perte en confection, incluant notamment la découpe. Procédé utilisé : " ++ processName

--- a/tests/Data/Textile/ProductTest.elm
+++ b/tests/Data/Textile/ProductTest.elm
@@ -1,44 +1,91 @@
 module Data.Textile.ProductTest exposing (..)
 
+import Data.Textile.Inputs as Inputs
+import Data.Textile.Knitting as Knitting
+import Data.Textile.Process as Process
 import Data.Textile.Product as Product
 import Data.Unit as Unit
 import Duration
 import Expect
 import Test exposing (..)
-import TestUtils exposing (asTest)
+import TestUtils exposing (asTest, suiteWithDb)
+
+
+sampleQuery : Inputs.Query
+sampleQuery =
+    Inputs.tShirtCotonAsie
 
 
 suite : Test
 suite =
-    describe "Data.Product"
-        [ describe "customDaysOfWear"
-            [ { daysOfWear = Duration.days 100, wearsPerCycle = 20 }
-                |> Product.customDaysOfWear (Just (Unit.quality 1)) Nothing
-                |> Expect.equal
-                    { daysOfWear = Duration.days 100
-                    , useNbCycles = 5
-                    }
-                |> asTest "should compute custom number of days of wear"
-            , { daysOfWear = Duration.days 100, wearsPerCycle = 20 }
-                |> Product.customDaysOfWear (Just (Unit.quality 0.8)) Nothing
-                |> Expect.equal
-                    { daysOfWear = Duration.days 80
-                    , useNbCycles = 4
-                    }
-                |> asTest "should compute custom number of days of wear with custom quality"
-            , { daysOfWear = Duration.days 100, wearsPerCycle = 20 }
-                |> Product.customDaysOfWear Nothing (Just (Unit.reparability 1.2))
-                |> Expect.equal
-                    { daysOfWear = Duration.days 120
-                    , useNbCycles = 6
-                    }
-                |> asTest "should compute custom number of days of wear with custom reparability"
-            , { daysOfWear = Duration.days 100, wearsPerCycle = 20 }
-                |> Product.customDaysOfWear (Just (Unit.quality 1.2)) (Just (Unit.reparability 1.2))
-                |> Expect.equal
-                    { daysOfWear = Duration.days 144
-                    , useNbCycles = 7
-                    }
-                |> asTest "should compute custom number of days of wear with custom quality & reparability"
+    suiteWithDb "Data.Simulator"
+        (\{ textileDb } ->
+            [ describe "Data.Product"
+                [ describe "customDaysOfWear"
+                    [ { daysOfWear = Duration.days 100, wearsPerCycle = 20 }
+                        |> Product.customDaysOfWear (Just (Unit.quality 1)) Nothing
+                        |> Expect.equal
+                            { daysOfWear = Duration.days 100
+                            , useNbCycles = 5
+                            }
+                        |> asTest "should compute custom number of days of wear"
+                    , { daysOfWear = Duration.days 100, wearsPerCycle = 20 }
+                        |> Product.customDaysOfWear (Just (Unit.quality 0.8)) Nothing
+                        |> Expect.equal
+                            { daysOfWear = Duration.days 80
+                            , useNbCycles = 4
+                            }
+                        |> asTest "should compute custom number of days of wear with custom quality"
+                    , { daysOfWear = Duration.days 100, wearsPerCycle = 20 }
+                        |> Product.customDaysOfWear Nothing (Just (Unit.reparability 1.2))
+                        |> Expect.equal
+                            { daysOfWear = Duration.days 120
+                            , useNbCycles = 6
+                            }
+                        |> asTest "should compute custom number of days of wear with custom reparability"
+                    , { daysOfWear = Duration.days 100, wearsPerCycle = 20 }
+                        |> Product.customDaysOfWear (Just (Unit.quality 1.2)) (Just (Unit.reparability 1.2))
+                        |> Expect.equal
+                            { daysOfWear = Duration.days 144
+                            , useNbCycles = 7
+                            }
+                        |> asTest "should compute custom number of days of wear with custom quality & reparability"
+                    ]
+                , let
+                    tshirtResult =
+                        sampleQuery
+                            |> Inputs.fromQuery textileDb
+                            |> Result.map .product
+
+                    wellKnownResult =
+                        Process.loadWellKnown textileDb.processes
+                  in
+                  describe "getFabricProcess"
+                    [ Result.map2
+                        (\product wellKnown ->
+                            let
+                                fabricProcess =
+                                    Product.getFabricProcess Nothing product wellKnown
+                            in
+                            Expect.equal product.fabric (Product.Knitted fabricProcess)
+                        )
+                        tshirtResult
+                        wellKnownResult
+                        |> Result.withDefault (Expect.fail "test failed")
+                        |> asTest "should return the default product fabric process when no knitting process is specified"
+                    , Result.map2
+                        (\product wellKnown ->
+                            let
+                                fabricProcess =
+                                    Product.getFabricProcess (Just Knitting.Seamless) product wellKnown
+                            in
+                            Expect.equal wellKnown.knittingSeamless fabricProcess
+                        )
+                        tshirtResult
+                        wellKnownResult
+                        |> Result.withDefault (Expect.fail "test failed")
+                        |> asTest "should return the selected knitting process over the default product fabric process"
+                    ]
+                ]
             ]
-        ]
+        )


### PR DESCRIPTION
[user story](https://www.notion.so/Tricotage-adapter-taux-de-perte-8c6226030a734dfc90b3e17216b29b0b) : it was always the default product's knitting process' waste that was used, instead of the selected one's.