### PR TITLE
More refactorings

### DIFF
--- a/src/Data/Impact.elm
+++ b/src/Data/Impact.elm
@@ -113,7 +113,7 @@ applyBonus bonus impacts =
             getImpact (trg "ecs") impacts
     in
     impacts
-        |> insert (trg "ecs")
+        |> insertWithoutAggregateComputation (trg "ecs")
             (Quantity.difference ecoScore bonus)
 
 
@@ -344,17 +344,17 @@ noImpacts =
         |> Impacts
 
 
-insert : Trigram -> Unit.Impact -> Impacts -> Impacts
-insert trigram impact (Impacts impacts) =
-    AnyDict.insert trigram impact impacts
-        |> Impacts
-
-
 impactsFromDefinitons : List Definition -> Impacts
 impactsFromDefinitons =
     List.map (\{ trigram } -> ( trigram, Quantity.zero ))
         >> AnyDict.fromList toString
         >> Impacts
+
+
+insertWithoutAggregateComputation : Trigram -> Unit.Impact -> Impacts -> Impacts
+insertWithoutAggregateComputation trigram impact (Impacts impacts) =
+    AnyDict.insert trigram impact impacts
+        |> Impacts
 
 
 getImpact : Trigram -> Impacts -> Unit.Impact
@@ -407,7 +407,7 @@ toDict (Impacts impacts) =
 
 updateImpact : List Definition -> Trigram -> Unit.Impact -> Impacts -> Impacts
 updateImpact definitions trigram value =
-    insert trigram value
+    insertWithoutAggregateComputation trigram value
         >> updateAggregatedScores definitions
 
 
@@ -457,7 +457,7 @@ updateAggregatedScores definitions impacts =
         aggregateScore getter trigram =
             impacts
                 |> computeAggregatedScore getter definitions
-                |> insert trigram
+                |> insertWithoutAggregateComputation trigram
     in
     impacts
         |> aggregateScore .ecoscoreData (trg "ecs")

--- a/src/Data/Session.elm
+++ b/src/Data/Session.elm
@@ -1,10 +1,12 @@
 module Data.Session exposing
     ( Notification(..)
     , Session
+    , UnloadedSession
     , checkComparedSimulations
     , closeNotification
     , deleteBookmark
     , deserializeStore
+    , fromUnloaded
     , maxComparedSimulations
     , notifyError
     , notifyHttpError
@@ -46,6 +48,35 @@ type alias Session =
     }
 
 
+type alias UnloadedSession =
+    { navKey : Nav.Key
+    , clientUrl : String
+    , store : Store
+    , currentVersion : Version
+    , builderDb : BuilderDb.Db
+    , explorerDb : ExplorerDb.Db
+    , notifications : List Notification
+    , queries :
+        { food : FoodQuery.Query
+        , textile : TextileInputs.Query
+        }
+    }
+
+
+fromUnloaded : UnloadedSession -> Db -> Session
+fromUnloaded unloadedSession db =
+    { navKey = unloadedSession.navKey
+    , clientUrl = unloadedSession.clientUrl
+    , store = unloadedSession.store
+    , currentVersion = unloadedSession.currentVersion
+    , db = db
+    , builderDb = unloadedSession.builderDb
+    , explorerDb = unloadedSession.explorerDb
+    , notifications = unloadedSession.notifications
+    , queries = unloadedSession.queries
+    }
+
+
 
 -- Notifications
 
@@ -65,7 +96,7 @@ notifyError title error ({ notifications } as session) =
     { session | notifications = notifications ++ [ GenericError title error ] }
 
 
-notifyHttpError : Http.Error -> Session -> Session
+notifyHttpError : Http.Error -> { a | notifications : List Notification } -> { a | notifications : List Notification }
 notifyHttpError error ({ notifications } as session) =
     { session | notifications = notifications ++ [ HttpError error ] }
 

--- a/src/Data/Textile/Db.elm
+++ b/src/Data/Textile/Db.elm
@@ -19,6 +19,7 @@ type alias Db =
     , materials : List Material
     , products : List Product
     , transports : Distances
+    , wellKnown : Process.WellKnown
     }
 
 
@@ -41,5 +42,18 @@ decode =
                                 (Decode.field "materials" (Material.decodeList processes))
                                 (Decode.field "products" (Product.decodeList processes))
                                 (Decode.field "transports" Transport.decodeDistances)
+                                |> Decode.andThen
+                                    (\partiallyLoaded ->
+                                        let
+                                            result =
+                                                Process.loadWellKnown processes
+                                        in
+                                        case result of
+                                            Ok wellKnown ->
+                                                Decode.succeed (partiallyLoaded wellKnown)
+
+                                            Err err ->
+                                                Decode.fail err
+                                    )
                         )
             )

--- a/src/Data/Textile/Db.elm
+++ b/src/Data/Textile/Db.elm
@@ -1,7 +1,6 @@
 module Data.Textile.Db exposing
     ( Db
     , buildFromJson
-    , empty
     )
 
 import Data.Country as Country exposing (Country)
@@ -20,17 +19,6 @@ type alias Db =
     , materials : List Material
     , products : List Product
     , transports : Distances
