### PR TITLE
Faster make commands

### DIFF
--- a/data/docker/Dockerfile
+++ b/data/docker/Dockerfile
@@ -21,6 +21,7 @@ ADD https://api.github.com/repos/brightway-lca/brightway2-parameters/git/refs/ta
 ADD https://api.github.com/repos/brightway-lca/brightway2-data/git/refs/tags/4.0.dev29 bw2-data.json
 ADD https://api.github.com/repos/brightway-lca/brightway2-calc/git/refs/tags/2.0.DEV14 bw2-calc.json
 ADD https://api.github.com/repos/brightway-lca/brightway2-analyzer/git/refs/tags/0.11.7 bw2-analyzer.json
+ADD https://api.github.com/repos/brightway-lca/bw_projects/git/refs/tags/v2.1.0 bw_projects.json
 
 COPY requirements.txt .
 

--- a/data/docker/requirements.txt
+++ b/data/docker/requirements.txt
@@ -1,20 +1,21 @@
 # don't forget to keep sync the api link in Dockerfile
+#jupyter_contrib_nbextensions @ git+https://github.com/ipython-contrib/jupyter_contrib_nbextensions
+#jupyter_nbextensions_configurator @ git+https://github.com/Jupyter-contrib/jupyter_nbextensions_configurator
 IPython>=8.16, <9
+fastapi
 fjson>=0.1, <0.2
 flatdict>=4.0, <4.1
-git+https://github.com/ccomb/brightway2-io@main
-git+https://github.com/brightway-lca/brightway2-parameters@1.1.0
-git+https://github.com/brightway-lca/brightway2-data@4.0.dev29
-git+https://github.com/brightway-lca/brightway2-calc@2.0.DEV14
 git+https://github.com/brightway-lca/brightway2-analyzer@0.11.7
+git+https://github.com/brightway-lca/brightway2-calc@2.0.DEV14
+git+https://github.com/brightway-lca/brightway2-data@4.0.dev29
+git+https://github.com/brightway-lca/brightway2-parameters@1.1.0
+git+https://github.com/brightway-lca/bw_projects@v2.1.0
+git+https://github.com/ccomb/brightway2-io@main
 ipywidgets>=8.1, <8.2
 matplotlib>=3.7, <3.8
-#jupyter_nbextensions_configurator @ git+https://github.com/Jupyter-contrib/jupyter_nbextensions_configurator
-#jupyter_contrib_nbextensions @ git+https://github.com/ipython-contrib/jupyter_contrib_nbextensions
 numpy>=1.25, <1.26
 olca-ipc==0.0.12
 pandas>=2.0, <2.1
 scipy>=1.11, <1.12
-xlrd>=2.0, <2.1
-fastapi
 uvicorn
+xlrd>=2.0, <2.1

--- a/data/setup.py
+++ b/data/setup.py
@@ -4,5 +4,4 @@ setup(
     name="ecobalyse_data",
     version="1.0",
     packages=["food", "common", "textile"],
-    install_requires=["bw_projects"],
 )


### PR DESCRIPTION
The docker entrypoint was installing bw_projects, thus requiring network and slowing down startup.
Installation of bw_projects has been moved to the Dockerfile for faster make commands and no network dependency.