### PR TITLE
Limit the col size again in the explorer

### DIFF
--- a/styles.scss
+++ b/styles.scss
@@ -645,6 +645,7 @@ q {
           white-space: nowrap;
           overflow: hidden;
           text-overflow: ellipsis;
+          max-width: 320px;
           vertical-align: middle;
         }
       }


### PR DESCRIPTION
Following the changes in #281 the columns are too wide for certain tabs in the explorer. Reverting for now.