### PR TITLE
Spread food impact information over three tabs in the sidebar.

### DIFF
--- a/src/Data/Impact.elm
+++ b/src/Data/Impact.elm
@@ -23,6 +23,7 @@ module Data.Impact exposing
     , impactsFromDefinitons
     , invalid
     , isAggregate
+    , isEcoscore
     , mapImpacts
     , noBonusImpacts
     , noImpacts
@@ -260,6 +261,11 @@ decodeQuality =
                     _ ->
                         Decode.succeed UnknownQuality
             )
+
+
+isEcoscore : Definition -> Bool
+isEcoscore { trigram } =
+    trigram == trg "ecs"
 
 
 toString : Trigram -> String

--- a/src/Page/Food/Builder.elm
+++ b/src/Page/Food/Builder.elm
@@ -1387,7 +1387,7 @@ impactTabsView db model results =
                 |> List.map
                     (\( tab, label ) ->
                         { label = label
-                        , event = SwitchImpactsTab tab
+                        , onTabClick = SwitchImpactsTab tab
                         , active = model.activeImpactsTab == tab
                         }
                     )

--- a/src/Page/Food/Builder.elm
+++ b/src/Page/Food/Builder.elm
@@ -1394,29 +1394,10 @@ impactTabsView db model results =
         , content =
             [ case model.activeImpactsTab of
                 DetailedImpactsTab ->
-                    let
-                        data =
-                            results.total
-                                |> Impact.getAggregatedScoreData db.impacts .ecoscoreData
-
-                        total =
-                            data |> List.map .value |> List.sum
-
-                        strongest =
-                            data |> List.map .value |> List.maximum |> Maybe.withDefault 100
-
-                        dataWithPercentages =
-                            data
-                                |> List.map
-                                    (\{ name, value } ->
-                                        { name = name
-                                        , percent = value / total * 100
-                                        , vsStrongest = value / strongest * 100
-                                        }
-                                    )
-                    in
-                    dataWithPercentages
-                        |> List.sortBy .percent
+                    results.total
+                        |> Impact.getAggregatedScoreData db.impacts .ecoscoreData
+                        |> List.map (\{ name, value } -> ( name, value ))
+                        |> List.sortBy Tuple.second
                         |> List.reverse
                         |> Table.percentageTable
 
@@ -1424,74 +1405,22 @@ impactTabsView db model results =
                     let
                         toFloat =
                             Impact.getImpact model.impact.trigram >> Unit.impactToFloat
-
-                        totalImpact =
-                            toFloat results.total
-
-                        data =
-                            [ { name = "Ingrédients"
-                              , impact = toFloat results.recipe.ingredientsTotal
-                              }
-                            , { name = "Transformation"
-                              , impact = toFloat results.recipe.transform
-                              }
-                            , { name = "Emballage"
-                              , impact = toFloat results.packaging
-                              }
-                            , { name = "Transports"
-                              , impact = toFloat results.transports.impacts
-                              }
-                            , { name = "Distribution"
-                              , impact = toFloat results.distribution.total
-                              }
-                            , { name = "Consommation"
-                              , impact = toFloat results.preparation
-                              }
-                            ]
-
-                        strongest =
-                            data |> List.map .impact |> List.maximum |> Maybe.withDefault 100
                     in
-                    data
-                        |> List.map
-                            (\{ name, impact } ->
-                                { name = name
-                                , percent =
-                                    if totalImpact /= 0 then
-                                        impact / totalImpact * 100
-
-                                    else
-                                        0
-                                , vsStrongest = impact / strongest * 100
-                                }
-                            )
-                        |> Table.percentageTable
+                    Table.percentageTable
+                        [ ( "Ingrédients", toFloat results.recipe.ingredientsTotal )
+                        , ( "Transformation", toFloat results.recipe.transform )
+                        , ( "Emballage", toFloat results.packaging )
+                        , ( "Transports", toFloat results.transports.impacts )
+                        , ( "Distribution", toFloat results.distribution.total )
+                        , ( "Consommation", toFloat results.preparation )
+                        ]
 
                 SubscoresTab ->
-                    div []
-                        [ let
-                            data =
-                                [ ( "Climat", Unit.impactToFloat results.scoring.climate )
-                                , ( "Biodiversité", Unit.impactToFloat results.scoring.biodiversity )
-                                , ( "Santé environnementale", Unit.impactToFloat results.scoring.health )
-                                , ( "Ressource", Unit.impactToFloat results.scoring.resources )
-                                ]
-
-                            total =
-                                data |> List.map Tuple.second |> List.sum
-
-                            strongest =
-                                data |> List.map Tuple.second |> List.maximum |> Maybe.withDefault 100
-                          in
-                          data
-                            |> List.map
-                                (\( name, impact ) ->
-                                    { name = name
-                                    , percent = impact / total * 100
-                                    , vsStrongest = impact / strongest * 100
-                                    }
-                                )
-                            |> Table.percentageTable
+                    Table.percentageTable
+                        [ ( "Climat", Unit.impactToFloat results.scoring.climate )
+                        , ( "Biodiversité", Unit.impactToFloat results.scoring.biodiversity )
+                        , ( "Santé environnementale", Unit.impactToFloat results.scoring.health )
+                        , ( "Ressource", Unit.impactToFloat results.scoring.resources )
                         ]
             ]
         }

