### PR TITLE
Store the food builder db in the session as a WebData (no more Db.empty)

### DIFF
--- a/src/Data/Bookmark.elm
+++ b/src/Data/Bookmark.elm
@@ -23,6 +23,7 @@ import Data.Textile.Db as TextileDb
 import Data.Textile.Inputs as TextileQuery
 import Json.Decode as Decode exposing (Decoder)
 import Json.Encode as Encode
+import RemoteData exposing (WebData)
 import Time exposing (Posix)
 
 
@@ -154,14 +155,19 @@ toFoodQueries =
         )
 
 
-toQueryDescription : { foodDb : BuilderDb.Db, textileDb : TextileDb.Db } -> Bookmark -> String
+toQueryDescription : { foodDb : WebData BuilderDb.Db, textileDb : TextileDb.Db } -> Bookmark -> String
 toQueryDescription { foodDb, textileDb } bookmark =
     case bookmark.query of
         Food foodQuery ->
-            foodQuery
-                |> Recipe.fromQuery foodDb
-                |> Result.map Recipe.toString
-                |> Result.withDefault bookmark.name
+            foodDb
+                |> RemoteData.map
+                    (\db ->
+                        foodQuery
+                            |> Recipe.fromQuery db
+                            |> Result.map Recipe.toString
+                            |> Result.withDefault bookmark.name
+                    )
+                |> RemoteData.withDefault bookmark.name
 
         Textile textileQuery ->
             textileQuery

--- a/src/Data/Food/Builder/Db.elm
+++ b/src/Data/Food/Builder/Db.elm
@@ -1,8 +1,6 @@
 module Data.Food.Builder.Db exposing
     ( Db
     , buildFromJson
-    , empty
-    , isEmpty
     )
 
 import Data.Country exposing (Country)
@@ -27,21 +25,6 @@ type alias Db =
     -- Ingredients are imported from public/data/food/ingredients.json
     , ingredients : List Ingredient
     }
-
-
-empty : Db
-empty =
-    { countries = []
-    , impacts = []
-    , transports = Transport.emptyDistances
-    , processes = []
-    , ingredients = []
-    }
-
-
-isEmpty : Db -> Bool
-isEmpty db =
-    db == empty
 
 
 buildFromJson : TextileDb.Db -> String -> String -> Result String Db

--- a/src/Data/Food/Builder/Recipe.elm
+++ b/src/Data/Food/Builder/Recipe.elm
@@ -170,10 +170,9 @@ compute db =
                                         volume =
                                             getTransformedIngredientsVolume recipe
                                     in
-                                    Result.map (Retail.computeImpacts db volume distrib)
-                                        (Process.loadWellKnown db.processes)
+                                    Retail.computeImpacts db volume distrib db.wellKnown
                                 )
-                            |> Maybe.withDefault (Ok Impact.noImpacts)
+                            |> Maybe.withDefault Impact.noImpacts
 
                     distributionTransportNeedsCooling =
                         ingredients
@@ -192,9 +191,7 @@ compute db =
                                         )
                                     |> Maybe.withDefault (Transport.default Impact.noImpacts)
                         in
-                        db.processes
-                            |> Process.loadWellKnown
-                            |> Result.map (Transport.computeImpacts db.impacts mass transport)
+                        Transport.computeImpacts db.impacts mass transport db.wellKnown
 
                     recipeImpacts =
                         Impact.sumImpacts db.impacts
@@ -213,8 +210,8 @@ compute db =
 
                     preparationImpacts =
                         preparation
-                            |> RE.combineMap (Preparation.apply db transformedIngredientsMass)
-                            |> Result.map (Impact.sumImpacts db.impacts >> List.singleton >> Impact.sumImpacts db.impacts)
+                            |> List.map (Preparation.apply db transformedIngredientsMass)
+                            |> (Impact.sumImpacts db.impacts >> List.singleton >> Impact.sumImpacts db.impacts)
 
                     preparedMass =
                         getPreparedMassAtConsumer recipe
@@ -235,66 +232,55 @@ compute db =
                         }
 
                     totalImpacts =
