### PR TITLE
Handle the Matomo site id as an env var.

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,2 +1,3 @@
+MATOMO_SITE_ID=xxx
 MATOMO_TOKEN=xxx
 SENTRY_DSN=https://xxx@xxx.ingest.sentry.io/xxx

--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ Chaque _Pull Request_ effectuée sur le dépôt est également automatiquement d
 Certaines variables d'environnement doivent être configurées via l'interface de [configuration Scalingo](https://dashboard.scalingo.com/apps/osc-fr1/ecobalyse/environment) :
 
 - `SENTRY_DSN`: le DSN [Sentry](https://sentry.io) à utiliser pour les rapports d'erreur.
-- `MATOMO_TOKEN`: le token [Matomo](https://stats.beta.gouv.fr/) permettant le suivi d'audience de l'API.
+- `MATOMO_SITE_ID`: l'identifiant du site Ecobalyse sur l'instance [Matomo](https://stats.beta.gouv.fr/) permettant le suivi d'audience du produit.
+- `MATOMO_TOKEN`: le token [Matomo](https://stats.beta.gouv.fr/) permettant le suivi d'audience du produit.
 
 ## Lancement du serveur
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 import { Elm } from "./src/Main.elm";
 import * as Sentry from "@sentry/browser";
-import { BrowserTracing } from "@sentry/tracing";
+import { BrowserTracing } from "@sentry/browser";
 import Charts from "./lib/charts";
 
 // Sentry
@@ -36,6 +36,7 @@ const storeKey = "store";
 const app = Elm.Main.init({
   flags: {
     clientUrl: location.origin + location.pathname,
+    matomoSiteId: process.env.MATOMO_SITE_ID,
     rawStore: localStorage[storeKey] || "",
   },
 });
@@ -59,7 +60,7 @@ app.ports.appStarted.subscribe(() => {
   var u = "https://stats.beta.gouv.fr/";
   _paq.push(["setTrackerUrl", u + "matomo.php"]);
   _paq.push(["disableCookies"]);
-  _paq.push(["setSiteId", "57"]);
+  _paq.push(["setSiteId", process.env.MATOMO_SITE_ID]);
   loadScript(u + "matomo.js");
 });
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 const matomo = require("piwik");
 
-function setupTracker(matomoUrl, token, spec) {
+function setupTracker(matomoUrl, token, siteId, spec) {
   const tracker = matomo.setup(matomoUrl, token);
 
   function toMatomoCvar(data) {
@@ -28,7 +28,7 @@ function setupTracker(matomoUrl, token, spec) {
         // https://developer.matomo.org/api-reference/tracking-api
         const payload = {
           url: "https://ecobalyse.beta.gouv.fr/api" + req.url,
-          idsite: 57,
+          idsite: process.env.MATOMO_SITE_ID,
           action_name: "ApiRequest",
           e_a: "ApiRequest",
           idgoal: 1, // "API" goal on Matomo

--- a/server.js
+++ b/server.js
@@ -81,6 +81,7 @@ const openApiContents = yaml.load(fs.readFileSync("openapi.yaml"));
 const apiTracker = lib.setupTracker(
   "https://stats.beta.gouv.fr/",
   process.env.MATOMO_TOKEN,
+  process.env.MATOMO_SITE_ID,
   openApiContents,
 );
 

--- a/src/Data/Session.elm
+++ b/src/Data/Session.elm
@@ -32,6 +32,7 @@ type alias Session =
     , clientUrl : String
     , store : Store
     , currentVersion : Version
+    , matomoSiteId : String
     , textileDb : TextileDb.Db
     , foodDb : FoodDb.Db
     , notifications : List Notification

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -26,6 +26,7 @@ import Views.Page as Page
 
 type alias Flags =
     { clientUrl : String
+    , matomoSiteId : String
     , rawStore : String
     }
 
@@ -89,6 +90,7 @@ init flags url navKey =
                             , navKey = navKey
                             , store = Session.deserializeStore flags.rawStore
                             , currentVersion = Request.Version.Unknown
+                            , matomoSiteId = flags.matomoSiteId
                             , foodDb = db.foodDb
                             , textileDb = db.textileDb
                             , notifications = []

--- a/src/Page/Stats.elm
+++ b/src/Page/Stats.elm
@@ -88,7 +88,7 @@ viewStats { heading, unit } webData =
 
 
 view : Session -> Model -> ( String, List (Html Msg) )
-view _ { mode, apiStats, webStats } =
+view { matomoSiteId } { mode, apiStats, webStats } =
     ( "Statistiques"
     , [ Container.centered [ class "pb-5" ]
             [ h1 [ class "mb-3" ] [ text "Statistiques" ]
@@ -139,7 +139,7 @@ view _ { mode, apiStats, webStats } =
                                       , ( "widget", "1" )
                                       , ( "moduleToWidgetize", "CoreHome" )
                                       , ( "actionToWidgetize", "renderWidgetContainer" )
-                                      , ( "idSite", "57" )
+                                      , ( "idSite", matomoSiteId )
                                       , ( "period", "day" )
                                       , ( "date", "yesterday" )
                                       , ( "disableLink", "1" )
@@ -171,7 +171,7 @@ view _ { mode, apiStats, webStats } =
                                       , ( "widget", "1" )
                                       , ( "moduleToWidgetize", "CoreHome" )
                                       , ( "actionToWidgetize", "renderWidgetContainer" )
-                                      , ( "idSite", "57" )
+                                      , ( "idSite", matomoSiteId )
                                       , ( "period", "day" )
                                       , ( "date", "yesterday" )
                                       , ( "disableLink", "1" )

--- a/src/Request/Matomo.elm
+++ b/src/Request/Matomo.elm
@@ -6,8 +6,8 @@ import Http
 import RemoteData exposing (WebData)
 
 
-getStats : Session -> String -> String -> (WebData (List Matomo.Stat) -> msg) -> Cmd msg
-getStats _ jsonKey qs event =
+getStats : String -> String -> (WebData (List Matomo.Stat) -> msg) -> Cmd msg
+getStats jsonKey qs event =
     Http.get
         { url = "https://stats.beta.gouv.fr/" ++ qs
         , expect =
@@ -17,10 +17,14 @@ getStats _ jsonKey qs event =
 
 
 getApiStats : Session -> (WebData (List Matomo.Stat) -> msg) -> Cmd msg
-getApiStats session =
-    getStats session "nb_conversions" "?module=API&method=Goals.get&format=json&idSite=57&idGoal=1&period=day&date=last30"
+getApiStats { matomoSiteId } =
+    "?module=API&method=Goals.get&format=json&idGoal=1&period=day&date=last30&idSite="
+        ++ matomoSiteId
+        |> getStats "nb_conversions"
 
 
 getWebStats : Session -> (WebData (List Matomo.Stat) -> msg) -> Cmd msg
-getWebStats session =
-    getStats session "nb_visits" "?module=API&method=VisitsSummary.get&format=json&idSite=57&period=day&date=last30"
+getWebStats { matomoSiteId } =
+    "?module=API&method=VisitsSummary.get&format=json&period=day&date=last30&idSite="
+        ++ matomoSiteId
+        |> getStats "nb_visits"


### PR DESCRIPTION
Migrating our use of Matomo to a new instance with a different site id has been tedious. This patch introduces a new env var for storing the instance host and site id as environment variables.