### PR TITLE
Add the missing "fabricProcess" parameter to the API example

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -450,6 +450,7 @@ components:
         countryFabric: "FR"
         countryDyeing: "FR"
         countryMaking: "FR"
+        fabricProcess: "knitting-mix"
     tShirtChina:
       summary: "T-Shirt Chine, low-cost, 100% Coton"
       value:


### PR DESCRIPTION
Quick fix, missing `fabricProcess` parameter in the API example