### PR TITLE
Remove confusing DOM element autofocusing behavior.

### DIFF
--- a/src/Page/Food.elm
+++ b/src/Page/Food.elm
@@ -8,7 +8,6 @@ module Page.Food exposing
     )
 
 import Autocomplete exposing (Autocomplete)
-import Browser.Dom as Dom
 import Browser.Events as BE
 import Browser.Navigation as Navigation
 import Data.AutocompleteSelector as AutocompleteSelector
@@ -160,7 +159,8 @@ update ({ db, queries } as session) msg model =
     in
     case msg of
         AddIngredient ingredient ->
-            update session (SetModal NoModal) model
+            model
+                |> update session (SetModal NoModal)
                 |> updateQuery (query |> Query.addIngredient (Recipe.ingredientQueryFromIngredient ingredient))
 
         AddPackaging ->
@@ -230,7 +230,8 @@ update ({ db, queries } as session) msg model =
                 |> updateQuery (Query.deletePreparation id query)
 
         LoadQuery queryToLoad ->
-            update session (SetModal NoModal) { model | initialQuery = queryToLoad }
+            { model | initialQuery = queryToLoad }
+                |> update session (SetModal NoModal)
                 |> updateQuery queryToLoad
 
         NoOp ->
@@ -326,7 +327,7 @@ update ({ db, queries } as session) msg model =
         SetModal NoModal ->
             ( { model | modal = NoModal }
             , session
-            , commandsForNoModal model.modal
+            , Ports.removeBodyClass "prevent-scrolling"
             )
 
         SetModal ComparatorModal ->
@@ -338,21 +339,13 @@ update ({ db, queries } as session) msg model =
         SetModal (AddIngredientModal maybeOldIngredient autocomplete) ->
             ( { model | modal = AddIngredientModal maybeOldIngredient autocomplete }
             , session
-            , Cmd.batch
-                [ Ports.addBodyClass "prevent-scrolling"
-                , Dom.focus "element-search"
-                    |> Task.attempt (always NoOp)
-                ]
+            , Ports.addBodyClass "prevent-scrolling"
             )
 
         SetModal (SelectExampleModal autocomplete) ->
             ( { model | modal = SelectExampleModal autocomplete }
             , session
-            , Cmd.batch
-                [ Ports.addBodyClass "prevent-scrolling"
-                , Dom.focus "element-search"
-                    |> Task.attempt (always NoOp)
-                ]
+            , Ports.addBodyClass "prevent-scrolling"
             )
 
         SwitchBookmarksTab bookmarkTab ->
@@ -431,35 +424,6 @@ updateQuery query ( model, session, msg ) =
     )
 
 
-commandsForNoModal : Modal -> Cmd Msg
-commandsForNoModal modal =
-    case modal of
-        AddIngredientModal maybeOldIngredient _ ->
-            Cmd.batch
-                [ Ports.removeBodyClass "prevent-scrolling"
-                , Dom.focus
-                    -- This whole "node to focus" management is happening as a fallback
-                    -- if the modal was closed without choosing anything.
-                    -- If anything has been chosen, then the focus will be done in `OnAutocompleteSelect`
-                    -- and overload any focus being done here.
-                    (maybeOldIngredient
-                        |> Maybe.map (.ingredient >> .id >> Ingredient.idToString >> (++) "selector-")
-                        |> Maybe.withDefault "add-new-element"
-                    )
-                    |> Task.attempt (always NoOp)
-                ]
-
-        SelectExampleModal _ ->
-            Cmd.batch
-                [ Ports.removeBodyClass "prevent-scrolling"
-                , Dom.focus "selector-example"
-                    |> Task.attempt (always NoOp)
-                ]
-
-        _ ->
-            Ports.removeBodyClass "prevent-scrolling"
-
-
 updateExistingIngredient : Query -> Model -> Session -> Recipe.RecipeIngredient -> Ingredient -> ( Model, Session, Cmd Msg )
 updateExistingIngredient query model session oldRecipeIngredient newIngredient =
     -- Update an existing ingredient
@@ -475,7 +439,6 @@ updateExistingIngredient query model session oldRecipeIngredient newIngredient =
     model
         |> update session (SetModal NoModal)
         |> updateQuery (Query.updateIngredient oldRecipeIngredient.ingredient.id ingredientQuery query)
-        |> focusNode ("selector-" ++ Ingredient.idToString newIngredient.id)
 
 
 updateIngredient : Query -> Model -> Session -> Maybe Recipe.RecipeIngredient -> Autocomplete Ingredient -> ( Model, Session, Cmd Msg )
@@ -493,24 +456,7 @@ updateIngredient query model session maybeOldRecipeIngredient autocompleteState 
             (model
                 |> update session (SetModal NoModal)
                 |> selectIngredient autocompleteState
-                |> focusNode
-                    (maybeSelectedValue
-                        |> Maybe.map (\selectedValue -> "selector-" ++ Ingredient.idToString selectedValue.id)
-                        |> Maybe.withDefault "add-new-element"
-                    )
             )
-
-
-focusNode : String -> ( Model, Session, Cmd Msg ) -> ( Model, Session, Cmd Msg )
-focusNode node ( model, session, commands ) =
-    ( model
-    , session
-    , Cmd.batch
-        [ commands
-        , Dom.focus node
-            |> Task.attempt (always NoOp)
-        ]
-    )
 
 
 findExistingBookmarkName : Session -> Query -> String


### PR DESCRIPTION
The auto-DOM-scrolling strategy when adding or updating examples/ingredients in the Food calculator makes it really hard and counter-intuitive to use. This patch removes all related code so the behavior is back to normal (no autoscroll at all).