### PR TITLE
Fix bogus github changelog decoding with ingredient editor.

### DIFF
--- a/src/Data/Github.elm
+++ b/src/Data/Github.elm
@@ -2,6 +2,7 @@ module Data.Github exposing (Commit, decodeCommit)
 
 import Iso8601
 import Json.Decode as Decode exposing (Decoder)
+import Json.Decode.Pipeline as Pipe
 import Time exposing (Posix)
 
 
@@ -11,16 +12,16 @@ type alias Commit =
     , date : Posix
     , authorName : String
     , authorLogin : String
-    , authorAvatar : String
+    , authorAvatar : Maybe String
     }
 
 
 decodeCommit : Decoder Commit
 decodeCommit =
-    Decode.map6 Commit
-        (Decode.at [ "sha" ] Decode.string)
-        (Decode.at [ "commit", "message" ] Decode.string)
-        (Decode.at [ "commit", "author", "date" ] Iso8601.decoder)
-        (Decode.at [ "commit", "author", "name" ] Decode.string)
-        (Decode.at [ "author", "login" ] Decode.string)
-        (Decode.at [ "author", "avatar_url" ] Decode.string)
+    Decode.succeed Commit
+        |> Pipe.requiredAt [ "sha" ] Decode.string
+        |> Pipe.requiredAt [ "commit", "message" ] Decode.string
+        |> Pipe.requiredAt [ "commit", "author", "date" ] Iso8601.decoder
+        |> Pipe.requiredAt [ "commit", "author", "name" ] Decode.string
+        |> Pipe.optionalAt [ "author", "login" ] Decode.string "Ecobalyse"
+        |> Pipe.optionalAt [ "author", "avatar_url" ] (Decode.maybe Decode.string) Nothing

--- a/src/Page/Changelog.elm
+++ b/src/Page/Changelog.elm
@@ -94,14 +94,19 @@ commitView time commit =
                 text title
             ]
         , td [ class "text-nowrap" ]
-            [ img
-                [ src commit.authorAvatar
-                , alt commit.authorName
-                , attribute "crossorigin" "anonymous"
-                , width 24
-                , class "rounded-circle shadow-sm align-top me-2"
-                ]
-                []
+            [ case commit.authorAvatar of
+                Just authorAvatar ->
+                    img
+                        [ src authorAvatar
+                        , alt commit.authorName
+                        , attribute "crossorigin" "anonymous"
+                        , class "rounded-circle shadow-sm align-top me-2"
+                        , style "width" "24px"
+                        ]
+                        []
+
+                Nothing ->
+                    text ""
             , text commit.authorName
             ]
         , td []


### PR DESCRIPTION
The changelog page is broken because some of the github API response author object fields are missing (ingredient editor commit data, cc @ccomb). Note that it would be nice if the ingredient editor could have an associated avatar image, but I'm not sure what would be required for that (we don't want to create a github account for that). Gravatar maybe? Anyway that's unrelated to this patch.

![image](https://github.com/MTES-MCT/ecobalyse/assets/41547/bf9ddb76-84d3-44bb-8aa3-83a02e64fb4f)