--- a/src/Page/Food/Builder.elm
+++ b/src/Page/Food/Builder.elm
@@ -143,7 +143,7 @@ init ({ db, builderDb, queries } as session) trigram maybeQuery =
               , modal = NoModal
               , chartHovering = []
               , activeImpactsTab =
-                    if shouldRenderBonuses impact then
+                    if Impact.isEcoscore impact then
                         SubscoresTab
 
                     else
@@ -424,11 +424,6 @@ findExistingBookmarkName { builderDb, store } query =
             )
 
 
-shouldRenderBonuses : Impact.Definition -> Bool
-shouldRenderBonuses { trigram } =
-    trigram == Impact.trg "ecs"
-
-
 
 -- Views
 
@@ -454,7 +449,7 @@ absoluteImpactView model results =
                     , results.total
                         |> Format.formatFoodSelectedImpact model.impact
                     ]
-                , if shouldRenderBonuses model.impact then
+                , if Impact.isEcoscore model.impact then
                     div [ class "text-center fs-7" ]
                         [ text " dont "
                         , results.recipe.totalBonusesImpact.total
@@ -687,7 +682,7 @@ updateIngredientFormView { excluded, db, recipeIngredient, impact, index, select
                 |> Format.formatFoodSelectedImpact selectedImpact
             ]
         , deleteItemButton (DeleteIngredient ingredientQuery.id)
-        , if shouldRenderBonuses selectedImpact then
+        , if Impact.isEcoscore selectedImpact then
             let
                 { bonuses, ingredient } =
                     recipeIngredient
@@ -1380,7 +1375,7 @@ impactTabsView : Db -> Model -> Recipe.Results -> Html Msg
 impactTabsView db model results =
     CardTabs.view
         { tabs =
-            (if shouldRenderBonuses model.impact then
+            (if Impact.isEcoscore model.impact then
                 [ ( SubscoresTab, "Sous-scores" )
                 , ( DetailedImpactsTab, "Impacts" )
                 , ( StepImpactsTab, "Étapes" )

--- a/src/Page/Food/Builder.elm
+++ b/src/Page/Food/Builder.elm
@@ -57,6 +57,7 @@ import Views.Impact as ImpactView
 import Views.Link as Link
 import Views.Modal as ModalView
 import Views.Spinner as Spinner
+import Views.Table as Table
 import Views.Textile.ComparativeChart as ComparativeChart
 import Views.Transport as TransportView
 
@@ -1337,32 +1338,6 @@ ingredientSelectorView selectedIngredient excluded event ingredients =
         )
 
 
-percentageTable : List { name : String, percent : Float, vsStrongest : Float } -> Html Msg
-percentageTable data =
-    table [ class "table w-100 m-0" ]
-        [ data
-            |> List.map
-                (\{ name, percent, vsStrongest } ->
-                    tr []
-                        [ th [ class "text-truncate fw-normal fs-8", style "max-width" "200px" ] [ text name ]
-                        , td [ style "width" "200px", style "vertical-align" "middle" ]
-                            [ div [ class "progress", style "width" "100%", style "height" "13px" ]
-                                [ div
-                                    [ class "progress-bar bg-secondary"
-                                    , style "width" (String.fromFloat vsStrongest ++ "%")
-                                    ]
-                                    []
-                                ]
-                            ]
-                        , td [ class "text-end fs-8" ]
-                            [ Format.percent percent
-                            ]
-                        ]
-                )
-            |> tbody []
-        ]
-
-
 sidebarView : Session -> Db -> Model -> Recipe.Results -> Html Msg
 sidebarView session db model results =
     div
@@ -1448,7 +1423,7 @@ impactTabsView db model results =
                     dataWithPercentages
                         |> List.sortBy .percent
                         |> List.reverse
-                        |> percentageTable
+                        |> Table.percentageTable
 
                 StepImpactsTab ->
                     let
@@ -1495,7 +1470,7 @@ impactTabsView db model results =
                                 , vsStrongest = impact / strongest * 100
                                 }
                             )
-                        |> percentageTable
+                        |> Table.percentageTable
 
                 SubscoresTab ->
                     div []
@@ -1521,7 +1496,7 @@ impactTabsView db model results =
                                     , vsStrongest = impact / strongest * 100
                                     }
                                 )
