### PR TITLE
Disallow setting air transport from France at the Making step.

### DIFF
--- a/src/Data/Textile/Step.elm
+++ b/src/Data/Textile/Step.elm
@@ -1,5 +1,6 @@
 module Data.Textile.Step exposing
     ( Step
+    , airTransportDisabled
     , airTransportRatioToString
     , computeTransports
     , create
@@ -421,6 +422,13 @@ updateWaste waste mass step =
         , inputMass = mass
         , outputMass = Quantity.difference mass waste
     }
+
+
+airTransportDisabled : Step -> Bool
+airTransportDisabled { enabled, label, country } =
+    not enabled
+        || -- Note: disallow air transport from France to France at the Making step
+           (label == Label.Making && country.code == Country.codeFromString "FR")
 
 
 airTransportRatioToString : Split -> String

--- a/src/Views/Textile/Step.elm
+++ b/src/Views/Textile/Step.elm
@@ -152,10 +152,7 @@ airTransportRatioField { current, updateAirTransportRatio } =
             , update = updateAirTransportRatio
             , value = current.airTransportRatio
             , toString = Step.airTransportRatioToString
-            , disabled =
-                not current.enabled
-                    || -- Note: disallow air transport from France to France at the Making step
-                       (current.label == Label.Making && current.country.code == Country.codeFromString "FR")
+            , disabled = Step.airTransportDisabled current
             , min = 0
             , max = 100
             }

--- a/src/Views/Textile/Step.elm
+++ b/src/Views/Textile/Step.elm
@@ -152,7 +152,10 @@ airTransportRatioField { current, updateAirTransportRatio } =
             , update = updateAirTransportRatio
             , value = current.airTransportRatio
             , toString = Step.airTransportRatioToString
-            , disabled = not current.enabled
+            , disabled =
+                not current.enabled
+                    || -- Note: disallow air transport from France to France at the Making step
+                       (current.label == Label.Making && current.country.code == Country.codeFromString "FR")
             , min = 0
             , max = 100
             }


### PR DESCRIPTION
[Bug report](https://www.notion.so/Distance-transport-1f160ec79d084fb98eaa92453411e51b)

This patch disables the air transport ratio rangeslider when the Making step takes place in France (and is then shipped to France by default). There's no real world situations where clothes are transported by plane from France to France. 