### PR TITLE
add-missing-fabricProcess-api-example

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -468,6 +468,7 @@ components:
         countryFabric: "FR"
         countryDyeing: "FR"
         countryMaking: "FR"
+        fabricProcess: "knitting-mix"
     tShirtChina:
       summary: "T-Shirt Chine, low-cost, 100% Coton"
       value:


### PR DESCRIPTION
same as https://github.com/MTES-MCT/ecobalyse/pull/462 but merge into master

Fix 
<img width="870" alt="image" src="https://github.com/MTES-MCT/ecobalyse/assets/13175018/222752b6-665d-42e1-b068-f6da44a7d5a9">
