### PR TITLE
Improve docs and checks for required env vars.

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,4 +1,4 @@
 MATOMO_HOST=stats.beta.gouv.fr
-MATOMO_SITE_ID=xxx
+MATOMO_SITE_ID=57
 MATOMO_TOKEN=xxx
 SENTRY_DSN=https://xxx@xxx.ingest.sentry.io/xxx

--- a/README.md
+++ b/README.md
@@ -14,6 +14,17 @@ Cette application est écrite en [Elm](https://elm-lang.org/). Vous devez dispos
 
     $ npm install
 
+## Configuration
+
+Les variables d'environnement suivantes doivent être définies :
+
+- `SENTRY_DSN`: le DSN [Sentry](https://sentry.io) à utiliser pour les rapports d'erreur.
+- `MATOMO_HOST`: le domaine de l'instance Matomo permettant le suivi d'audience du produit (typiquement `stats.beta.gouv.fr`).
+- `MATOMO_SITE_ID`: l'identifiant du site Ecobalyse sur l'instance Matomo permettant le suivi d'audience du produit.
+- `MATOMO_TOKEN`: le token Matomo permettant le suivi d'audience du produit.
+
+En développement, copiez le fichier `.env.sample`, renommez-le `.env`, et mettez à jour les valeurs qu'il contient ; le serveur de développement node chargera les variables en conséquences.
+
 ## Développement
 
 ### Environnement de développement local
@@ -76,12 +87,7 @@ Chaque _Pull Request_ effectuée sur le dépôt est également automatiquement d
 
 ## Variables d'environnement
 
-Certaines variables d'environnement doivent être configurées via l'interface de [configuration Scalingo](https://dashboard.scalingo.com/apps/osc-fr1/ecobalyse/environment) :
-
-- `SENTRY_DSN`: le DSN [Sentry](https://sentry.io) à utiliser pour les rapports d'erreur.
-- `MATOMO_HOST`: le domaine de l'instance Matomo permettant le suivi d'audience du produit (typiquement `stats.beta.gouv.fr`).
-- `MATOMO_SITE_ID`: l'identifiant du site Ecobalyse sur l'instance Matomo permettant le suivi d'audience du produit.
-- `MATOMO_TOKEN`: le token Matomo permettant le suivi d'audience du produit.
+Les variables d'environnement doivent être positionnées via l'interface de [configuration Scalingo](https://dashboard.scalingo.com/apps/osc-fr1/ecobalyse/environment) (voir la section [Configuration](#configuration)).
 
 ## Lancement du serveur
 

--- a/index.js
+++ b/index.js
@@ -36,8 +36,11 @@ const storeKey = "store";
 const app = Elm.Main.init({
   flags: {
     clientUrl: location.origin + location.pathname,
-    matomo: { host: process.env.MATOMO_HOST, siteId: process.env.MATOMO_SITE_ID },
     rawStore: localStorage[storeKey] || "",
+    matomo: {
+      host: process.env.MATOMO_HOST || "",
+      siteId: process.env.MATOMO_SITE_ID || "",
+    },
   },
 });
 

--- a/server.js
+++ b/server.js
@@ -17,7 +17,7 @@ const port = process.env.PORT || 3000;
 const { SENTRY_DSN, MATOMO_HOST, MATOMO_SITE_ID, MATOMO_TOKEN } = process.env;
 
 // Matomo
-if (!MATOMO_HOST || !MATOMO_SITE_ID || !MATOMO_TOKEN) {
+if (process.env.NODE_ENV !== "test" && (!MATOMO_HOST || !MATOMO_SITE_ID || !MATOMO_TOKEN)) {
   console.error("Matomo environment variables are missing. Please check the README.");
   process.exit(1);
 }

--- a/server.js
+++ b/server.js
@@ -13,8 +13,16 @@ const api = express(); // api app
 const host = "0.0.0.0";
 const port = process.env.PORT || 3000;
 
+// Env vars
+const { SENTRY_DSN, MATOMO_HOST, MATOMO_SITE_ID, MATOMO_TOKEN } = process.env;
+
+// Matomo
+if (!MATOMO_HOST || !MATOMO_SITE_ID || !MATOMO_TOKEN) {
+  console.error("Matomo environment variables are missing. Please check the README.");
+  process.exit(1);
+}
+
 // Sentry
-const { SENTRY_DSN } = process.env;
 if (SENTRY_DSN) {
   Sentry.init({ dsn: SENTRY_DSN, tracesSampleRate: 0.1 });
   // Note: Sentry middleware *must* be the very first applied to be effective


### PR DESCRIPTION
@magopian Not sure if I prefer this or your approach in #423, which seems more robust 🤔

If we go the #423 route, ideally we would have a `Maybe Matomo` so we could disable stats in dev and only have them in production when env vars are properly set. What do you think?