-    }
-
-
-empty : Db
-empty =
-    { impacts = []
-    , processes = []
-    , countries = []
-    , materials = []
-    , products = []
-    , transports = Transport.emptyDistances
     }
 
 

--- a/src/Data/Textile/LifeCycle.elm
+++ b/src/Data/Textile/LifeCycle.elm
@@ -23,14 +23,13 @@ import Data.Transport as Transport exposing (Transport)
 import Json.Encode as Encode
 import List.Extra as LE
 import Quantity
-import Result.Extra as RE
 
 
 type alias LifeCycle =
     Array Step
 
 
-computeStepsTransport : Db -> LifeCycle -> Result String LifeCycle
+computeStepsTransport : Db -> LifeCycle -> LifeCycle
 computeStepsTransport db lifeCycle =
     lifeCycle
         |> Array.map
@@ -44,11 +43,8 @@ computeStepsTransport db lifeCycle =
                             )
 
                 else
-                    Ok step
+                    step
             )
-        |> Array.toList
-        |> RE.combine
-        |> Result.map Array.fromList
 
 
 computeTotalTransportImpacts : Db -> LifeCycle -> Transport

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -5,8 +5,8 @@ import Browser.Navigation as Nav
 import Data.Food.Builder.Db as BuilderDb
 import Data.Food.Builder.Query as FoodQuery
 import Data.Food.Explorer.Db as ExplorerDb
-import Data.Session as Session exposing (Session)
-import Data.Textile.Db as Db exposing (Db)
+import Data.Session as Session exposing (Session, UnloadedSession)
+import Data.Textile.Db exposing (Db)
 import Data.Textile.Inputs as TextileInputs
 import Html
 import Page.Api as Api
@@ -49,9 +49,14 @@ type Page
     | TextileSimulatorPage TextileSimulator.Model
 
 
+type State
+    = Loading UnloadedSession
+    | Loaded Page Session
+    | LoadingFailed UnloadedSession
+
+
 type alias Model =
-    { page : Page
-    , session : Session
+    { state : State
     , mobileNavigationOpened : Bool
     }
 
@@ -83,12 +88,11 @@ type Msg
 init : Flags -> Url -> Nav.Key -> ( Model, Cmd Msg )
 init flags url navKey =
     let
-        session =
+        unloadedSession =
             { clientUrl = flags.clientUrl
             , navKey = navKey
             , store = Session.deserializeStore flags.rawStore
             , currentVersion = Request.Version.Unknown
-            , db = Db.empty
             , builderDb = BuilderDb.empty
             , explorerDb = ExplorerDb.empty
             , notifications = []
@@ -98,325 +102,349 @@ init flags url navKey =
                 }
             }
     in