-                        [ Ok recipeImpacts
-                        , Ok packagingImpacts
+                        [ recipeImpacts
+                        , packagingImpacts
                         , distributionImpacts
-                        , distributionTransport |> Result.map .impacts
+                        , distributionTransport.impacts
                         , preparationImpacts
                         ]
-                            |> RE.combine
-                            |> Result.map (Impact.sumImpacts db.impacts)
-                            |> Result.map addIngredientsBonuses
+                            |> Impact.sumImpacts db.impacts
+                            |> addIngredientsBonuses
 
                     impactsPerKg =
                         -- Note: Product impacts per kg is computed against prepared
                         --       product mass at consumer, excluding packaging
                         totalImpacts
-                            |> Result.map (Impact.perKg preparedMass)
+                            |> Impact.perKg preparedMass
 
                     scoring =
                         impactsPerKg
-                            |> Result.map (computeScoring db.impacts)
+                            |> computeScoring db.impacts
                 in
-                Ok
-                    (\total perKg distrib distribTransport preparationImpacts_ score ->
-                        ( recipe
-                        , { total = total
-                          , perKg = perKg
-                          , scoring = score
-                          , totalMass = getMassAtPackaging recipe
-                          , preparedMass = preparedMass
-                          , recipe =
-                                { total = addIngredientsBonuses recipeImpacts
-                                , ingredientsTotal = addIngredientsBonuses ingredientsTotalImpacts
-                                , ingredients = ingredientsImpacts
-                                , totalBonusesImpact = totalBonusesImpact
-                                , totalBonusesImpactPerKg = totalBonusesImpactPerKg
-                                , transform = transformImpacts
-                                , transports = ingredientsTransport
-                                , transformedMass = transformedIngredientsMass
-                                }
-                          , packaging = packagingImpacts
-                          , distribution =
-                                { total = distrib
-                                , transports = distribTransport
-                                }
-                          , preparation = preparationImpacts_
-                          , transports =
-                                Transport.sum db.impacts
-                                    [ ingredientsTransport
-                                    , distribTransport
-                                    ]
-                          }
-                        )
-                    )
-                    |> RE.andMap totalImpacts
-                    |> RE.andMap impactsPerKg
-                    |> RE.andMap distributionImpacts
-                    |> RE.andMap distributionTransport
-                    |> RE.andMap preparationImpacts
-                    |> RE.andMap scoring
+                ( recipe
+                , { total = totalImpacts
+                  , perKg = impactsPerKg
+                  , scoring = scoring
+                  , totalMass = getMassAtPackaging recipe
+                  , preparedMass = preparedMass
+                  , recipe =
+                        { total = addIngredientsBonuses recipeImpacts
+                        , ingredientsTotal = addIngredientsBonuses ingredientsTotalImpacts
+                        , ingredients = ingredientsImpacts
+                        , totalBonusesImpact = totalBonusesImpact
+                        , totalBonusesImpactPerKg = totalBonusesImpactPerKg
+                        , transform = transformImpacts
+                        , transports = ingredientsTransport
+                        , transformedMass = transformedIngredientsMass
+                        }
+                  , packaging = packagingImpacts
+                  , distribution =
+                        { total = distributionImpacts
+                        , transports = distributionTransport
+                        }
+                  , preparation = preparationImpacts
+                  , transports =
+                        Transport.sum db.impacts
+                            [ ingredientsTransport
+                            , distributionTransport
+                            ]
+                  }
+                )
             )
-        >> RE.join
 
 
 computeIngredientBonusesImpacts : List Impact.Definition -> Ingredient.Bonuses -> Impacts -> Impact.BonusImpacts
@@ -455,10 +441,7 @@ computeIngredientTransport db { ingredient, country, mass, planeTransport } =
                 |> toTransformation
                 |> toLogistics
     in
-    db.processes
-        |> Process.loadWellKnown
-        |> Result.map (Transport.computeImpacts db.impacts mass transport)
-        |> Result.withDefault (Transport.default Impact.noImpacts)
+    Transport.computeImpacts db.impacts mass transport db.wellKnown
 
 
 preparationListFromQuery : Query -> Result String (List Preparation)

--- a/src/Data/Food/Builder/Recipe.elm
+++ b/src/Data/Food/Builder/Recipe.elm
@@ -191,7 +191,7 @@ compute db =
                                         )
                                     |> Maybe.withDefault (Transport.default Impact.noImpacts)
                         in
-                        Transport.computeImpacts db.impacts mass transport db.wellKnown
+                        Transport.computeImpacts db mass transport
 
                     recipeImpacts =
                         Impact.sumImpacts db.impacts