-                            |> percentageTable
+                            |> Table.percentageTable
                         ]
             ]
         }

--- a/src/Page/Food/Builder.elm
+++ b/src/Page/Food/Builder.elm
@@ -1383,31 +1383,34 @@ sidebarView session db model results =
                             total =
                                 data |> List.map .value |> List.sum
 
+                            strongest =
+                                data |> List.map .value |> List.maximum |> Maybe.withDefault 100
+
                             dataWithPercentages =
                                 data
                                     |> List.map
                                         (\{ name, value } ->
-                                            { name = name, percent = value / total * 100 }
+                                            { name = name, percent = value / total * 100, vsStrongest = value / strongest * 100 }
                                         )
                         in
-                        table [ class "table fs-7" ]
+                        table [ class "table mb-0" ]
                             [ dataWithPercentages
                                 |> List.sortBy .percent
                                 |> List.reverse
                                 |> List.map
-                                    (\{ name, percent } ->
+                                    (\{ name, percent, vsStrongest } ->
                                         tr []
-                                            [ th [ class "text-truncate", style "max-width" "200px" ] [ text name ]
+                                            [ th [ class "text-truncate fw-normal fs-8", style "max-width" "200px" ] [ text name ]
                                             , td [ style "width" "200px", style "vertical-align" "middle" ]
                                                 [ div [ class "progress", style "width" "100%", style "height" "13px" ]
                                                     [ div
                                                         [ class "progress-bar bg-secondary"
-                                                        , style "width" (String.fromFloat percent ++ "%")
+                                                        , style "width" (String.fromFloat vsStrongest ++ "%")
                                                         ]
                                                         []
                                                     ]
                                                 ]
-                                            , td [ class "text-end" ]
+                                            , td [ class "text-end fs-8" ]
                                                 [ Format.percent percent
                                                 ]
                                             ]
@@ -1419,7 +1422,7 @@ sidebarView session db model results =
                         stepResultsView model results
 
                     SubscoresTab ->
-                        div [ class "card-body" ]
+                        table [ class "table Subscores w-100 m-0" ]
                             [ [ ( "Climat", results.scoring.climate )
                               , ( "Biodiversité", results.scoring.biodiversity )
                               , ( "Santé environnementale", results.scoring.health )
@@ -1428,8 +1431,8 @@ sidebarView session db model results =
                                 |> List.map
                                     (\( label, subScore ) ->
                                         tr []
-                                            [ th [ class "fw-normal" ] [ text label ]
-                                            , td [ class "text-end" ]
+                                            [ th [ class "ps-3 fw-normal" ] [ text label ]
+                                            , td [ class "pe-3 text-end" ]
                                                 [ strong []
                                                     [ subScore
                                                         |> Unit.impactToFloat
@@ -1438,7 +1441,7 @@ sidebarView session db model results =
                                                 ]
                                             ]
                                     )
-                                |> table [ class "Subscores w-100 m-0" ]
+                                |> tbody []
                             ]
                 ]
             }

--- a/src/Views/Bookmark.elm
+++ b/src/Views/Bookmark.elm
@@ -10,6 +10,7 @@ import Html.Attributes exposing (..)
 import Html.Events exposing (..)
 import Page.Textile.Simulator.ViewMode as ViewMode exposing (ViewMode)
 import Route
+import Views.CardTabs as CardTabs
 import Views.Icon as Icon
 
 
@@ -39,29 +40,27 @@ type ActiveTab
 
 view : ManagerConfig msg -> Html msg
 view ({ activeTab, switchTab } as config) =
-    div [ class "card shadow-sm" ]
-        [ div [ class "card-header px-0 pb-0 border-bottom-0" ]
-            [ [ ( SaveTab, "Sauvegarder" ), ( ShareTab, "Partager" ) ]
+    CardTabs.view
+        { tabs =
+            [ ( SaveTab, "Sauvegarder" )
+            , ( ShareTab, "Partager" )
+            ]
                 |> List.map
                     (\( tab, label ) ->
-                        li [ class "TabsTab nav-item", classList [ ( "active", activeTab == tab ) ] ]
-                            [ button
-                                [ class "nav-link no-outline border-top-0"
-                                , classList [ ( "active", activeTab == tab ) ]
-                                , onClick <| switchTab tab
-                                ]
-                                [ text label ]
-                            ]
+                        { label = label
+                        , event = switchTab tab
+                        , active = activeTab == tab
+                        }
                     )
-                |> ul [ class "Tabs nav nav-tabs justify-content-end gap-2 px-3" ]
-            ]
-        , case activeTab of
-            ShareTab ->
-                shareLinkView config
+        , content =
+            [ case activeTab of
+                ShareTab ->
+                    shareLinkView config
 
-            SaveTab ->
-                managerView config
-        ]
+                SaveTab ->
+                    managerView config
+            ]
+        }
 
 
 shareLinkView : ManagerConfig msg -> Html msg

--- a/src/Views/Bookmark.elm
+++ b/src/Views/Bookmark.elm
@@ -48,7 +48,7 @@ view ({ activeTab, switchTab } as config) =
                 |> List.map
                     (\( tab, label ) ->
                         { label = label
-                        , event = switchTab tab
+                        , onTabClick = switchTab tab
                         , active = activeTab == tab
                         }
                     )

--- a/src/Views/CardTabs.elm
+++ b/src/Views/CardTabs.elm
@@ -1,0 +1,33 @@
+module Views.CardTabs exposing (view)
+
+import Html exposing (..)
+import Html.Attributes exposing (..)
+import Html.Events exposing (..)
+
+
+type alias Config msg =
+    { tabs : List { label : String, event : msg, active : Bool }
+    , content : List (Html msg)
+    }
+
+
+view : Config msg -> Html msg
+view { tabs, content } =
+    div [ class "card shadow-sm" ]
+        (div [ class "card-header px-0 pb-0 border-bottom-0" ]
+            [ tabs
+                |> List.map
+                    (\{ label, event, active } ->
+                        li [ class "TabsTab nav-item", classList [ ( "active", active ) ] ]
+                            [ button
+                                [ class "nav-link no-outline border-top-0"
+                                , classList [ ( "active", active ) ]
+                                , onClick event
+                                ]
+                                [ text label ]
+                            ]
+                    )
+                |> ul [ class "Tabs nav nav-tabs justify-content-end gap-2 px-3" ]
+            ]
+            :: content
+        )

--- a/src/Views/CardTabs.elm
+++ b/src/Views/CardTabs.elm
@@ -27,7 +27,7 @@ view { tabs, content } =
                                 [ text label ]
                             ]
                     )
-                |> ul [ class "Tabs nav nav-tabs justify-content-end gap-2 px-3" ]
+                |> ul [ class "Tabs nav nav-tabs nav-fill justify-content-end gap-2 px-2" ]
             ]
             :: content
         )

--- a/src/Views/CardTabs.elm
+++ b/src/Views/CardTabs.elm
@@ -5,8 +5,15 @@ import Html.Attributes exposing (..)
 import Html.Events exposing (..)
 
 
+type alias Tab msg =
+    { label : String
+    , active : Bool
+    , onTabClick : msg
+    }
+
+
 type alias Config msg =
-    { tabs : List { label : String, event : msg, active : Bool }
+    { tabs : List (Tab msg)
     , content : List (Html msg)
     }
 
@@ -17,12 +24,12 @@ view { tabs, content } =
         (div [ class "card-header px-0 pb-0 border-bottom-0" ]
             [ tabs
                 |> List.map
-                    (\{ label, event, active } ->
+                    (\{ label, onTabClick, active } ->
                         li [ class "TabsTab nav-item", classList [ ( "active", active ) ] ]
                             [ button
                                 [ class "nav-link no-outline border-top-0"
                                 , classList [ ( "active", active ) ]
-                                , onClick event
+                                , onClick onTabClick
                                 ]
                                 [ text label ]
                             ]

--- a/src/Views/Table.elm
+++ b/src/Views/Table.elm
@@ -22,41 +22,44 @@ responsiveDefault attrs content =
 percentageTable : List ( String, Float ) -> Html msg
 percentageTable data =
     let
-        total =
-            data |> List.map Tuple.second |> List.sum
+        values =
+            List.map Tuple.second data
 
-        strongest =
-            data |> List.map Tuple.second |> List.maximum |> Maybe.withDefault 100
+        ( total, maximum ) =
+            ( List.sum values
+            , values |> List.maximum |> Maybe.withDefault 0
+            )
+    in
+    if total == 0 || maximum == 0 then
+        text ""
 
-        dataWithPercentages =
-            data
+    else
+        table [ class "table w-100 m-0" ]
+            [ data
                 |> List.map
                     (\( name, value ) ->
                         { name = name
                         , percent = value / total * 100
-                        , vsStrongest = value / strongest * 100
+                        , width = value / maximum * 100
                         }
                     )
-    in
-    table [ class "table w-100 m-0" ]
-        [ dataWithPercentages
-            |> List.map
-                (\{ name, percent, vsStrongest } ->
-                    tr []
-                        [ th [ class "text-truncate fw-normal fs-8", style "max-width" "200px" ] [ text name ]
-                        , td [ style "width" "200px", style "vertical-align" "middle" ]
-                            [ div [ class "progress bg-white", style "width" "100%", style "height" "13px" ]
-                                [ div
-                                    [ class "progress-bar bg-secondary"
-                                    , style "width" (String.fromFloat vsStrongest ++ "%")
+                |> List.map
+                    (\{ name, percent, width } ->
+                        tr []
+                            [ th [ class "text-truncate fw-normal fs-8", style "max-width" "200px" ] [ text name ]
+                            , td [ style "width" "200px", style "vertical-align" "middle" ]
+                                [ div [ class "progress bg-white", style "width" "100%", style "height" "13px" ]
+                                    [ div
+                                        [ class "progress-bar bg-secondary"
+                                        , style "width" (String.fromFloat width ++ "%")
+                                        ]
+                                        []
                                     ]
-                                    []
+                                ]
+                            , td [ class "text-end fs-8" ]
+                                [ Format.percent percent
                                 ]
                             ]
-                        , td [ class "text-end fs-8" ]
-                            [ Format.percent percent
-                            ]
-                        ]
-                )
-            |> tbody []
-        ]
+                    )
+                |> tbody []
+            ]

--- a/src/Views/Table.elm
+++ b/src/Views/Table.elm
@@ -19,10 +19,27 @@ responsiveDefault attrs content =
         ]
 
 
-percentageTable : List { name : String, percent : Float, vsStrongest : Float } -> Html msg
+percentageTable : List ( String, Float ) -> Html msg
 percentageTable data =
+    let
+        total =
+            data |> List.map Tuple.second |> List.sum
+
+        strongest =
+            data |> List.map Tuple.second |> List.maximum |> Maybe.withDefault 100
+
+        dataWithPercentages =
+            data
+                |> List.map
+                    (\( name, value ) ->
+                        { name = name
+                        , percent = value / total * 100
+                        , vsStrongest = value / strongest * 100
+                        }
+                    )
+    in
     table [ class "table w-100 m-0" ]
-        [ data
+        [ dataWithPercentages
             |> List.map
                 (\{ name, percent, vsStrongest } ->
                     tr []

--- a/src/Views/Table.elm
+++ b/src/Views/Table.elm
@@ -34,21 +34,22 @@ percentageTable data =
         text ""
 
     else
-        table [ class "table w-100 m-0" ]
+        table [ class "table table-hover w-100 m-0" ]
             [ data
                 |> List.map
                     (\( name, value ) ->
                         { name = name
+                        , impact = value
                         , percent = value / total * 100
                         , width = value / maximum * 100
                         }
                     )
                 |> List.map
-                    (\{ name, percent, width } ->
-                        tr []
+                    (\{ name, impact, percent, width } ->
+                        tr [ title <| name ++ ": " ++ Format.formatFloat 2 percent ++ "\u{202F}% (" ++ Format.formatFloat 2 impact ++ "\u{202F}µPts)" ]
                             [ th [ class "text-truncate fw-normal fs-8", style "max-width" "200px" ] [ text name ]
                             , td [ style "width" "200px", style "vertical-align" "middle" ]
-                                [ div [ class "progress bg-white", style "width" "100%", style "height" "13px" ]
+                                [ div [ class "progress bg-transparent", style "width" "100%", style "height" "13px" ]
                                     [ div
                                         [ class "progress-bar bg-secondary"
                                         , style "width" (String.fromFloat width ++ "%")

--- a/src/Views/Table.elm
+++ b/src/Views/Table.elm
@@ -1,7 +1,11 @@
-module Views.Table exposing (responsiveDefault)
+module Views.Table exposing
+    ( percentageTable
+    , responsiveDefault
+    )
 
 import Html exposing (..)
 import Html.Attributes exposing (..)
+import Views.Format as Format
 
 
 responsiveDefault : List (Attribute msg) -> List (Html msg) -> Html msg
@@ -12,4 +16,30 @@ responsiveDefault attrs content =
                 :: attrs
             )
             content
+        ]
+
+
+percentageTable : List { name : String, percent : Float, vsStrongest : Float } -> Html msg
+percentageTable data =
+    table [ class "table w-100 m-0" ]
+        [ data
+            |> List.map
+                (\{ name, percent, vsStrongest } ->
+                    tr []
+                        [ th [ class "text-truncate fw-normal fs-8", style "max-width" "200px" ] [ text name ]
+                        , td [ style "width" "200px", style "vertical-align" "middle" ]
+                            [ div [ class "progress", style "width" "100%", style "height" "13px" ]
+                                [ div
+                                    [ class "progress-bar bg-secondary"
+                                    , style "width" (String.fromFloat vsStrongest ++ "%")
+                                    ]
+                                    []
+                                ]
+                            ]
+                        , td [ class "text-end fs-8" ]
+                            [ Format.percent percent
+                            ]
+                        ]
+                )
+            |> tbody []
         ]

--- a/src/Views/Table.elm
+++ b/src/Views/Table.elm
@@ -28,7 +28,7 @@ percentageTable data =
                     tr []
                         [ th [ class "text-truncate fw-normal fs-8", style "max-width" "200px" ] [ text name ]
                         , td [ style "width" "200px", style "vertical-align" "middle" ]
-                            [ div [ class "progress", style "width" "100%", style "height" "13px" ]
+                            [ div [ class "progress bg-white", style "width" "100%", style "height" "13px" ]
                                 [ div
                                     [ class "progress-bar bg-secondary"
                                     , style "width" (String.fromFloat vsStrongest ++ "%")

--- a/styles.scss
+++ b/styles.scss
@@ -1198,6 +1198,12 @@ q {
     box-shadow: 0 -2px 0 0 $primary;
     color: $text-darker;
     font-weight: 700;
+    font-size: 0.975em;
+
+    .nav-link {
+      padding-left: 5px;
+      padding-right: 5px;
+    }
 
     &.active {
       color: $primary !important;


### PR DESCRIPTION
This is the first part of [this card](https://www.notion.so/Harmoniser-la-pr-sentation-du-d-tail-des-postes-entre-textile-et-alimentaire-c7530e3369e64dabaed7df8026bea733) (remaining work will be to add support for ecoscore to Textile — which should happen separately — and use the blocks provided by this patch to render impacts information tabs the same way we do for food here)