### PR TITLE
Improve textile examples autocomplete.

### DIFF
--- a/src/Data/Textile/Inputs.elm
+++ b/src/Data/Textile/Inputs.elm
@@ -897,6 +897,7 @@ exampleProductToCategory q =
 exampleProducts : List Query
 exampleProducts =
     productsAndNames
+        |> List.sortBy .name
         |> List.map .query
 
 

--- a/src/Data/Textile/Inputs.elm
+++ b/src/Data/Textile/Inputs.elm
@@ -1059,7 +1059,7 @@ pullLaineAsie =
 jupePolyesterAsie : Query
 jupePolyesterAsie =
     { jupeCotonAsie
-        | materials = [ { id = Material.Id "polyester", share = Split.full, spinning = Nothing, country = Nothing } ]
+        | materials = [ { id = Material.Id "pet", share = Split.full, spinning = Nothing, country = Nothing } ]
     }
 
 
@@ -1076,5 +1076,5 @@ manteauMixAsie =
 tShirtPolyesterAsie : Query
 tShirtPolyesterAsie =
     { tShirtCotonAsie
-        | materials = [ { id = Material.Id "polyester", share = Split.full, spinning = Nothing, country = Nothing } ]
+        | materials = [ { id = Material.Id "pet", share = Split.full, spinning = Nothing, country = Nothing } ]
     }

--- a/src/Data/Textile/Inputs.elm
+++ b/src/Data/Textile/Inputs.elm
@@ -24,6 +24,7 @@ module Data.Textile.Inputs exposing
     , isFaded
     , jupeCotonAsie
     , parseBase64Query
+    , productsAndNames
     , removeMaterial
     , tShirtCotonAsie
     , tShirtCotonFrance

--- a/tests/Data/Textile/InputsTest.elm
+++ b/tests/Data/Textile/InputsTest.elm
@@ -118,5 +118,13 @@ suite =
                     |> testComplementEqual -102.85
                     |> asTest "should compute Microfibers complement impact for a half-natural, half-synthetic garment"
                 ]
+            , describe "productsAndNames"
+                (Inputs.productsAndNames
+                    |> List.map
+                        (\{ name, query } ->
+                            Expect.ok (Inputs.fromQuery textileDb query)
+                                |> asTest (name ++ " example is ok")
+                        )
+                )
             ]
         )


### PR DESCRIPTION
A very simple enhancement and a small bugfix. 

@magopian I was also thinking of searching into the category name as well, because atm if you search for "polo" it shows no results, while we might want to expose t-shirt examples from the *t-shirt/polo* category as a starting point… what do you think?