### PR TITLE
Fix hot module reloading by keeping the NavKey in the main model

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -59,6 +59,9 @@ type State
 type alias Model =
     { state : State
     , mobileNavigationOpened : Bool
+
+    -- Duplicate the nav key in the model so Parcel's hot module reloading finds it always in the same place.
+    , navKey : Nav.Key
     }
 
 
@@ -106,6 +109,7 @@ init flags url navKey =
     in
     ( { state = Loading unloadedSession
       , mobileNavigationOpened = False
+      , navKey = navKey
       }
     , Cmd.batch
         [ Ports.appStarted ()


### PR DESCRIPTION
Parcel's hot module reloading needs the NavKey to always be in the same place. With the new way to load the session (sometimes a partial session, without the db, sometimes a full session with the db loaded), the nav key "changes" place.

The easy and naive fix is to duplicate the NavKey in the model.