@@ -441,7 +441,7 @@ computeIngredientTransport db { ingredient, country, mass, planeTransport } =
                 |> toTransformation
                 |> toLogistics
     in
-    Transport.computeImpacts db.impacts mass transport db.wellKnown
+    Transport.computeImpacts db mass transport
 
 
 preparationListFromQuery : Query -> Result String (List Preparation)

--- a/src/Data/Session.elm
+++ b/src/Data/Session.elm
@@ -28,6 +28,7 @@ import Http
 import Json.Decode as Decode exposing (Decoder)
 import Json.Decode.Pipeline as JDP
 import Json.Encode as Encode
+import RemoteData exposing (WebData)
 import Request.Version exposing (Version)
 import Set exposing (Set)
 
@@ -38,7 +39,7 @@ type alias Session =
     , store : Store
     , currentVersion : Version
     , db : Db
-    , builderDb : BuilderDb.Db
+    , builderDb : WebData BuilderDb.Db
     , explorerDb : ExplorerDb.Db
     , notifications : List Notification
     , queries :
@@ -53,7 +54,7 @@ type alias UnloadedSession =
     , clientUrl : String
     , store : Store
     , currentVersion : Version
-    , builderDb : BuilderDb.Db
+    , builderDb : WebData BuilderDb.Db
     , explorerDb : ExplorerDb.Db
     , notifications : List Notification
     , queries :

--- a/src/Data/Transport.elm
+++ b/src/Data/Transport.elm
@@ -93,10 +93,10 @@ addRoadWithCooling distance withCooling transport =
         { transport | road = transport.road |> Quantity.plus distance }
 
 
-computeImpacts : List Impact.Definition -> Mass -> Transport -> Process.WellKnown -> Transport
-computeImpacts impactsDefinition mass transport wellKnown =
+computeImpacts : { a | impacts : List Impact.Definition, wellKnown : Process.WellKnown } -> Mass -> Transport -> Transport
+computeImpacts { impacts, wellKnown } mass transport =
     let
-        impacts =
+        transportImpacts =
             [ ( wellKnown.lorryTransport, transport.road )
             , ( wellKnown.lorryCoolingTransport, transport.roadCooled )
             , ( wellKnown.boatTransport, transport.sea )
@@ -114,9 +114,9 @@ computeImpacts impactsDefinition mass transport wellKnown =
                                         |> Unit.impact
                                 )
                     )
-                |> Impact.sumImpacts impactsDefinition
+                |> Impact.sumImpacts impacts
     in
-    { transport | impacts = impacts }
+    { transport | impacts = transportImpacts }
 
 
 sum : List Impact.Definition -> List Transport -> Transport

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -163,8 +163,18 @@ setRoute url ( { state } as model, cmds ) =
                         |> toPage EditorialPage EditorialMsg
 
                 Just (Route.Explore scope dataset) ->
-                    Explore.init scope dataset session
-                        |> toPage ExplorePage ExploreMsg
+                    case session.builderDb of
+                        RemoteData.Success builderDb ->
+                            Explore.init builderDb scope dataset session
+                                |> toPage ExplorePage ExploreMsg
+
+                        RemoteData.NotAsked ->
+                            ( model
+                            , Request.Food.BuilderDb.loadDb session (FoodBuilderDbReceived url)
+                            )
+
+                        _ ->
+                            ( model, cmds )
 
                 Just (Route.FoodBuilder trigram maybeQuery) ->
                     case session.builderDb of

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -2,7 +2,6 @@ module Main exposing (main)
 
 import Browser exposing (Document)
 import Browser.Navigation as Nav
-import Data.Food.Builder.Db as BuilderDb
 import Data.Food.Builder.Query as FoodQuery
 import Data.Food.Explorer.Db as ExplorerDb
 import Data.Session as Session exposing (Session, UnloadedSession)
@@ -93,7 +92,7 @@ init flags url navKey =
             , navKey = navKey
             , store = Session.deserializeStore flags.rawStore
             , currentVersion = Request.Version.Unknown
-            , builderDb = BuilderDb.empty
+            , builderDb = RemoteData.NotAsked
             , explorerDb = ExplorerDb.empty
             , notifications = []
             , queries =