-    ( { page = BlankPage
+    ( { state = Loading unloadedSession
       , mobileNavigationOpened = False
-      , session = session
       }
     , Cmd.batch
         [ Ports.appStarted ()
-        , Request.Textile.Db.loadDb session (TextileDbReceived url)
+        , Request.Textile.Db.loadDb (TextileDbReceived url)
         , Request.Version.loadVersion VersionReceived
         ]
     )
 
 
 setRoute : Maybe Route -> ( Model, Cmd Msg ) -> ( Model, Cmd Msg )
-setRoute maybeRoute ( { session } as model, cmds ) =
-    let
-        -- TODO: factor this with `update` internal `toPage`
-        toPage page subMsg ( subModel, newSession, subCmds ) =
+setRoute maybeRoute ( { state } as model, cmds ) =
+    case state of
+        Loaded _ session ->
             let
-                storeCmd =
-                    if model.session.store /= newSession.store then
-                        newSession.store |> Session.serializeStore |> Ports.saveStore
+                -- TODO: factor this with `update` internal `toPage`
+                toPage page subMsg ( subModel, newSession, subCmds ) =
+                    let
+                        storeCmd =
+                            if session.store /= newSession.store then
+                                newSession.store |> Session.serializeStore |> Ports.saveStore
 
-                    else
-                        Cmd.none
+                            else
+                                Cmd.none
+                    in
+                    ( { model | state = Loaded (page subModel) newSession }
+                    , Cmd.batch
+                        [ cmds
+                        , Cmd.map subMsg subCmds
+                        , storeCmd
+                        ]
+                    )
             in
-            ( { model | session = newSession, page = page subModel }
-            , Cmd.batch
-                [ cmds
-                , Cmd.map subMsg subCmds
-                , storeCmd
-                ]
-            )
-    in
-    case maybeRoute of
-        Nothing ->
-            ( { model | page = NotFoundPage }, Cmd.none )
+            case maybeRoute of
+                Nothing ->
+                    ( { model | state = Loaded NotFoundPage session }, Cmd.none )
 
-        Just Route.Home ->
-            Home.init session
-                |> toPage HomePage HomeMsg
+                Just Route.Home ->
+                    Home.init session
+                        |> toPage HomePage HomeMsg
 
-        Just Route.Api ->
-            Api.init session
-                |> toPage ApiPage ApiMsg
+                Just Route.Api ->
+                    Api.init session
+                        |> toPage ApiPage ApiMsg
 
-        Just Route.Changelog ->
-            Changelog.init session
-                |> toPage ChangelogPage ChangelogMsg
+                Just Route.Changelog ->
+                    Changelog.init session
+                        |> toPage ChangelogPage ChangelogMsg
 
-        Just (Route.Editorial slug) ->
-            Editorial.init slug session
-                |> toPage EditorialPage EditorialMsg
+                Just (Route.Editorial slug) ->
+                    Editorial.init slug session
+                        |> toPage EditorialPage EditorialMsg
 
-        Just (Route.Explore scope dataset) ->
-            Explore.init scope dataset session
-                |> toPage ExplorePage ExploreMsg
+                Just (Route.Explore scope dataset) ->
+                    Explore.init scope dataset session
+                        |> toPage ExplorePage ExploreMsg
 
-        Just (Route.FoodBuilder trigram maybeQuery) ->
-            FoodBuilder.init session trigram maybeQuery
-                |> toPage FoodBuilderPage FoodBuilderMsg
+                Just (Route.FoodBuilder trigram maybeQuery) ->
+                    FoodBuilder.init session trigram maybeQuery
+                        |> toPage FoodBuilderPage FoodBuilderMsg
 
-        Just Route.FoodExplore ->
-            FoodExplore.init session
-                |> toPage FoodExplorePage FoodExploreMsg
+                Just Route.FoodExplore ->
+                    FoodExplore.init session
+                        |> toPage FoodExplorePage FoodExploreMsg
 
-        Just Route.Stats ->
-            Stats.init session
-                |> toPage StatsPage StatsMsg
+                Just Route.Stats ->
+                    Stats.init session
+                        |> toPage StatsPage StatsMsg
 
-        Just Route.TextileExamples ->
-            TextileExamples.init session
-                |> toPage TextileExamplesPage TextileExamplesMsg
+                Just Route.TextileExamples ->
+                    TextileExamples.init session
+                        |> toPage TextileExamplesPage TextileExamplesMsg
 
-        Just (Route.TextileSimulator trigram funit detailed maybeQuery) ->
-            TextileSimulator.init trigram funit detailed maybeQuery session
-                |> toPage TextileSimulatorPage TextileSimulatorMsg
+                Just (Route.TextileSimulator trigram funit detailed maybeQuery) ->
+                    TextileSimulator.init trigram funit detailed maybeQuery session
+                        |> toPage TextileSimulatorPage TextileSimulatorMsg
+
+        _ ->
+            ( model, cmds )
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )
-update msg ({ page, session } as model) =
-    let
-        -- TODO: factor this with `setRoute` internal `toPage`
-        toPage toModel toMsg ( newModel, newSession, newCmd ) =
-            let
-                storeCmd =
-                    if session.store /= newSession.store then
-                        newSession.store |> Session.serializeStore |> Ports.saveStore
-
-                    else
-                        Cmd.none
-            in
-            ( { model | session = newSession, page = toModel newModel }
-            , Cmd.map toMsg (Cmd.batch [ newCmd, storeCmd ])
-            )
-    in
-    case ( msg, page ) of
-        -- Pages
-        ( HomeMsg homeMsg, HomePage homeModel ) ->
-            Home.update session homeMsg homeModel
-                |> toPage HomePage HomeMsg
-
-        ( ApiMsg changelogMsg, ApiPage changelogModel ) ->
-            Api.update session changelogMsg changelogModel
-                |> toPage ApiPage ApiMsg
-
-        ( ChangelogMsg changelogMsg, ChangelogPage changelogModel ) ->
-            Changelog.update session changelogMsg changelogModel
-                |> toPage ChangelogPage ChangelogMsg
-
-        ( EditorialMsg editorialMsg, EditorialPage editorialModel ) ->
-            Editorial.update session editorialMsg editorialModel
-                |> toPage EditorialPage EditorialMsg
-
-        ( ExploreMsg examplesMsg, ExplorePage examplesModel ) ->
-            Explore.update session examplesMsg examplesModel
-                |> toPage ExplorePage ExploreMsg
-
-        -- Food
-        ( FoodBuilderMsg foodMsg, FoodBuilderPage foodModel ) ->
-            FoodBuilder.update session foodMsg foodModel
-                |> toPage FoodBuilderPage FoodBuilderMsg
-
-        ( FoodExploreMsg foodMsg, FoodExplorePage foodModel ) ->
-            FoodExplore.update session foodMsg foodModel
-                |> toPage FoodExplorePage FoodExploreMsg
-
-        -- Textile
-        ( TextileDbReceived url (RemoteData.Success db), _ ) ->
+update rawMsg ({ state } as model) =
+    case ( state, rawMsg ) of
+        ( Loading unloadedSession, TextileDbReceived url (RemoteData.Success db) ) ->
             -- Db successfully loaded, attach it to session and process to requested page.
             -- That way, the page will always access a fully loaded Db.
+            let
+                session =
+                    Session.fromUnloaded unloadedSession db
+            in
             setRoute (Route.fromUrl url)
-                ( { model | session = { session | db = db } }, Cmd.none )
+                ( { model | state = Loaded BlankPage session }, Cmd.none )
 
-        ( TextileDbReceived url (RemoteData.Failure httpError), _ ) ->
+        ( Loading unloadedSession, TextileDbReceived url (RemoteData.Failure httpError) ) ->
             setRoute (Route.fromUrl url)
-                ( { model | session = session |> Session.notifyHttpError httpError }
+                ( { model | state = LoadingFailed (unloadedSession |> Session.notifyHttpError httpError) }
                 , Cmd.none
                 )
 
-        ( TextileExamplesMsg examplesMsg, TextileExamplesPage examplesModel ) ->
-            TextileExamples.update session examplesMsg examplesModel
-                |> toPage TextileExamplesPage TextileExamplesMsg
-
-        ( TextileSimulatorMsg counterMsg, TextileSimulatorPage counterModel ) ->
-            TextileSimulator.update session counterMsg counterModel
-                |> toPage TextileSimulatorPage TextileSimulatorMsg
-
-        -- Stats
-        ( StatsMsg statsMsg, StatsPage statsModel ) ->
-            Stats.update session statsMsg statsModel
-                |> toPage StatsPage StatsMsg
-
-        -- Notifications
-        ( CloseNotification notification, _ ) ->
-            ( { model | session = session |> Session.closeNotification notification }, Cmd.none )
-
-        -- Store
-        ( StoreChanged json, _ ) ->
-            ( { model | session = { session | store = Session.deserializeStore json } }, Cmd.none )
-
-        -- Mobile navigation menu
-        ( CloseMobileNavigation, _ ) ->
-            ( { model | mobileNavigationOpened = False }, Cmd.none )
-
-        ( OpenMobileNavigation, _ ) ->
-            ( { model | mobileNavigationOpened = True }, Cmd.none )
-
-        -- Url
-        ( LoadUrl url, _ ) ->
-            ( model, Nav.load url )
-
-        ( ReloadPage, _ ) ->
-            ( model, Nav.reloadAndSkipCache )
-
-        ( UrlChanged url, _ ) ->
-            ( { model | mobileNavigationOpened = False }, Cmd.none )
-                |> setRoute (Route.fromUrl url)
-
-        ( UrlRequested (Browser.Internal url), _ ) ->
-            ( model, Nav.pushUrl session.navKey (Url.toString url) )
-
-        ( UrlRequested (Browser.External href), _ ) ->
-            ( model, Nav.load href )
-
-        -- Version check
-        ( VersionReceived webData, _ ) ->
-            ( { model | session = { session | currentVersion = Request.Version.updateVersion session.currentVersion webData } }, Cmd.none )
-
-        ( VersionPoll, _ ) ->
-            ( model, Request.Version.loadVersion VersionReceived )
-
-        -- Catch-all
-        ( _, NotFoundPage ) ->
-            ( { model | page = NotFoundPage }, Cmd.none )
-
-        _ ->
+        ( Loading _, _ ) ->
             ( model, Cmd.none )
+
+        ( LoadingFailed _, _ ) ->
+            ( model, Cmd.none )
+
+        ( Loaded page session, msg ) ->
+            let
+                -- TODO: factor this with `setRoute` internal `toPage`
+                toPage toModel toMsg ( newModel, newSession, newCmd ) =
+                    let
+                        storeCmd =
+                            if session.store /= newSession.store then
+                                newSession.store |> Session.serializeStore |> Ports.saveStore
+
+                            else
+                                Cmd.none
+                    in
+                    ( { model | state = Loaded (toModel newModel) newSession }
+                    , Cmd.map toMsg (Cmd.batch [ newCmd, storeCmd ])
+                    )
+            in
+            case ( msg, page ) of
+                -- Pages
+                ( HomeMsg homeMsg, HomePage homeModel ) ->
+                    Home.update session homeMsg homeModel
+                        |> toPage HomePage HomeMsg
+
+                ( ApiMsg changelogMsg, ApiPage changelogModel ) ->
+                    Api.update session changelogMsg changelogModel
+                        |> toPage ApiPage ApiMsg
+
+                ( ChangelogMsg changelogMsg, ChangelogPage changelogModel ) ->
+                    Changelog.update session changelogMsg changelogModel
+                        |> toPage ChangelogPage ChangelogMsg
+
+                ( EditorialMsg editorialMsg, EditorialPage editorialModel ) ->
+                    Editorial.update session editorialMsg editorialModel
+                        |> toPage EditorialPage EditorialMsg
+
+                ( ExploreMsg examplesMsg, ExplorePage examplesModel ) ->
+                    Explore.update session examplesMsg examplesModel
+                        |> toPage ExplorePage ExploreMsg
+
+                -- Food
+                ( FoodBuilderMsg foodMsg, FoodBuilderPage foodModel ) ->
+                    FoodBuilder.update session foodMsg foodModel
+                        |> toPage FoodBuilderPage FoodBuilderMsg
+
+                ( FoodExploreMsg foodMsg, FoodExplorePage foodModel ) ->
+                    FoodExplore.update session foodMsg foodModel
+                        |> toPage FoodExplorePage FoodExploreMsg
+
+                ( TextileExamplesMsg examplesMsg, TextileExamplesPage examplesModel ) ->
+                    TextileExamples.update session examplesMsg examplesModel
+                        |> toPage TextileExamplesPage TextileExamplesMsg
+
+                ( TextileSimulatorMsg counterMsg, TextileSimulatorPage counterModel ) ->
+                    TextileSimulator.update session counterMsg counterModel
+                        |> toPage TextileSimulatorPage TextileSimulatorMsg
+
+                -- Stats
+                ( StatsMsg statsMsg, StatsPage statsModel ) ->
+                    Stats.update session statsMsg statsModel
+                        |> toPage StatsPage StatsMsg
+
+                -- Notifications
+                ( CloseNotification notification, currentPage ) ->
+                    ( { model | state = Loaded currentPage (session |> Session.closeNotification notification) }, Cmd.none )
+
+                -- Store
+                ( StoreChanged json, currentPage ) ->
+                    ( { model | state = Loaded currentPage { session | store = Session.deserializeStore json } }, Cmd.none )
+
+                -- Mobile navigation menu
+                ( CloseMobileNavigation, _ ) ->
+                    ( { model | mobileNavigationOpened = False }, Cmd.none )
+
+                ( OpenMobileNavigation, _ ) ->
+                    ( { model | mobileNavigationOpened = True }, Cmd.none )
+
+                -- Url
+                ( LoadUrl url, _ ) ->
+                    ( model, Nav.load url )
+
+                ( ReloadPage, _ ) ->
+                    ( model, Nav.reloadAndSkipCache )
+
+                ( UrlChanged url, _ ) ->
+                    ( { model | mobileNavigationOpened = False }, Cmd.none )
+                        |> setRoute (Route.fromUrl url)
+
+                ( UrlRequested (Browser.Internal url), _ ) ->
+                    ( model, Nav.pushUrl session.navKey (Url.toString url) )
+
+                ( UrlRequested (Browser.External href), _ ) ->
+                    ( model, Nav.load href )
+
+                -- Version check
+                ( VersionReceived webData, currentPage ) ->
+                    ( { model | state = Loaded currentPage { session | currentVersion = Request.Version.updateVersion session.currentVersion webData } }, Cmd.none )
+
+                ( VersionPoll, _ ) ->
+                    ( model, Request.Version.loadVersion VersionReceived )
+
+                -- Catch-all
+                ( _, NotFoundPage ) ->
+                    ( { model | state = Loaded NotFoundPage session }, Cmd.none )
+
+                _ ->
+                    ( model, Cmd.none )
 
 
 subscriptions : Model -> Sub Msg
-subscriptions model =
+subscriptions { state } =
     Sub.batch
         [ Ports.storeChanged StoreChanged
         , Request.Version.pollVersion VersionPoll
-        , case model.page of
-            HomePage subModel ->
+        , case state of
+            Loaded (HomePage subModel) _ ->
                 Home.subscriptions subModel
                     |> Sub.map HomeMsg
 
-            ApiPage _ ->
-                Sub.none
-
-            ChangelogPage _ ->
-                Sub.none
-
-            EditorialPage _ ->
-                Sub.none
-
-            ExplorePage subModel ->
+            Loaded (ExplorePage subModel) _ ->
                 Explore.subscriptions subModel
                     |> Sub.map ExploreMsg
 
-            FoodBuilderPage subModel ->
+            Loaded (FoodBuilderPage subModel) _ ->
                 FoodBuilder.subscriptions subModel
                     |> Sub.map FoodBuilderMsg
 
-            FoodExplorePage _ ->
-                Sub.none
-
-            TextileExamplesPage _ ->
-                Sub.none
-
-            TextileSimulatorPage subModel ->
+            Loaded (TextileSimulatorPage subModel) _ ->
                 TextileSimulator.subscriptions subModel
                     |> Sub.map TextileSimulatorMsg
 
-            StatsPage _ ->
-                Sub.none
-
-            NotFoundPage ->
-                Sub.none
-
-            BlankPage ->
+            _ ->
                 Sub.none
         ]
 
 
 view : Model -> Document Msg
-view { page, mobileNavigationOpened, session } =
-    let
-        pageConfig =
-            Page.Config session
-                mobileNavigationOpened
-                CloseMobileNavigation
-                OpenMobileNavigation
-                LoadUrl
-                ReloadPage
-                CloseNotification
+view { state, mobileNavigationOpened } =
+    case state of
+        Loaded page session ->
+            let
+                pageConfig =
+                    Page.Config session
+                        mobileNavigationOpened
+                        CloseMobileNavigation
+                        OpenMobileNavigation
+                        LoadUrl
+                        ReloadPage
+                        CloseNotification
 
-        mapMsg msg ( title, content ) =
-            ( title, content |> List.map (Html.map msg) )
-    in
-    case page of
-        HomePage homeModel ->
-            Home.view session homeModel
-                |> mapMsg HomeMsg
-                |> Page.frame (pageConfig Page.Home)
+                mapMsg msg ( title, content ) =
+                    ( title, content |> List.map (Html.map msg) )
+            in
+            case page of
+                HomePage homeModel ->
+                    Home.view session homeModel
+                        |> mapMsg HomeMsg
+                        |> Page.frame (pageConfig Page.Home)
 
-        ApiPage examplesModel ->
-            Api.view session examplesModel
-                |> mapMsg ApiMsg
-                |> Page.frame (pageConfig Page.Api)
+                ApiPage examplesModel ->
+                    Api.view session examplesModel
+                        |> mapMsg ApiMsg
+                        |> Page.frame (pageConfig Page.Api)
 
-        ChangelogPage changelogModel ->
-            Changelog.view session changelogModel
-                |> mapMsg ChangelogMsg
-                |> Page.frame (pageConfig Page.Changelog)
+                ChangelogPage changelogModel ->
+                    Changelog.view session changelogModel
+                        |> mapMsg ChangelogMsg
+                        |> Page.frame (pageConfig Page.Changelog)
 
-        EditorialPage editorialModel ->
-            Editorial.view session editorialModel
-                |> mapMsg EditorialMsg
-                |> Page.frame (pageConfig (Page.Editorial editorialModel.slug))
+                EditorialPage editorialModel ->
+                    Editorial.view session editorialModel
+                        |> mapMsg EditorialMsg
+                        |> Page.frame (pageConfig (Page.Editorial editorialModel.slug))
 
-        ExplorePage examplesModel ->
-            Explore.view session examplesModel
-                |> mapMsg ExploreMsg
-                |> Page.frame (pageConfig Page.Explore)
+                ExplorePage examplesModel ->
+                    Explore.view session examplesModel
+                        |> mapMsg ExploreMsg
+                        |> Page.frame (pageConfig Page.Explore)
 
-        FoodBuilderPage foodModel ->
-            FoodBuilder.view session foodModel
-                |> mapMsg FoodBuilderMsg
-                |> Page.frame (pageConfig Page.FoodBuilder)
+                FoodBuilderPage foodModel ->
+                    FoodBuilder.view session foodModel
+                        |> mapMsg FoodBuilderMsg
+                        |> Page.frame (pageConfig Page.FoodBuilder)
 
-        FoodExplorePage foodModel ->
-            FoodExplore.view session foodModel
-                |> mapMsg FoodExploreMsg
-                |> Page.frame (pageConfig Page.FoodExplore)
+                FoodExplorePage foodModel ->
+                    FoodExplore.view session foodModel
+                        |> mapMsg FoodExploreMsg
+                        |> Page.frame (pageConfig Page.FoodExplore)
 
-        TextileExamplesPage examplesModel ->
-            TextileExamples.view session examplesModel
-                |> mapMsg TextileExamplesMsg
-                |> Page.frame (pageConfig Page.TextileExamples)
+                TextileExamplesPage examplesModel ->
+                    TextileExamples.view session examplesModel
+                        |> mapMsg TextileExamplesMsg
+                        |> Page.frame (pageConfig Page.TextileExamples)
 
-        TextileSimulatorPage simulatorModel ->
-            TextileSimulator.view session simulatorModel
-                |> mapMsg TextileSimulatorMsg
-                |> Page.frame (pageConfig Page.TextileSimulator)
+                TextileSimulatorPage simulatorModel ->
+                    TextileSimulator.view session simulatorModel
+                        |> mapMsg TextileSimulatorMsg
+                        |> Page.frame (pageConfig Page.TextileSimulator)
 
-        StatsPage statsModel ->
-            Stats.view session statsModel
-                |> mapMsg StatsMsg
-                |> Page.frame (pageConfig Page.Stats)
+                StatsPage statsModel ->
+                    Stats.view session statsModel
+                        |> mapMsg StatsMsg
+                        |> Page.frame (pageConfig Page.Stats)
 
-        NotFoundPage ->
-            ( "Page manquante", [ Page.notFound ] )
+                NotFoundPage ->
+                    ( "Page manquante", [ Page.notFound ] )
+                        |> Page.frame (pageConfig Page.Other)
+
+                BlankPage ->
+                    ( "Chargement…", [ Page.loading ] )
+                        |> Page.frame (pageConfig Page.Other)
+
+        Loading unloadedSession ->
+            let
+                pageConfig =
+                    Page.Config unloadedSession
+                        mobileNavigationOpened
+                        CloseMobileNavigation
+                        OpenMobileNavigation
+                        LoadUrl
+                        ReloadPage
+                        CloseNotification
+            in
+            ( "Chargement…", [ Page.loading ] )
                 |> Page.frame (pageConfig Page.Other)
 
-        BlankPage ->
-            ( "Chargement…", [ Page.loading ] )
+        LoadingFailed unloadedSession ->
+            let
+                pageConfig =
+                    Page.Config unloadedSession
+                        mobileNavigationOpened
+                        CloseMobileNavigation
+                        OpenMobileNavigation
+                        LoadUrl
+                        ReloadPage
+                        CloseNotification
+            in
+            ( "Erreur lors du chargement…", [ Page.notFound ] )
                 |> Page.frame (pageConfig Page.Other)
 
 

--- a/src/Request/Textile/Db.elm
+++ b/src/Request/Textile/Db.elm
@@ -2,7 +2,6 @@ module Request.Textile.Db exposing (loadDb)
 
 import Data.Country as Country exposing (Country)
 import Data.Impact as Impact
-import Data.Session exposing (Session)
 import Data.Textile.Db exposing (Db)
 import Data.Textile.Material as Material exposing (Material)
 import Data.Textile.Process as Process exposing (Process)
@@ -76,8 +75,8 @@ handleImpactsLoaded impactsData =
             Task.succeed RemoteData.Loading
 
 
-loadDb : Session -> (WebData Db -> msg) -> Cmd msg
-loadDb _ event =
+loadDb : (WebData Db -> msg) -> Cmd msg
+loadDb event =
     getJson Impact.decodeList "impacts.json"
         |> Task.andThen handleImpactsLoaded
         |> Task.attempt

--- a/src/Request/Textile/Db.elm
+++ b/src/Request/Textile/Db.elm
@@ -7,6 +7,7 @@ import Data.Textile.Material as Material exposing (Material)
 import Data.Textile.Process as Process exposing (Process)
 import Data.Textile.Product as Product exposing (Product)
 import Data.Transport as Transport exposing (Distances)
+import Http
 import RemoteData exposing (WebData)
 import Request.Common exposing (getJson)
 import Task exposing (Task)
@@ -26,6 +27,13 @@ buildFromWebData impacts processes countries materials products transports =
         |> RemoteData.andMap materials
         |> RemoteData.andMap products
         |> RemoteData.andMap transports
+        |> RemoteData.andThen
+            (\partiallyLoaded ->
+                Process.loadWellKnown processes
+                    |> Result.map partiallyLoaded
+                    |> RemoteData.fromResult
+                    |> RemoteData.mapError Http.BadBody
+            )
 
 
 loadDependentData : List Impact.Definition -> List Process -> Task () (WebData Db)

--- a/src/Views/Page.elm
+++ b/src/Views/Page.elm
@@ -11,13 +11,13 @@ import Data.Dataset as Dataset
 import Data.Env as Env
 import Data.Impact as Impact
 import Data.Scope as Scope
-import Data.Session as Session exposing (Session)
+import Data.Session as Session
 import Data.Unit as Unit
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (..)
 import Page.Textile.Simulator.ViewMode as ViewMode
-import Request.Version as Version
+import Request.Version as Version exposing (Version)
 import Route
 import Views.Alert as Alert
 import Views.Container as Container
@@ -46,8 +46,8 @@ type MenuLink
     | MailTo String String
 
 
-type alias Config msg =
-    { session : Session
+type alias Config msg a =
+    { session : { a | clientUrl : String, notifications : List Session.Notification, currentVersion : Version }
     , mobileNavigationOpened : Bool
     , closeMobileNavigation : msg
     , openMobileNavigation : msg
@@ -58,7 +58,7 @@ type alias Config msg =
     }
 
 
-frame : Config msg -> ( String, List (Html msg) ) -> Document msg
+frame : Config msg a -> ( String, List (Html msg) ) -> Document msg
 frame ({ activePage } as config) ( title, content ) =
     { title = title ++ " | Ecobalyse"
     , body =
@@ -93,7 +93,7 @@ frame ({ activePage } as config) ( title, content ) =
     }
 
 
-stagingAlert : Config msg -> Html msg
+stagingAlert : Config msg a -> Html msg
 stagingAlert { session, loadUrl } =
     if
         String.contains "ecobalyse-pr" session.clientUrl
@@ -113,7 +113,7 @@ stagingAlert { session, loadUrl } =
         text ""
 
 
-newVersionAlert : Config msg -> Html msg
+newVersionAlert : Config msg a -> Html msg
 newVersionAlert { session, reloadPage } =
     case session.currentVersion of
         Version.NewerVersion ->
@@ -178,7 +178,7 @@ legalMenuLinks =
     ]
 
 
-pageFooter : Session -> Html msg
+pageFooter : { a | currentVersion : Version } -> Html msg
 pageFooter { currentVersion } =
     let
         makeLink link =
@@ -261,7 +261,7 @@ pageFooter { currentVersion } =
         ]
 
 
-pageHeader : Config msg -> Html msg
+pageHeader : Config msg a -> Html msg
 pageHeader config =
     header [ class "Header shadow-sm", attribute "role" "banner" ]
         [ div [ class "MobileMenuButton" ]
@@ -325,7 +325,7 @@ viewNavigationLink activePage link =
             a [ class "nav-link", href <| "mailto:" ++ email ] [ text label ]
 
 
-notificationListView : Config msg -> Html msg
+notificationListView : Config msg a -> Html msg
 notificationListView ({ session } as config) =
     case session.notifications of
         [] ->
@@ -337,7 +337,7 @@ notificationListView ({ session } as config) =
                 |> Container.centered [ class "bg-white pt-3" ]
 
 
-notificationView : Config msg -> Session.Notification -> Html msg
+notificationView : Config msg a -> Session.Notification -> Html msg
 notificationView { closeNotification } notification =
     -- TODO:
     -- - absolute positionning
@@ -370,7 +370,7 @@ loading =
         ]
 
 
-mobileNavigation : Config msg -> Html msg
+mobileNavigation : Config msg a -> Html msg
 mobileNavigation { activePage, closeMobileNavigation } =
     div []
         [ div

--- a/src/Views/Textile/Step.elm
+++ b/src/Views/Textile/Step.elm
@@ -16,7 +16,6 @@ import Data.Textile.Inputs as Inputs exposing (Inputs)
 import Data.Textile.Knitting as Knitting exposing (Knitting)
 import Data.Textile.MakingComplexity as MakingComplexity exposing (MakingComplexity)
 import Data.Textile.Printing as Printing exposing (Printing)
-import Data.Textile.Process as Process
 import Data.Textile.Product as Product exposing (Product)
 import Data.Textile.Step as Step exposing (Step)
 import Data.Textile.Step.Label as Label exposing (Label)
@@ -411,14 +410,9 @@ makingWasteField : Config msg -> Html msg
 makingWasteField { current, db, inputs, updateMakingWaste } =
     let
         processName =
-            db.processes
-                |> Process.loadWellKnown
-                |> Result.map
-                    (Product.getFabricProcess inputs.knittingProcess inputs.product
-                        >> .name
-                    )
-                |> Result.toMaybe
-                |> Maybe.withDefault "process not found"
+            db.wellKnown
+                |> Product.getFabricProcess inputs.knittingProcess inputs.product
+                |> .name
     in
     span
         [ title <| "Taux personnalisé de perte en confection, incluant notamment la découpe. Procédé utilisé : " ++ processName

--- a/tests/Data/Textile/LifeCycleTest.elm
+++ b/tests/Data/Textile/LifeCycleTest.elm
@@ -21,7 +21,7 @@ suite =
             [ describe "computeTransportSummary"
                 [ tShirtCotonFrance
                     |> LifeCycle.fromQuery textileDb
-                    |> Result.andThen (LifeCycle.computeStepsTransport textileDb)
+                    |> Result.map (LifeCycle.computeStepsTransport textileDb)
                     |> Result.map (LifeCycle.computeTotalTransportImpacts textileDb)
                     |> Result.map (\{ road, sea } -> ( Length.inKilometers road, Length.inKilometers sea ))
                     |> Expect.equal (Ok ( 3000, 21549 ))
@@ -32,7 +32,7 @@ suite =
                         , countryDyeing = Country.Code "IN" -- Ennoblement in India
                         , countryMaking = Country.Code "FR"
                     }
-                    |> Result.andThen (LifeCycle.computeStepsTransport textileDb)
+                    |> Result.map (LifeCycle.computeStepsTransport textileDb)
                     |> Result.map (LifeCycle.computeTotalTransportImpacts textileDb)
                     |> Result.map (\{ road, sea } -> ( Length.inKilometers road, Length.inKilometers sea ))
                     |> Expect.equal (Ok ( 2000, 45471 ))

--- a/tests/Data/Textile/ProductTest.elm
+++ b/tests/Data/Textile/ProductTest.elm
@@ -2,7 +2,6 @@ module Data.Textile.ProductTest exposing (..)
 
 import Data.Textile.Inputs as Inputs
 import Data.Textile.Knitting as Knitting
-import Data.Textile.Process as Process
 import Data.Textile.Product as Product
 import Data.Unit as Unit
 import Duration
@@ -56,33 +55,28 @@ suite =
                         sampleQuery
                             |> Inputs.fromQuery textileDb
                             |> Result.map .product
-
-                    wellKnownResult =
-                        Process.loadWellKnown textileDb.processes
                   in
                   describe "getFabricProcess"
-                    [ Result.map2
-                        (\product wellKnown ->
+                    [ Result.map
+                        (\product ->
                             let
                                 fabricProcess =
-                                    Product.getFabricProcess Nothing product wellKnown
+                                    Product.getFabricProcess Nothing product textileDb.wellKnown
                             in
                             Expect.equal product.fabric (Product.Knitted fabricProcess)
                         )
                         tshirtResult
-                        wellKnownResult
                         |> Result.withDefault (Expect.fail "test failed")
                         |> asTest "should return the default product fabric process when no knitting process is specified"
-                    , Result.map2
-                        (\product wellKnown ->
+                    , Result.map
+                        (\product ->
                             let
                                 fabricProcess =
-                                    Product.getFabricProcess (Just Knitting.Seamless) product wellKnown
+                                    Product.getFabricProcess (Just Knitting.Seamless) product textileDb.wellKnown
                             in
-                            Expect.equal wellKnown.knittingSeamless fabricProcess
+                            Expect.equal textileDb.wellKnown.knittingSeamless fabricProcess
                         )
                         tshirtResult
-                        wellKnownResult
                         |> Result.withDefault (Expect.fail "test failed")
                         |> asTest "should return the selected knitting process over the default product fabric process"
                     ]


### PR DESCRIPTION
- a small rename to make sure we don't update an `Impact.Impacts` dict without later updating the aggregated scores
- load the well known processes at DB load (app load), instead of having to deal with results later on throughout the code