### PR TITLE
Rely on dotenv to read environment variables.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@sentry/tracing": "^7.87.0",
         "bootstrap": "^5.3.2",
         "cors": "^2.8.5",
+        "dotenv": "^16.3.1",
         "elm": "^0.19.1-6",
         "express": "^4.18.2",
         "helmet": "^7.1.0",
@@ -1866,6 +1867,14 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/core/node_modules/dotenv": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-7.0.0.tgz",
+      "integrity": "sha512-M3NhsLbV1i6HuGzBUH8vXrtxOk+tWmzWKDMbAVSUp3Zsjm7ywFeuwrUXhmhQyRK1q5B5GGy7hcXPbj3bnfZg2g==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@parcel/diagnostic": {
@@ -5780,11 +5789,14 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-7.0.0.tgz",
-      "integrity": "sha512-M3NhsLbV1i6HuGzBUH8vXrtxOk+tWmzWKDMbAVSUp3Zsjm7ywFeuwrUXhmhQyRK1q5B5GGy7hcXPbj3bnfZg2g==",
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
       "engines": {
-        "node": ">=6"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
     "node_modules/dotenv-expand": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@sentry/tracing": "^7.87.0",
     "bootstrap": "^5.3.2",
     "cors": "^2.8.5",
+    "dotenv": "^16.3.1",
     "elm": "^0.19.1-6",
     "express": "^4.18.2",
     "helmet": "^7.1.0",

--- a/server.js
+++ b/server.js
@@ -1,3 +1,4 @@
+require("dotenv").config();
 const fs = require("fs");
 const express = require("express");
 const bodyParser = require("body-parser");


### PR DESCRIPTION
Replaces #428

Note: no need to update the README as this patch actually implements what is documented there: *le serveur de développement node chargera les variables en conséquences* :)