--- a/src/Page/Food/Builder.elm
+++ b/src/Page/Food/Builder.elm
@@ -1225,9 +1225,7 @@ consumptionView db selectedImpact recipe results =
                             , span [ class "w-50 text-end" ]
                                 [ usedPreparation
                                     |> Preparation.apply db results.recipe.transformedMass
-                                    |> Result.map
-                                        (Format.formatFoodSelectedImpact selectedImpact)
-                                    |> Result.withDefault (text "N/A")
+                                    |> Format.formatFoodSelectedImpact selectedImpact
                                 ]
                             , deleteItemButton (DeletePreparation usedPreparation.id)
                             ]

--- a/src/Request/Food/BuilderDb.elm
+++ b/src/Request/Food/BuilderDb.elm
@@ -4,6 +4,7 @@ import Data.Food.Builder.Db exposing (Db)
 import Data.Food.Ingredient as Ingredient exposing (Ingredient)
 import Data.Food.Process as Process exposing (Process)
 import Data.Session exposing (Session)
+import Http
 import RemoteData exposing (WebData)
 import Request.Common exposing (getJson)
 import Task exposing (Task)
@@ -31,13 +32,10 @@ handleIngredientsLoaded session processes ingredientsData =
     case ingredientsData of
         RemoteData.Success ingredients ->
             Task.succeed
-                (RemoteData.succeed
-                    { countries = session.db.countries
-                    , impacts = session.db.impacts
-                    , transports = session.db.transports
-                    , processes = processes
-                    , ingredients = ingredients
-                    }
+                (Process.loadWellKnown processes
+                    |> Result.map (Db session.db.countries session.db.impacts session.db.transports processes ingredients)
+                    |> RemoteData.fromResult
+                    |> RemoteData.mapError Http.BadBody
                 )
 
         RemoteData.Failure error ->

--- a/src/Request/Food/BuilderDb.elm
+++ b/src/Request/Food/BuilderDb.elm
@@ -30,18 +30,13 @@ handleIngredientsLoaded : Session -> List Process -> WebData (List Ingredient) -
 handleIngredientsLoaded session processes ingredientsData =
     case ingredientsData of
         RemoteData.Success ingredients ->
-            let
-                builderDb =
-                    session.builderDb
-            in
             Task.succeed
                 (RemoteData.succeed
-                    { builderDb
-                        | countries = session.db.countries
-                        , impacts = session.db.impacts
-                        , transports = session.db.transports
-                        , ingredients = ingredients
-                        , processes = processes
+                    { countries = session.db.countries
+                    , impacts = session.db.impacts
+                    , transports = session.db.transports
+                    , processes = processes
+                    , ingredients = ingredients
                     }
                 )
 

--- a/tests/Data/Food/PreparationTest.elm
+++ b/tests/Data/Food/PreparationTest.elm
@@ -23,7 +23,8 @@ suite =
                   , applyRawToCookedRatio = False
                   }
                     |> Preparation.apply builderDb (Mass.kilograms 1)
-                    |> (Impact.getImpact (Impact.trg "cch") >> Unit.impactToFloat)
+                    |> Impact.getImpact (Impact.trg "cch")
+                    |> Unit.impactToFloat
                     |> Expect.within (Expect.Absolute 0.001) 0.08
                     |> asTest "compute impacts from applying a consumption preparation technique"
                 ]

--- a/tests/Data/Food/PreparationTest.elm
+++ b/tests/Data/Food/PreparationTest.elm
@@ -23,8 +23,7 @@ suite =
                   , applyRawToCookedRatio = False
                   }
                     |> Preparation.apply builderDb (Mass.kilograms 1)
-                    |> Result.map (Impact.getImpact (Impact.trg "cch") >> Unit.impactToFloat)
-                    |> Result.withDefault 0
+                    |> (Impact.getImpact (Impact.trg "cch") >> Unit.impactToFloat)
                     |> Expect.within (Expect.Absolute 0.001) 0.08
                     |> asTest "compute impacts from applying a consumption preparation technique"
                 ]


### PR DESCRIPTION
More refactoring: 

- [x] save the food wellknown processes in the db as soon as it's loaded (same as what we did for the textile: #296)
- ~~[ ] split Textile.Db.(impacts|countries|transports) into Common.Db to be reused by Textile and Food databases~~ this is not possible because the countries are actually "Textile countries" with textile processes for electricity and stuff... so we would also need to load the textile processes, which makes less sense... or split the "textile part" of the countries data in another db... we'll see that in another PR ;)
- [x] load the food builder db in main so we don't have to deal with WebData in the food builder and explorer pages