### PR TITLE
Split the textile inputs & query modules.

### DIFF
--- a/src/Data/Bookmark.elm
+++ b/src/Data/Bookmark.elm
@@ -15,7 +15,8 @@ module Data.Bookmark exposing
 import Data.Food.Query as FoodQuery
 import Data.Food.Recipe as Recipe
 import Data.Scope as Scope exposing (Scope)
-import Data.Textile.Inputs as TextileQuery
+import Data.Textile.Inputs as Inputs
+import Data.Textile.Query as TextileQuery
 import Json.Decode as Decode exposing (Decoder)
 import Json.Encode as Encode
 import Static.Db exposing (Db)
@@ -46,7 +47,7 @@ decodeQuery : Decoder Query
 decodeQuery =
     Decode.oneOf
         [ Decode.map Food FoodQuery.decode
-        , Decode.map Textile TextileQuery.decodeQuery
+        , Decode.map Textile TextileQuery.decode
         ]
 
 
@@ -66,7 +67,7 @@ encodeQuery v =
             FoodQuery.encode query
 
         Textile query ->
-            TextileQuery.encodeQuery query
+            TextileQuery.encode query
 
 
 isFood : Bookmark -> Bool
@@ -136,6 +137,6 @@ toQueryDescription db bookmark =
 
         Textile textileQuery ->
             textileQuery
-                |> TextileQuery.fromQuery db.countries db.textile.materials db.textile.products
-                |> Result.map TextileQuery.toString
+                |> Inputs.fromQuery db.countries db.textile.materials db.textile.products
+                |> Result.map Inputs.toString
                 |> Result.withDefault bookmark.name

--- a/src/Data/Bookmark.elm
+++ b/src/Data/Bookmark.elm
@@ -137,6 +137,6 @@ toQueryDescription db bookmark =
 
         Textile textileQuery ->
             textileQuery
-                |> Inputs.fromQuery db.countries db.textile.materials db.textile.products
+                |> Inputs.fromQuery db
                 |> Result.map Inputs.toString
                 |> Result.withDefault bookmark.name

--- a/src/Data/Session.elm
+++ b/src/Data/Session.elm
@@ -17,7 +17,7 @@ module Data.Session exposing
 import Browser.Navigation as Nav
 import Data.Bookmark as Bookmark exposing (Bookmark)
 import Data.Food.Query as FoodQuery
-import Data.Textile.Inputs as TextileInputs
+import Data.Textile.Query as TextileQuery
 import Json.Decode as Decode exposing (Decoder)
 import Json.Decode.Pipeline as JDP
 import Json.Encode as Encode
@@ -36,7 +36,7 @@ type alias Session =
     , notifications : List Notification
     , queries :
         { food : FoodQuery.Query
-        , textile : TextileInputs.Query
+        , textile : TextileQuery.Query
         }
     }
 
@@ -94,7 +94,7 @@ updateFoodQuery foodQuery ({ queries } as session) =
     { session | queries = { queries | food = foodQuery } }
 
 
-updateTextileQuery : TextileInputs.Query -> Session -> Session
+updateTextileQuery : TextileQuery.Query -> Session -> Session
 updateTextileQuery textileQuery ({ queries } as session) =
     { session | queries = { queries | textile = textileQuery } }
 

--- a/src/Data/Textile/ExampleProduct.elm
+++ b/src/Data/Textile/ExampleProduct.elm
@@ -5,7 +5,7 @@ module Data.Textile.ExampleProduct exposing
     , toName
     )
 
-import Data.Textile.Inputs as Inputs exposing (Query)
+import Data.Textile.Query as Query exposing (Query)
 import Json.Decode as Decode exposing (Decoder)
 
 
@@ -20,7 +20,7 @@ decode : Decoder ExampleProduct
 decode =
     Decode.map3 ExampleProduct
         (Decode.field "name" Decode.string)
-        (Decode.field "query" Inputs.decodeQuery)
+        (Decode.field "query" Query.decode)
         (Decode.field "category" Decode.string)
 
 

--- a/src/Data/Textile/Inputs.elm
+++ b/src/Data/Textile/Inputs.elm
@@ -37,6 +37,7 @@ import Json.Encode as Encode
 import Mass exposing (Mass)
 import Quantity
 import Result.Extra as RE
+import Static.Db exposing (Db)
 import Views.Format as Format
 
 
@@ -145,12 +146,12 @@ getMainMaterialCountry countries =
             )
 
 
-fromQuery : List Country -> List Material -> List Product -> Query -> Result String Inputs
-fromQuery countries materials products query =
+fromQuery : Db -> Query -> Result String Inputs
+fromQuery { countries, textile } query =
     let
         materials_ =
             query.materials
-                |> fromMaterialQuery materials countries
+                |> fromMaterialQuery textile.materials countries
 
         franceResult =
             Country.findByCode (Country.Code "FR") countries
@@ -166,7 +167,7 @@ fromQuery countries materials products query =
     Ok Inputs
         |> RE.andMap (Ok query.mass)
         |> RE.andMap materials_
-        |> RE.andMap (products |> Product.findById query.product)
+        |> RE.andMap (textile.products |> Product.findById query.product)
         -- Material country is constrained to be the first material's default country
         |> RE.andMap mainMaterialCountry
         -- Spinning country is either provided by query or fallbacks to material's default

--- a/src/Data/Textile/Inputs.elm
+++ b/src/Data/Textile/Inputs.elm
@@ -1,18 +1,9 @@
 module Data.Textile.Inputs exposing
     ( Inputs
     , MaterialInput
-    , MaterialQuery
-    , Query
-    , addMaterial
-    , b64decode
-    , b64encode
-    , buildApiQuery
     , computeMaterialTransport
     , countryList
-    , decodeQuery
-    , defaultQuery
     , encode
-    , encodeQuery
     , fromQuery
     , getMaterialMicrofibersComplement
     , getMaterialsOriginShares
@@ -20,20 +11,10 @@ module Data.Textile.Inputs exposing
     , getOutOfEuropeEOLProbability
     , getTotalMicrofibersComplement
     , isFaded
-    , jupeCotonAsie
-    , parseBase64Query
-    , removeMaterial
-    , tShirtCotonFrance
     , toQuery
     , toString
-    , toggleStep
-    , updateMaterial
-    , updateMaterialSpinning
-    , updateProduct
-    , updateStepCountry
     )
 
-import Base64
 import Data.Country as Country exposing (Country)
 import Data.Impact as Impact
 import Data.Scope as Scope
@@ -47,18 +28,15 @@ import Data.Textile.Material.Origin as Origin exposing (Origin)
 import Data.Textile.Material.Spinning as Spinning exposing (Spinning)
 import Data.Textile.Printing as Printing exposing (Printing)
 import Data.Textile.Product as Product exposing (Product)
+import Data.Textile.Query exposing (MaterialQuery, Query)
 import Data.Textile.Step.Label as Label exposing (Label)
 import Data.Transport as Transport exposing (Distances, Transport)
 import Data.Unit as Unit
 import Duration exposing (Duration)
-import Json.Decode as Decode exposing (Decoder)
-import Json.Decode.Pipeline as Pipe
 import Json.Encode as Encode
-import List.Extra as LE
 import Mass exposing (Mass)
 import Quantity
 import Result.Extra as RE
-import Url.Parser as Parser exposing (Parser)
 import Views.Format as Format
 
 
@@ -104,48 +82,13 @@ type alias Inputs =
     }
 
 
-type alias MaterialQuery =
-    { id : Material.Id
-    , share : Split
-    , spinning : Maybe Spinning
-    , country : Maybe Country.Code
-    }
-
-
-type alias Query =
-    { mass : Mass
-    , materials : List MaterialQuery
-    , product : Product.Id
-    , countrySpinning : Maybe Country.Code
-    , countryFabric : Country.Code
-    , countryDyeing : Country.Code
-    , countryMaking : Country.Code
-    , airTransportRatio : Maybe Split
-    , makingWaste : Maybe Split
-    , makingDeadStock : Maybe Split
-    , makingComplexity : Maybe MakingComplexity
-    , yarnSize : Maybe Unit.YarnSize
-    , surfaceMass : Maybe Unit.SurfaceMass
-    , fabricProcess : Fabric
-    , disabledSteps : List Label
-    , fading : Maybe Bool
-    , dyeingMedium : Maybe DyeingMedium
-    , printing : Maybe Printing
-    , business : Maybe Economics.Business
-    , marketingDuration : Maybe Duration
-    , numberOfReferences : Maybe Int
-    , price : Maybe Economics.Price
-    , traceability : Maybe Bool
-    }
-
-
 isFaded : Inputs -> Bool
 isFaded inputs =
     inputs.fading == Just True || (inputs.fading == Nothing && Product.isFadedByDefault inputs.product)
 
 
-toMaterialInputs : List Material -> List Country -> List MaterialQuery -> Result String (List MaterialInput)
-toMaterialInputs materials countries =
+fromMaterialQuery : List Material -> List Country -> List MaterialQuery -> Result String (List MaterialInput)
+fromMaterialQuery materials countries =
     List.map
         (\{ id, share, spinning, country } ->
             let
@@ -207,7 +150,7 @@ fromQuery countries materials products query =
     let
         materials_ =
             query.materials
-                |> toMaterialInputs materials countries
+                |> fromMaterialQuery materials countries
 
         franceResult =
             Country.findByCode (Country.Code "FR") countries
@@ -434,140 +377,6 @@ countryList inputs =
     ]
 
 
-updateStepCountry : Label -> Country.Code -> Query -> Query
-updateStepCountry label code query =
-    case label of
-        Label.Spinning ->
-            { query | countrySpinning = Just code }
-
-        Label.Fabric ->
-            { query | countryFabric = code }
-
-        Label.Ennobling ->
-            { query | countryDyeing = code }
-
-        Label.Making ->
-            { query
-                | countryMaking = code
-                , airTransportRatio =
-                    if query.countryMaking /= code then
-                        -- reset custom value as we just switched country
-                        Nothing
-
-                    else
-                        query.airTransportRatio
-            }
-
-        _ ->
-            query
-
-
-toggleStep : Label -> Query -> Query
-toggleStep label query =
-    { query
-        | disabledSteps =
-            if List.member label query.disabledSteps then
-                List.filter ((/=) label) query.disabledSteps
-
-            else
-                label :: query.disabledSteps
-    }
-
-
-addMaterial : Material -> Query -> Query
-addMaterial material query =
-    let
-        materialQuery =
-            { id = material.id
-            , share = Split.zero
-            , spinning = Nothing
-            , country = Nothing
-            }
-    in
-    { query
-        | materials =
-            query.materials ++ [ materialQuery ]
-    }
-
-
-updateMaterialQuery : Material.Id -> (MaterialQuery -> MaterialQuery) -> Query -> Query
-updateMaterialQuery materialId update query =
-    { query | materials = query.materials |> LE.updateIf (.id >> (==) materialId) update }
-
-
-updateMaterial : Material.Id -> MaterialQuery -> Query -> Query
-updateMaterial oldMaterialId newMaterial =
-    updateMaterialQuery oldMaterialId
-        (\materialQuery ->
-            { materialQuery
-                | id = newMaterial.id
-                , share = newMaterial.share
-                , spinning = Nothing
-                , country = newMaterial.country
-            }
-        )
-
-
-updateMaterialShare : Material.Id -> Split -> Query -> Query
-updateMaterialShare materialId share =
-    updateMaterialQuery materialId
-        (\materialQuery -> { materialQuery | share = share })
-
-
-updateMaterialSpinning : Material -> Spinning -> Query -> Query
-updateMaterialSpinning material spinning query =
-    { query
-        | materials =
-            query.materials
-                |> List.map
-                    (\materialQuery ->
-                        if materialQuery.id == material.id then
-                            { materialQuery | spinning = Just spinning }
-
-                        else
-                            materialQuery
-                    )
-    }
-
-
-removeMaterial : Material.Id -> Query -> Query
-removeMaterial materialId query =
-    { query | materials = query.materials |> List.filter (\m -> m.id /= materialId) }
-        |> (\newQuery ->
-                -- set share to 100% when a single material remains
-                if List.length newQuery.materials == 1 then
-                    newQuery.materials
-                        |> List.head
-                        |> Maybe.map (\m -> updateMaterialShare m.id Split.full newQuery)
-                        |> Maybe.withDefault newQuery
-
-                else
-                    newQuery
-           )
-
-
-updateProduct : Product -> Query -> Query
-updateProduct product query =
-    if product.id /= query.product then
-        -- Product has changed, reset a bunch of related query params
-        { query
-            | product = product.id
-            , mass = product.mass
-            , makingWaste = Nothing
-            , makingDeadStock = Nothing
-            , makingComplexity = Nothing
-            , yarnSize = Nothing
-            , surfaceMass = Nothing
-            , fabricProcess = product.fabric
-            , fading = Nothing
-            , dyeingMedium = Nothing
-            , printing = Nothing
-        }
-
-    else
-        query
-
-
 getMaterialMicrofibersComplement : Mass -> MaterialInput -> Unit.Impact
 getMaterialMicrofibersComplement finalProductMass { material, share } =
     -- Note: Impact is computed against the final product mass, because microfibers
@@ -666,17 +475,6 @@ computeMaterialTransport distances nextCountryCode { material, country, share } 
         Transport.default Impact.empty
 
 
-buildApiQuery : String -> Query -> String
-buildApiQuery clientUrl query =
-    """curl -X POST %apiUrl% \\
-  -H "accept: application/json" \\
-  -H "content-type: application/json" \\
-  -d '%json%'
-"""
-        |> String.replace "%apiUrl%" (clientUrl ++ "api/textile/simulator")
-        |> String.replace "%json%" (encodeQuery query |> Encode.encode 0)
-
-
 encode : Inputs -> Encode.Value
 encode inputs =
     Encode.object
@@ -714,162 +512,3 @@ encodeMaterialInput v =
     ]
         |> List.filterMap (\( key, maybeVal ) -> maybeVal |> Maybe.map (\val -> ( key, val )))
         |> Encode.object
-
-
-decodeQuery : Decoder Query
-decodeQuery =
-    Decode.succeed Query
-        |> Pipe.required "mass" (Decode.map Mass.kilograms Decode.float)
-        |> Pipe.required "materials" (Decode.list decodeMaterialQuery)
-        |> Pipe.required "product" (Decode.map Product.Id Decode.string)
-        |> Pipe.optional "countrySpinning" (Decode.maybe Country.decodeCode) Nothing
-        |> Pipe.required "countryFabric" Country.decodeCode
-        |> Pipe.required "countryDyeing" Country.decodeCode
-        |> Pipe.required "countryMaking" Country.decodeCode
-        |> Pipe.optional "airTransportRatio" (Decode.maybe Split.decodeFloat) Nothing
-        |> Pipe.optional "makingWaste" (Decode.maybe Split.decodeFloat) Nothing
-        |> Pipe.optional "makingDeadStock" (Decode.maybe Split.decodeFloat) Nothing
-        |> Pipe.optional "makingComplexity" (Decode.maybe MakingComplexity.decode) Nothing
-        |> Pipe.optional "yarnSize" (Decode.maybe Unit.decodeYarnSize) Nothing
-        |> Pipe.optional "surfaceMass" (Decode.maybe Unit.decodeSurfaceMass) Nothing
-        |> Pipe.required "fabricProcess" Fabric.decode
-        |> Pipe.optional "disabledSteps" (Decode.list Label.decodeFromCode) []
-        |> Pipe.optional "fading" (Decode.maybe Decode.bool) Nothing
-        |> Pipe.optional "dyeingMedium" (Decode.maybe DyeingMedium.decode) Nothing
-        |> Pipe.optional "printing" (Decode.maybe Printing.decode) Nothing
-        |> Pipe.optional "business" (Decode.maybe Economics.decodeBusiness) Nothing
-        |> Pipe.optional "marketingDuration" (Decode.maybe (Decode.map Duration.days Decode.float)) Nothing
-        |> Pipe.optional "numberOfReferences" (Decode.maybe Decode.int) Nothing
-        |> Pipe.optional "price" (Decode.maybe Economics.decodePrice) Nothing
-        |> Pipe.optional "traceability" (Decode.maybe Decode.bool) Nothing
-
-
-decodeMaterialQuery : Decoder MaterialQuery
-decodeMaterialQuery =
-    Decode.succeed MaterialQuery
-        |> Pipe.required "id" (Decode.map Material.Id Decode.string)
-        |> Pipe.required "share" Split.decodeFloat
-        |> Pipe.optional "spinning" (Decode.maybe Spinning.decode) Nothing
-        |> Pipe.optional "country" (Decode.maybe Country.decodeCode) Nothing
-
-
-encodeQuery : Query -> Encode.Value
-encodeQuery query =
-    [ ( "mass", query.mass |> Mass.inKilograms |> Encode.float |> Just )
-    , ( "materials", query.materials |> Encode.list encodeMaterialQuery |> Just )
-    , ( "product", query.product |> Product.idToString |> Encode.string |> Just )
-    , ( "countrySpinning", query.countrySpinning |> Maybe.map Country.encodeCode )
-    , ( "countryFabric", query.countryFabric |> Country.encodeCode |> Just )
-    , ( "countryDyeing", query.countryDyeing |> Country.encodeCode |> Just )
-    , ( "countryMaking", query.countryMaking |> Country.encodeCode |> Just )
-    , ( "airTransportRatio", query.airTransportRatio |> Maybe.map Split.encodeFloat )
-    , ( "makingWaste", query.makingWaste |> Maybe.map Split.encodeFloat )
-    , ( "makingDeadStock", query.makingDeadStock |> Maybe.map Split.encodeFloat )
-    , ( "makingComplexity", query.makingComplexity |> Maybe.map (MakingComplexity.toString >> Encode.string) )
-    , ( "yarnSize", query.yarnSize |> Maybe.map Unit.encodeYarnSize )
-    , ( "surfaceMass", query.surfaceMass |> Maybe.map Unit.encodeSurfaceMass )
-    , ( "fabricProcess", query.fabricProcess |> Fabric.encode |> Just )
-    , ( "disabledSteps"
-      , case query.disabledSteps of
-            [] ->
-                Nothing
-
-            list ->
-                Encode.list Label.encode list |> Just
-      )
-    , ( "fading", query.fading |> Maybe.map Encode.bool )
-    , ( "dyeingMedium", query.dyeingMedium |> Maybe.map DyeingMedium.encode )
-    , ( "printing", query.printing |> Maybe.map Printing.encode )
-    , ( "business", query.business |> Maybe.map Economics.encodeBusiness )
-    , ( "marketingDuration", query.marketingDuration |> Maybe.map (Duration.inDays >> Encode.float) )
-    , ( "numberOfReferences", query.numberOfReferences |> Maybe.map Encode.int )
-    , ( "price", query.price |> Maybe.map Economics.encodePrice )
-    , ( "traceability", query.traceability |> Maybe.map Encode.bool )
-    ]
-        -- For concision, drop keys where no param is defined
-        |> List.filterMap (\( key, maybeVal ) -> maybeVal |> Maybe.map (\val -> ( key, val )))
-        |> Encode.object
-
-
-encodeMaterialQuery : MaterialQuery -> Encode.Value
-encodeMaterialQuery v =
-    [ ( "id", Material.encodeId v.id |> Just )
-    , ( "share", Split.encodeFloat v.share |> Just )
-    , ( "spinning", v.spinning |> Maybe.map Spinning.encode )
-    , ( "country", v.country |> Maybe.map Country.encodeCode )
-    ]
-        |> List.filterMap (\( key, maybeVal ) -> maybeVal |> Maybe.map (\val -> ( key, val )))
-        |> Encode.object
-
-
-b64decode : String -> Result String Query
-b64decode =
-    Base64.decode
-        >> Result.andThen
-            (Decode.decodeString decodeQuery
-                >> Result.mapError Decode.errorToString
-            )
-
-
-b64encode : Query -> String
-b64encode =
-    encodeQuery >> Encode.encode 0 >> Base64.encode
-
-
-
--- Parser
-
-
-parseBase64Query : Parser (Maybe Query -> a) a
-parseBase64Query =
-    Parser.custom "QUERY" <|
-        b64decode
-            >> Result.toMaybe
-            >> Just
-
-
-defaultQuery : Query
-defaultQuery =
-    { mass = Mass.kilograms 0.17
-    , materials = [ { id = Material.Id "coton", share = Split.full, spinning = Nothing, country = Nothing } ]
-    , product = Product.Id "tshirt"
-    , countrySpinning = Just (Country.Code "CN")
-    , countryFabric = Country.Code "CN"
-    , countryDyeing = Country.Code "CN"
-    , countryMaking = Country.Code "CN"
-    , airTransportRatio = Nothing
-    , makingWaste = Nothing
-    , makingDeadStock = Nothing
-    , makingComplexity = Nothing
-    , yarnSize = Nothing
-    , surfaceMass = Nothing
-    , fabricProcess = Fabric.KnittingMix
-    , disabledSteps = []
-    , fading = Nothing
-    , dyeingMedium = Nothing
-    , printing = Nothing
-    , business = Nothing
-    , marketingDuration = Nothing
-    , numberOfReferences = Nothing
-    , price = Nothing
-    , traceability = Nothing
-    }
-
-
-jupeCotonAsie : Query
-jupeCotonAsie =
-    { defaultQuery
-        | mass = Mass.kilograms 0.3
-        , product = Product.Id "jupe"
-        , fabricProcess = Fabric.Weaving
-    }
-
-
-tShirtCotonFrance : Query
-tShirtCotonFrance =
-    { defaultQuery
-        | countrySpinning = Just (Country.Code "FR")
-        , countryFabric = Country.Code "FR"
-        , countryDyeing = Country.Code "FR"
-        , countryMaking = Country.Code "FR"
-    }

--- a/src/Data/Textile/LifeCycle.elm
+++ b/src/Data/Textile/LifeCycle.elm
@@ -121,8 +121,7 @@ getStepProp label prop default =
 
 fromQuery : Db -> Query -> Result String LifeCycle
 fromQuery db =
-    Inputs.fromQuery db.countries db.textile.materials db.textile.products
-        >> Result.map (init db)
+    Inputs.fromQuery db >> Result.map (init db)
 
 
 init : Db -> Inputs -> LifeCycle

--- a/src/Data/Textile/LifeCycle.elm
+++ b/src/Data/Textile/LifeCycle.elm
@@ -17,6 +17,7 @@ module Data.Textile.LifeCycle exposing
 import Array exposing (Array)
 import Data.Impact as Impact exposing (Impacts)
 import Data.Textile.Inputs as Inputs exposing (Inputs)
+import Data.Textile.Query exposing (Query)
 import Data.Textile.Step as Step exposing (Step)
 import Data.Textile.Step.Label as Label exposing (Label)
 import Data.Transport as Transport exposing (Transport)
@@ -118,7 +119,7 @@ getStepProp label prop default =
     getStep label >> Maybe.map prop >> Maybe.withDefault default
 
 
-fromQuery : Db -> Inputs.Query -> Result String LifeCycle
+fromQuery : Db -> Query -> Result String LifeCycle
 fromQuery db =
     Inputs.fromQuery db.countries db.textile.materials db.textile.products
         >> Result.map (init db)

--- a/src/Data/Textile/Query.elm
+++ b/src/Data/Textile/Query.elm
@@ -1,0 +1,384 @@
+module Data.Textile.Query exposing
+    ( MaterialQuery
+    , Query
+    , addMaterial
+    , b64decode
+    , b64encode
+    , buildApiQuery
+    , decode
+    , default
+    , encode
+    , jupeCotonAsie
+    , parseBase64Query
+    , removeMaterial
+    , tShirtCotonFrance
+    , toggleStep
+    , updateMaterial
+    , updateMaterialSpinning
+    , updateProduct
+    , updateStepCountry
+    )
+
+import Base64
+import Data.Country as Country
+import Data.Split as Split exposing (Split)
+import Data.Textile.DyeingMedium as DyeingMedium exposing (DyeingMedium)
+import Data.Textile.Economics as Economics
+import Data.Textile.Fabric as Fabric exposing (Fabric)
+import Data.Textile.MakingComplexity as MakingComplexity exposing (MakingComplexity)
+import Data.Textile.Material as Material exposing (Material)
+import Data.Textile.Material.Spinning as Spinning exposing (Spinning)
+import Data.Textile.Printing as Printing exposing (Printing)
+import Data.Textile.Product as Product exposing (Product)
+import Data.Textile.Step.Label as Label exposing (Label)
+import Data.Unit as Unit
+import Duration exposing (Duration)
+import Json.Decode as Decode exposing (Decoder)
+import Json.Decode.Pipeline as Pipe
+import Json.Encode as Encode
+import List.Extra as LE
+import Mass exposing (Mass)
+import Url.Parser as Parser exposing (Parser)
+
+
+type alias MaterialQuery =
+    { id : Material.Id
+    , share : Split
+    , spinning : Maybe Spinning
+    , country : Maybe Country.Code
+    }
+
+
+type alias Query =
+    { mass : Mass
+    , materials : List MaterialQuery
+    , product : Product.Id
+    , countrySpinning : Maybe Country.Code
+    , countryFabric : Country.Code
+    , countryDyeing : Country.Code
+    , countryMaking : Country.Code
+    , airTransportRatio : Maybe Split
+    , makingWaste : Maybe Split
+    , makingDeadStock : Maybe Split
+    , makingComplexity : Maybe MakingComplexity
+    , yarnSize : Maybe Unit.YarnSize
+    , surfaceMass : Maybe Unit.SurfaceMass
+    , fabricProcess : Fabric
+    , disabledSteps : List Label
+    , fading : Maybe Bool
+    , dyeingMedium : Maybe DyeingMedium
+    , printing : Maybe Printing
+    , business : Maybe Economics.Business
+    , marketingDuration : Maybe Duration
+    , numberOfReferences : Maybe Int
+    , price : Maybe Economics.Price
+    , traceability : Maybe Bool
+    }
+
+
+addMaterial : Material -> Query -> Query
+addMaterial material query =
+    let
+        materialQuery =
+            { id = material.id
+            , share = Split.zero
+            , spinning = Nothing
+            , country = Nothing
+            }
+    in
+    { query
+        | materials =
+            query.materials ++ [ materialQuery ]
+    }
+
+
+buildApiQuery : String -> Query -> String
+buildApiQuery clientUrl query =
+    """curl -X POST %apiUrl% \\
+  -H "accept: application/json" \\
+  -H "content-type: application/json" \\
+  -d '%json%'
+"""
+        |> String.replace "%apiUrl%" (clientUrl ++ "api/textile/simulator")
+        |> String.replace "%json%" (encode query |> Encode.encode 0)
+
+
+decode : Decoder Query
+decode =
+    Decode.succeed Query
+        |> Pipe.required "mass" (Decode.map Mass.kilograms Decode.float)
+        |> Pipe.required "materials" (Decode.list decodeMaterialQuery)
+        |> Pipe.required "product" (Decode.map Product.Id Decode.string)
+        |> Pipe.optional "countrySpinning" (Decode.maybe Country.decodeCode) Nothing
+        |> Pipe.required "countryFabric" Country.decodeCode
+        |> Pipe.required "countryDyeing" Country.decodeCode
+        |> Pipe.required "countryMaking" Country.decodeCode
+        |> Pipe.optional "airTransportRatio" (Decode.maybe Split.decodeFloat) Nothing
+        |> Pipe.optional "makingWaste" (Decode.maybe Split.decodeFloat) Nothing
+        |> Pipe.optional "makingDeadStock" (Decode.maybe Split.decodeFloat) Nothing
+        |> Pipe.optional "makingComplexity" (Decode.maybe MakingComplexity.decode) Nothing
+        |> Pipe.optional "yarnSize" (Decode.maybe Unit.decodeYarnSize) Nothing
+        |> Pipe.optional "surfaceMass" (Decode.maybe Unit.decodeSurfaceMass) Nothing
+        |> Pipe.required "fabricProcess" Fabric.decode
+        |> Pipe.optional "disabledSteps" (Decode.list Label.decodeFromCode) []
+        |> Pipe.optional "fading" (Decode.maybe Decode.bool) Nothing
+        |> Pipe.optional "dyeingMedium" (Decode.maybe DyeingMedium.decode) Nothing
+        |> Pipe.optional "printing" (Decode.maybe Printing.decode) Nothing
+        |> Pipe.optional "business" (Decode.maybe Economics.decodeBusiness) Nothing
+        |> Pipe.optional "marketingDuration" (Decode.maybe (Decode.map Duration.days Decode.float)) Nothing
+        |> Pipe.optional "numberOfReferences" (Decode.maybe Decode.int) Nothing
+        |> Pipe.optional "price" (Decode.maybe Economics.decodePrice) Nothing
+        |> Pipe.optional "traceability" (Decode.maybe Decode.bool) Nothing
+
+
+decodeMaterialQuery : Decoder MaterialQuery
+decodeMaterialQuery =
+    Decode.succeed MaterialQuery
+        |> Pipe.required "id" (Decode.map Material.Id Decode.string)
+        |> Pipe.required "share" Split.decodeFloat
+        |> Pipe.optional "spinning" (Decode.maybe Spinning.decode) Nothing
+        |> Pipe.optional "country" (Decode.maybe Country.decodeCode) Nothing
+
+
+encode : Query -> Encode.Value
+encode query =
+    [ ( "mass", query.mass |> Mass.inKilograms |> Encode.float |> Just )
+    , ( "materials", query.materials |> Encode.list encodeMaterialQuery |> Just )
+    , ( "product", query.product |> Product.idToString |> Encode.string |> Just )
+    , ( "countrySpinning", query.countrySpinning |> Maybe.map Country.encodeCode )
+    , ( "countryFabric", query.countryFabric |> Country.encodeCode |> Just )
+    , ( "countryDyeing", query.countryDyeing |> Country.encodeCode |> Just )
+    , ( "countryMaking", query.countryMaking |> Country.encodeCode |> Just )
+    , ( "airTransportRatio", query.airTransportRatio |> Maybe.map Split.encodeFloat )
+    , ( "makingWaste", query.makingWaste |> Maybe.map Split.encodeFloat )
+    , ( "makingDeadStock", query.makingDeadStock |> Maybe.map Split.encodeFloat )
+    , ( "makingComplexity", query.makingComplexity |> Maybe.map (MakingComplexity.toString >> Encode.string) )
+    , ( "yarnSize", query.yarnSize |> Maybe.map Unit.encodeYarnSize )
+    , ( "surfaceMass", query.surfaceMass |> Maybe.map Unit.encodeSurfaceMass )
+    , ( "fabricProcess", query.fabricProcess |> Fabric.encode |> Just )
+    , ( "disabledSteps"
+      , case query.disabledSteps of
+            [] ->
+                Nothing
+
+            list ->
+                Encode.list Label.encode list |> Just
+      )
+    , ( "fading", query.fading |> Maybe.map Encode.bool )
+    , ( "dyeingMedium", query.dyeingMedium |> Maybe.map DyeingMedium.encode )
+    , ( "printing", query.printing |> Maybe.map Printing.encode )
+    , ( "business", query.business |> Maybe.map Economics.encodeBusiness )
+    , ( "marketingDuration", query.marketingDuration |> Maybe.map (Duration.inDays >> Encode.float) )
+    , ( "numberOfReferences", query.numberOfReferences |> Maybe.map Encode.int )
+    , ( "price", query.price |> Maybe.map Economics.encodePrice )
+    , ( "traceability", query.traceability |> Maybe.map Encode.bool )
+    ]
+        -- For concision, drop keys where no param is defined
+        |> List.filterMap (\( key, maybeVal ) -> maybeVal |> Maybe.map (\val -> ( key, val )))
+        |> Encode.object
+
+
+encodeMaterialQuery : MaterialQuery -> Encode.Value
+encodeMaterialQuery v =
+    [ ( "id", Material.encodeId v.id |> Just )
+    , ( "share", Split.encodeFloat v.share |> Just )
+    , ( "spinning", v.spinning |> Maybe.map Spinning.encode )
+    , ( "country", v.country |> Maybe.map Country.encodeCode )
+    ]
+        |> List.filterMap (\( key, maybeVal ) -> maybeVal |> Maybe.map (\val -> ( key, val )))
+        |> Encode.object
+
+
+removeMaterial : Material.Id -> Query -> Query
+removeMaterial materialId query =
+    { query | materials = query.materials |> List.filter (\m -> m.id /= materialId) }
+        |> (\newQuery ->
+                -- set share to 100% when a single material remains
+                if List.length newQuery.materials == 1 then
+                    newQuery.materials
+                        |> List.head
+                        |> Maybe.map (\m -> updateMaterialShare m.id Split.full newQuery)
+                        |> Maybe.withDefault newQuery
+
+                else
+                    newQuery
+           )
+
+
+toggleStep : Label -> Query -> Query
+toggleStep label query =
+    { query
+        | disabledSteps =
+            if List.member label query.disabledSteps then
+                List.filter ((/=) label) query.disabledSteps
+
+            else
+                label :: query.disabledSteps
+    }
+
+
+updateMaterial : Material.Id -> MaterialQuery -> Query -> Query
+updateMaterial oldMaterialId newMaterial =
+    updateMaterialQuery oldMaterialId
+        (\materialQuery ->
+            { materialQuery
+                | id = newMaterial.id
+                , share = newMaterial.share
+                , spinning = Nothing
+                , country = newMaterial.country
+            }
+        )
+
+
+updateMaterialQuery : Material.Id -> (MaterialQuery -> MaterialQuery) -> Query -> Query
+updateMaterialQuery materialId update query =
+    { query | materials = query.materials |> LE.updateIf (.id >> (==) materialId) update }
+
+
+updateMaterialShare : Material.Id -> Split -> Query -> Query
+updateMaterialShare materialId share =
+    updateMaterialQuery materialId
+        (\materialQuery -> { materialQuery | share = share })
+
+
+updateMaterialSpinning : Material -> Spinning -> Query -> Query
+updateMaterialSpinning material spinning query =
+    { query
+        | materials =
+            query.materials
+                |> List.map
+                    (\materialQuery ->
+                        if materialQuery.id == material.id then
+                            { materialQuery | spinning = Just spinning }
+
+                        else
+                            materialQuery
+                    )
+    }
+
+
+updateProduct : Product -> Query -> Query
+updateProduct product query =
+    if product.id /= query.product then
+        -- Product has changed, reset a bunch of related query params
+        { query
+            | product = product.id
+            , mass = product.mass
+            , makingWaste = Nothing
+            , makingDeadStock = Nothing
+            , makingComplexity = Nothing
+            , yarnSize = Nothing
+            , surfaceMass = Nothing
+            , fabricProcess = product.fabric
+            , fading = Nothing
+            , dyeingMedium = Nothing
+            , printing = Nothing
+        }
+
+    else
+        query
+
+
+updateStepCountry : Label -> Country.Code -> Query -> Query
+updateStepCountry label code query =
+    case label of
+        Label.Spinning ->
+            { query | countrySpinning = Just code }
+
+        Label.Fabric ->
+            { query | countryFabric = code }
+
+        Label.Ennobling ->
+            { query | countryDyeing = code }
+
+        Label.Making ->
+            { query
+                | countryMaking = code
+                , airTransportRatio =
+                    if query.countryMaking /= code then
+                        -- reset custom value as we just switched country
+                        Nothing
+
+                    else
+                        query.airTransportRatio
+            }
+
+        _ ->
+            query
+
+
+
+-- Sample data
+
+
+default : Query
+default =
+    { mass = Mass.kilograms 0.17
+    , materials = [ { id = Material.Id "coton", share = Split.full, spinning = Nothing, country = Nothing } ]
+    , product = Product.Id "tshirt"
+    , countrySpinning = Just (Country.Code "CN")
+    , countryFabric = Country.Code "CN"
+    , countryDyeing = Country.Code "CN"
+    , countryMaking = Country.Code "CN"
+    , airTransportRatio = Nothing
+    , makingWaste = Nothing
+    , makingDeadStock = Nothing
+    , makingComplexity = Nothing
+    , yarnSize = Nothing
+    , surfaceMass = Nothing
+    , fabricProcess = Fabric.KnittingMix
+    , disabledSteps = []
+    , fading = Nothing
+    , dyeingMedium = Nothing
+    , printing = Nothing
+    , business = Nothing
+    , marketingDuration = Nothing
+    , numberOfReferences = Nothing
+    , price = Nothing
+    , traceability = Nothing
+    }
+
+
+jupeCotonAsie : Query
+jupeCotonAsie =
+    { default
+        | mass = Mass.kilograms 0.3
+        , product = Product.Id "jupe"
+        , fabricProcess = Fabric.Weaving
+    }
+
+
+tShirtCotonFrance : Query
+tShirtCotonFrance =
+    { default
+        | countrySpinning = Just (Country.Code "FR")
+        , countryFabric = Country.Code "FR"
+        , countryDyeing = Country.Code "FR"
+        , countryMaking = Country.Code "FR"
+    }
+
+
+
+-- Parser
+
+
+b64decode : String -> Result String Query
+b64decode =
+    Base64.decode
+        >> Result.andThen
+            (Decode.decodeString decode
+                >> Result.mapError Decode.errorToString
+            )
+
+
+b64encode : Query -> String
+b64encode =
+    encode >> Encode.encode 0 >> Base64.encode
+
+
+parseBase64Query : Parser (Maybe Query -> a) a
+parseBase64Query =
+    Parser.custom "QUERY" <|
+        b64decode
+            >> Result.toMaybe
+            >> Just

--- a/src/Data/Textile/Simulator.elm
+++ b/src/Data/Textile/Simulator.elm
@@ -61,7 +61,7 @@ init db =
         defaultImpacts =
             Impact.empty
     in
-    Inputs.fromQuery db.countries db.textile.materials db.textile.products
+    Inputs.fromQuery db
         >> Result.map
             (\({ product } as inputs) ->
                 inputs

--- a/src/Data/Textile/Simulator.elm
+++ b/src/Data/Textile/Simulator.elm
@@ -19,6 +19,7 @@ import Data.Textile.Material as Material exposing (Material)
 import Data.Textile.Material.Origin as Origin
 import Data.Textile.Material.Spinning as Spinning exposing (Spinning)
 import Data.Textile.Product as Product exposing (Product)
+import Data.Textile.Query exposing (Query)
 import Data.Textile.Step as Step exposing (Step)
 import Data.Textile.Step.Label as Label exposing (Label)
 import Data.Textile.WellKnown as WellKnown
@@ -54,7 +55,7 @@ encode v =
         ]
 
 
-init : Db -> Inputs.Query -> Result String Simulator
+init : Db -> Query -> Result String Simulator
 init db =
     let
         defaultImpacts =
@@ -80,7 +81,7 @@ init db =
 
 {-| Computes simulation impacts.
 -}
-compute : Db -> Inputs.Query -> Result String Simulator
+compute : Db -> Query -> Result String Simulator
 compute db query =
     let
         next fn =

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -5,7 +5,7 @@ import Browser.Navigation as Nav
 import Data.Food.Query as FoodQuery
 import Data.Impact as Impact
 import Data.Session as Session exposing (Session)
-import Data.Textile.Inputs as TextileInputs
+import Data.Textile.Query as TextileQuery
 import Html
 import Page.Api as Api
 import Page.Changelog as Changelog
@@ -95,7 +95,7 @@ init flags url navKey =
                             , notifications = []
                             , queries =
                                 { food = FoodQuery.emptyQuery
-                                , textile = TextileInputs.defaultQuery
+                                , textile = TextileQuery.default
                                 }
                             }
                             LoadingPage

--- a/src/Page/Explore/TextileProducts.elm
+++ b/src/Page/Explore/TextileProducts.elm
@@ -9,10 +9,10 @@ import Data.Textile.DyeingMedium as DyeingMedium
 import Data.Textile.Economics as Economics
 import Data.Textile.Fabric as Fabric
 import Data.Textile.Formula as Formula
-import Data.Textile.Inputs as TextileInputs
 import Data.Textile.LifeCycle as LifeCycle
 import Data.Textile.MakingComplexity as MakingComplexity
 import Data.Textile.Product as Product exposing (Product)
+import Data.Textile.Query as TextileQuery
 import Data.Textile.Simulator as Simulator
 import Data.Textile.Step.Label as Label
 import Data.Unit as Unit
@@ -118,8 +118,8 @@ table db { detailed, scope } =
             picking product surfaceMass ys =
                 let
                     outputMass =
-                        TextileInputs.defaultQuery
-                            |> TextileInputs.updateProduct product
+                        TextileQuery.default
+                            |> TextileQuery.updateProduct product
                             |> Simulator.compute db
                             |> Result.map (.lifeCycle >> LifeCycle.getStepProp Label.Fabric .outputMass Quantity.zero)
                             |> Result.withDefault Quantity.zero

--- a/src/Page/Textile/Simulator.elm
+++ b/src/Page/Textile/Simulator.elm
@@ -183,7 +183,7 @@ findExistingBookmarkName { db, store } query =
         |> Maybe.map .name
         |> Maybe.withDefault
             (query
-                |> Inputs.fromQuery db.countries db.textile.materials db.textile.products
+                |> Inputs.fromQuery db
                 |> Result.map Inputs.toString
                 |> Result.withDefault ""
             )

--- a/src/Route.elm
+++ b/src/Route.elm
@@ -10,7 +10,7 @@ import Data.Food.Query as FoodQuery
 import Data.Impact as Impact
 import Data.Impact.Definition as Definition
 import Data.Scope as Scope exposing (Scope)
-import Data.Textile.Inputs as TextileQuery
+import Data.Textile.Query as TextileQuery
 import Html exposing (Attribute)
 import Html.Attributes as Attr
 import Url exposing (Url)

--- a/src/Server.elm
+++ b/src/Server.elm
@@ -17,6 +17,7 @@ import Data.Scope as Scope
 import Data.Textile.Inputs as Inputs
 import Data.Textile.Material as Material exposing (Material)
 import Data.Textile.Product as TextileProduct exposing (Product)
+import Data.Textile.Query as TextileQuery
 import Data.Textile.Simulator as Simulator exposing (Simulator)
 import Json.Decode as Decode
 import Json.Encode as Encode
@@ -81,7 +82,7 @@ toAllImpactsSimple { inputs, impacts } =
         [ ( "webUrl", serverRootUrl ++ toTextileWebUrl Nothing inputs |> Encode.string )
         , ( "impacts", Impact.encode impacts )
         , ( "description", inputs |> Inputs.toString |> Encode.string )
-        , ( "query", inputs |> Inputs.toQuery |> Inputs.encodeQuery )
+        , ( "query", inputs |> Inputs.toQuery |> TextileQuery.encode )
         ]
 
 
@@ -107,7 +108,7 @@ toSingleImpactSimple trigram { inputs, impacts } =
           , Impact.encodeSingleImpact impacts trigram
           )
         , ( "description", inputs |> Inputs.toString |> Encode.string )
-        , ( "query", inputs |> Inputs.toQuery |> Inputs.encodeQuery )
+        , ( "query", inputs |> Inputs.toQuery |> TextileQuery.encode )
         ]
 
 
@@ -128,7 +129,7 @@ executeFoodQuery db encoder =
         >> toResponse
 
 
-executeTextileQuery : Db -> (Simulator -> Encode.Value) -> Inputs.Query -> JsonResponse
+executeTextileQuery : Db -> (Simulator -> Encode.Value) -> TextileQuery.Query -> JsonResponse
 executeTextileQuery db encoder =
     Simulator.compute db
         >> Result.map encoder
@@ -285,17 +286,17 @@ handleRequest db request =
 
         Just Route.PostTextileSimulator ->
             request.body
-                |> handleDecodeBody Inputs.decodeQuery
+                |> handleDecodeBody TextileQuery.decode
                     (executeTextileQuery db toAllImpactsSimple)
 
         Just Route.PostTextileSimulatorDetailed ->
             request.body
-                |> handleDecodeBody Inputs.decodeQuery
+                |> handleDecodeBody TextileQuery.decode
                     (executeTextileQuery db Simulator.encode)
 
         Just (Route.PostTextileSimulatorSingle trigram) ->
             request.body
-                |> handleDecodeBody Inputs.decodeQuery
+                |> handleDecodeBody TextileQuery.decode
                     (executeTextileQuery db (toSingleImpactSimple trigram))
 
         Nothing ->

--- a/src/Server/Query.elm
+++ b/src/Server/Query.elm
@@ -19,12 +19,12 @@ import Data.Textile.Db as Textile
 import Data.Textile.DyeingMedium as DyeingMedium exposing (DyeingMedium)
 import Data.Textile.Economics as Economics
 import Data.Textile.Fabric as Fabric exposing (Fabric)
-import Data.Textile.Inputs as Inputs
 import Data.Textile.MakingComplexity as MakingComplexity exposing (MakingComplexity)
 import Data.Textile.Material as Material exposing (Material)
 import Data.Textile.Material.Spinning as Spinning exposing (Spinning)
 import Data.Textile.Printing as Printing exposing (Printing)
 import Data.Textile.Product as Product exposing (Product)
+import Data.Textile.Query as TextileQuery
 import Data.Textile.Step.Label as Label exposing (Label)
 import Data.Unit as Unit
 import Dict exposing (Dict)
@@ -357,9 +357,9 @@ parseTransform_ transforms string =
             Err <| "Format de procédé de transformation invalide : " ++ string ++ "."
 
 
-parseTextileQuery : List Country -> Textile.Db -> Parser (Result Errors Inputs.Query)
+parseTextileQuery : List Country -> Textile.Db -> Parser (Result Errors TextileQuery.Query)
 parseTextileQuery countries textile =
-    succeed (Ok Inputs.Query)
+    succeed (Ok TextileQuery.Query)
         |> apply (massParserInKilograms "mass")
         |> apply (materialListParser "materials" textile.materials countries)
         |> apply (productParser "product" textile.products)
@@ -464,7 +464,7 @@ productParser key products =
             )
 
 
-materialListParser : String -> List Material -> List Country -> Parser (ParseResult (List Inputs.MaterialQuery))
+materialListParser : String -> List Material -> List Country -> Parser (ParseResult (List TextileQuery.MaterialQuery))
 materialListParser key materials countries =
     Query.custom (key ++ "[]")
         (List.map (parseMaterial_ materials countries)
@@ -474,7 +474,7 @@ materialListParser key materials countries =
         )
 
 
-parseMaterial_ : List Material -> List Country -> String -> Result String Inputs.MaterialQuery
+parseMaterial_ : List Material -> List Country -> String -> Result String TextileQuery.MaterialQuery
 parseMaterial_ materials countries string =
     case String.split ";" string of
         [ id, share, spinningString, countryCode ] ->
@@ -482,7 +482,7 @@ parseMaterial_ materials countries string =
                 |> Material.findById (Material.Id id)
                 |> Result.andThen
                     (\material ->
-                        Ok Inputs.MaterialQuery
+                        Ok TextileQuery.MaterialQuery
                             |> RE.andMap (Ok material.id)
                             |> RE.andMap (parseSplit share)
                             |> RE.andMap (parseSpinning material spinningString)
@@ -494,7 +494,7 @@ parseMaterial_ materials countries string =
                 |> Material.findById (Material.Id id)
                 |> Result.andThen
                     (\material ->
-                        Ok Inputs.MaterialQuery
+                        Ok TextileQuery.MaterialQuery
                             |> RE.andMap (Ok material.id)
                             |> RE.andMap (parseSplit share)
                             |> RE.andMap (parseSpinning material spinningString)
@@ -502,7 +502,7 @@ parseMaterial_ materials countries string =
                     )
 
         [ id, share ] ->
-            Ok Inputs.MaterialQuery
+            Ok TextileQuery.MaterialQuery
                 |> RE.andMap (parseMaterialId_ materials id)
                 |> RE.andMap (parseSplit share)
                 |> Result.map (\partiallyApplied -> partiallyApplied Nothing Nothing)
@@ -558,7 +558,7 @@ parseSpinning material spinningString =
                 )
 
 
-validateMaterialList : List Inputs.MaterialQuery -> Result String (List Inputs.MaterialQuery)
+validateMaterialList : List TextileQuery.MaterialQuery -> Result String (List TextileQuery.MaterialQuery)
 validateMaterialList list =
     if list == [] then
         Ok []

--- a/src/Server/Route.elm
+++ b/src/Server/Route.elm
@@ -9,7 +9,7 @@ import Data.Food.Query as BuilderQuery
 import Data.Impact as Impact
 import Data.Impact.Definition as Definition
 import Data.Textile.Db as Textile
-import Data.Textile.Inputs as TextileInputs
+import Data.Textile.Query as TextileQuery
 import Server.Query as Query
 import Server.Request exposing (Request)
 import Static.Db exposing (Db)
@@ -49,11 +49,11 @@ type Route
       --     Textile Product list
     | GetTextileProductList
       --     Textile Simple version of all impacts (GET, query string)
-    | GetTextileSimulator (Result Query.Errors TextileInputs.Query)
+    | GetTextileSimulator (Result Query.Errors TextileQuery.Query)
       --     Textile Detailed version for all impacts (GET, query string)
-    | GetTextileSimulatorDetailed (Result Query.Errors TextileInputs.Query)
+    | GetTextileSimulatorDetailed (Result Query.Errors TextileQuery.Query)
       --     Textile Simple version for one specific impact (GET, query string)
-    | GetTextileSimulatorSingle Definition.Trigram (Result Query.Errors TextileInputs.Query)
+    | GetTextileSimulatorSingle Definition.Trigram (Result Query.Errors TextileQuery.Query)
       --   POST
       --     Textile Simple version of all impacts (POST, JSON body)
     | PostTextileSimulator

--- a/src/Views/Bookmark.elm
+++ b/src/Views/Bookmark.elm
@@ -5,7 +5,7 @@ import Data.Food.Query as FoodQuery
 import Data.Impact.Definition exposing (Definition)
 import Data.Scope as Scope exposing (Scope)
 import Data.Session exposing (Session)
-import Data.Textile.Inputs as TextileInputs
+import Data.Textile.Query as TextileQuery
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (..)
@@ -85,9 +85,9 @@ shareTabView { session, impact, copyToClipBoard, scope } =
                         |> Route.toString
                         |> (++) session.clientUrl
                     , session.queries.textile
-                        |> TextileInputs.buildApiQuery session.clientUrl
+                        |> TextileQuery.buildApiQuery session.clientUrl
                     , session.queries.textile
-                        |> TextileInputs.encodeQuery
+                        |> TextileQuery.encode
                         |> Encode.encode 2
                     )
     in

--- a/src/Views/Textile/Step.elm
+++ b/src/Views/Textile/Step.elm
@@ -20,6 +20,7 @@ import Data.Textile.Material.Origin as Origin
 import Data.Textile.Material.Spinning as Spinning exposing (Spinning)
 import Data.Textile.Printing as Printing exposing (Printing)
 import Data.Textile.Product as Product exposing (Product)
+import Data.Textile.Query exposing (MaterialQuery)
 import Data.Textile.Simulator exposing (stepMaterialImpacts)
 import Data.Textile.Step as Step exposing (Step)
 import Data.Textile.Step.Label as Label exposing (Label)
@@ -68,7 +69,7 @@ type alias Config msg modal =
     , updateMakingComplexity : MakingComplexity -> msg
     , updateMakingDeadStock : Maybe Split -> msg
     , updateMakingWaste : Maybe Split -> msg
-    , updateMaterial : Inputs.MaterialQuery -> Inputs.MaterialQuery -> msg
+    , updateMaterial : MaterialQuery -> MaterialQuery -> msg
     , updateMaterialSpinning : Material -> Spinning -> msg
     , updatePrinting : Maybe Printing -> msg
     , updateSurfaceMass : Maybe Unit.SurfaceMass -> msg
@@ -792,7 +793,7 @@ viewMaterialComplements finalProductMass materialInput =
 createElementSelectorConfig : Config msg modal -> Inputs.MaterialInput -> BaseElement.Config Material Split msg
 createElementSelectorConfig cfg materialInput =
     let
-        materialQuery : Inputs.MaterialQuery
+        materialQuery : MaterialQuery
         materialQuery =
             { id = materialInput.material.id
             , share = materialInput.share

--- a/tests/Data/Textile/InputsTest.elm
+++ b/tests/Data/Textile/InputsTest.elm
@@ -29,7 +29,7 @@ suite =
                     , countryDyeing = Country.Code "CN"
                     , countryMaking = Country.Code "CN"
                   }
-                    |> Inputs.fromQuery db.countries db.textile.materials db.textile.products
+                    |> Inputs.fromQuery db
                     |> Result.map Inputs.countryList
                     |> Result.andThen (LE.getAt 0 >> Maybe.map .code >> Result.fromMaybe "")
                     |> Expect.equal (Ok (Country.codeFromString "CN"))
@@ -39,13 +39,13 @@ suite =
                     , countryDyeing = Country.Code "CN"
                     , countryMaking = Country.Code "CN"
                   }
-                    |> Inputs.fromQuery db.countries db.textile.materials db.textile.products
+                    |> Inputs.fromQuery db
                     |> Expect.equal (Err "Code pays invalide: XX.")
                     |> asTest "should validate country codes"
                 ]
             , let
                 testComplementEqual x =
-                    Inputs.fromQuery db.countries db.textile.materials db.textile.products
+                    Inputs.fromQuery db
                         >> Result.map (Inputs.getOutOfEuropeEOLComplement >> Unit.impactToFloat)
                         >> Result.withDefault 0
                         >> Expect.within (Expect.Absolute 0.001) x
@@ -65,7 +65,7 @@ suite =
                 ]
             , let
                 testComplementEqual x =
-                    Inputs.fromQuery db.countries db.textile.materials db.textile.products
+                    Inputs.fromQuery db
                         >> Result.map (Inputs.getTotalMicrofibersComplement >> Unit.impactToFloat)
                         >> Result.withDefault 0
                         >> Expect.within (Expect.Absolute 0.001) x

--- a/tests/Data/Textile/InputsTest.elm
+++ b/tests/Data/Textile/InputsTest.elm
@@ -2,21 +2,17 @@ module Data.Textile.InputsTest exposing (..)
 
 import Data.Country as Country
 import Data.Split as Split
-import Data.Textile.Inputs as Inputs exposing (defaultQuery, jupeCotonAsie, tShirtCotonFrance)
-import Data.Textile.LifeCycle as LifeCycle
+import Data.Textile.Inputs as Inputs
 import Data.Textile.Material as Material
-import Data.Textile.Product as Product
-import Data.Textile.Simulator as Simulator
-import Data.Textile.Step.Label as Label
+import Data.Textile.Query exposing (Query, default, jupeCotonAsie, tShirtCotonFrance)
 import Data.Unit as Unit
 import Expect
 import List.Extra as LE
-import Quantity
 import Test exposing (..)
 import TestUtils exposing (asTest, suiteWithDb)
 
 
-sampleQuery : Inputs.Query
+sampleQuery : Query
 sampleQuery =
     { jupeCotonAsie
         | materials = [ { id = Material.Id "acrylique", share = Split.full, spinning = Nothing, country = Just (Country.Code "CN") } ]
@@ -27,24 +23,8 @@ suite : Test
 suite =
     suiteWithDb "Data.Inputs"
         (\db ->
-            [ describe "Base64"
-                [ describe "Encoding and decoding queries"
-                    [ sampleQuery
-                        |> Inputs.fromQuery db.countries db.textile.materials db.textile.products
-                        |> Result.map Inputs.toQuery
-                        |> Expect.equal (Ok sampleQuery)
-                        |> asTest "should encode and decode a query"
-                    ]
-                , describe "Base64 encoding and decoding queries"
-                    [ sampleQuery
-                        |> Inputs.b64encode
-                        |> Inputs.b64decode
-                        |> Expect.equal (Ok sampleQuery)
-                        |> asTest "should base64 encode and decode a query"
-                    ]
-                ]
-            , describe "Query countries validation"
-                [ { defaultQuery
+            [ describe "Query countries validation"
+                [ { default
                     | countryFabric = Country.Code "CN"
                     , countryDyeing = Country.Code "CN"
                     , countryMaking = Country.Code "CN"
@@ -54,7 +34,7 @@ suite =
                     |> Result.andThen (LE.getAt 0 >> Maybe.map .code >> Result.fromMaybe "")
                     |> Expect.equal (Ok (Country.codeFromString "CN"))
                     |> asTest "should replace the first country with the material's default country"
-                , { defaultQuery
+                , { default
                     | countryFabric = Country.Code "XX"
                     , countryDyeing = Country.Code "CN"
                     , countryMaking = Country.Code "CN"
@@ -62,20 +42,6 @@ suite =
                     |> Inputs.fromQuery db.countries db.textile.materials db.textile.products
                     |> Expect.equal (Err "Code pays invalide: XX.")
                     |> asTest "should validate country codes"
-                ]
-            , describe "Product update"
-                [ asTest "should update step masses"
-                    (case Product.findById (Product.Id "jean") db.textile.products of
-                        Ok jean ->
-                            defaultQuery
-                                |> Inputs.updateProduct jean
-                                |> Simulator.compute db
-                                |> Result.map (.lifeCycle >> LifeCycle.getStepProp Label.Distribution .inputMass Quantity.zero)
-                                |> Expect.equal (Ok jean.mass)
-
-                        Err error ->
-                            Expect.fail error
-                    )
                 ]
             , let
                 testComplementEqual x =

--- a/tests/Data/Textile/LifeCycleTest.elm
+++ b/tests/Data/Textile/LifeCycleTest.elm
@@ -1,8 +1,9 @@
 module Data.Textile.LifeCycleTest exposing (..)
 
 import Data.Country as Country
-import Data.Textile.Inputs as Inputs exposing (tShirtCotonFrance)
+import Data.Textile.Inputs as Inputs
 import Data.Textile.LifeCycle as LifeCycle exposing (LifeCycle)
+import Data.Textile.Query exposing (Query, tShirtCotonFrance)
 import Expect
 import Length
 import Static.Db exposing (Db)
@@ -15,7 +16,7 @@ km =
     Length.kilometers
 
 
-lifeCycleToTransports : Db -> Inputs.Query -> LifeCycle -> Result String LifeCycle
+lifeCycleToTransports : Db -> Query -> LifeCycle -> Result String LifeCycle
 lifeCycleToTransports db query lifeCycle =
     query
         |> Inputs.fromQuery db.countries db.textile.materials db.textile.products

--- a/tests/Data/Textile/LifeCycleTest.elm
+++ b/tests/Data/Textile/LifeCycleTest.elm
@@ -19,7 +19,7 @@ km =
 lifeCycleToTransports : Db -> Query -> LifeCycle -> Result String LifeCycle
 lifeCycleToTransports db query lifeCycle =
     query
-        |> Inputs.fromQuery db.countries db.textile.materials db.textile.products
+        |> Inputs.fromQuery db
         |> Result.map
             (\materials ->
                 LifeCycle.computeStepsTransport db materials lifeCycle

--- a/tests/Data/Textile/QueryTest.elm
+++ b/tests/Data/Textile/QueryTest.elm
@@ -1,0 +1,60 @@
+module Data.Textile.QueryTest exposing (..)
+
+import Data.Country as Country
+import Data.Split as Split
+import Data.Textile.Inputs as Inputs
+import Data.Textile.LifeCycle as LifeCycle
+import Data.Textile.Material as Material
+import Data.Textile.Product as Product
+import Data.Textile.Query as Query exposing (Query, default, jupeCotonAsie)
+import Data.Textile.Simulator as Simulator
+import Data.Textile.Step.Label as Label
+import Expect
+import Quantity
+import Test exposing (..)
+import TestUtils exposing (asTest, suiteWithDb)
+
+
+sampleQuery : Query
+sampleQuery =
+    { jupeCotonAsie
+        | materials = [ { id = Material.Id "acrylique", share = Split.full, spinning = Nothing, country = Just (Country.Code "CN") } ]
+    }
+
+
+suite : Test
+suite =
+    suiteWithDb "Data.Inputs"
+        (\db ->
+            [ describe "Base64"
+                [ describe "Encoding and decoding queries"
+                    [ sampleQuery
+                        |> Inputs.fromQuery db.countries db.textile.materials db.textile.products
+                        |> Result.map Inputs.toQuery
+                        |> Expect.equal (Ok sampleQuery)
+                        |> asTest "should encode and decode a query"
+                    ]
+                , describe "Base64 encoding and decoding queries"
+                    [ sampleQuery
+                        |> Query.b64encode
+                        |> Query.b64decode
+                        |> Expect.equal (Ok sampleQuery)
+                        |> asTest "should base64 encode and decode a query"
+                    ]
+                ]
+            , describe "Product update"
+                [ asTest "should update step masses"
+                    (case Product.findById (Product.Id "jean") db.textile.products of
+                        Ok jean ->
+                            default
+                                |> Query.updateProduct jean
+                                |> Simulator.compute db
+                                |> Result.map (.lifeCycle >> LifeCycle.getStepProp Label.Distribution .inputMass Quantity.zero)
+                                |> Expect.equal (Ok jean.mass)
+
+                        Err error ->
+                            Expect.fail error
+                    )
+                ]
+            ]
+        )

--- a/tests/Data/Textile/QueryTest.elm
+++ b/tests/Data/Textile/QueryTest.elm
@@ -29,7 +29,7 @@ suite =
             [ describe "Base64"
                 [ describe "Encoding and decoding queries"
                     [ sampleQuery
-                        |> Inputs.fromQuery db.countries db.textile.materials db.textile.products
+                        |> Inputs.fromQuery db
                         |> Result.map Inputs.toQuery
                         |> Expect.equal (Ok sampleQuery)
                         |> asTest "should encode and decode a query"

--- a/tests/Data/Textile/SimulatorTest.elm
+++ b/tests/Data/Textile/SimulatorTest.elm
@@ -2,8 +2,8 @@ module Data.Textile.SimulatorTest exposing (..)
 
 import Data.Impact as Impact
 import Data.Impact.Definition as Definition
-import Data.Textile.Inputs as Inputs exposing (..)
 import Data.Textile.LifeCycle as LifeCycle
+import Data.Textile.Query exposing (Query, tShirtCotonFrance)
 import Data.Textile.Simulator as Simulator
 import Data.Textile.Step.Label as Label
 import Data.Unit as Unit
@@ -13,7 +13,7 @@ import Test exposing (..)
 import TestUtils exposing (asTest, suiteWithDb)
 
 
-getImpact : Db -> Definition.Trigram -> Inputs.Query -> Result String Float
+getImpact : Db -> Definition.Trigram -> Query -> Result String Float
 getImpact db trigram =
     Simulator.compute db
         >> Result.map
@@ -23,7 +23,7 @@ getImpact db trigram =
             )
 
 
-expectImpact : Db -> Definition.Trigram -> Float -> Inputs.Query -> Expectation
+expectImpact : Db -> Definition.Trigram -> Float -> Query -> Expectation
 expectImpact db trigram value query =
     case getImpact db trigram query of
         Ok result ->

--- a/tests/Server/RouteTest.elm
+++ b/tests/Server/RouteTest.elm
@@ -5,10 +5,10 @@ import Data.Food.Fixtures as Fixtures
 import Data.Food.Query as FoodQuery
 import Data.Impact.Definition as Definition
 import Data.Split as Split
-import Data.Textile.Inputs as Inputs exposing (Query, tShirtCotonFrance)
 import Data.Textile.Material as Material
 import Data.Textile.Material.Origin as Origin
 import Data.Textile.Material.Spinning as Spinning
+import Data.Textile.Query as Query exposing (Query, tShirtCotonFrance)
 import Data.Textile.Step.Label as Label
 import Dict exposing (Dict)
 import Expect
@@ -217,7 +217,7 @@ textileEndpoints db =
         ]
     , describe "POST endpoints"
         [ "/textile/simulator"
-            |> testEndpoint db "POST" (Inputs.encodeQuery tShirtCotonFrance)
+            |> testEndpoint db "POST" (Query.encode tShirtCotonFrance)
             |> Expect.equal (Just Route.PostTextileSimulator)
             |> asTest "should map the POST /textile/simulator endpoint"
         , "/textile/simulator"
@@ -394,7 +394,7 @@ testEndpoint dbs method body url =
         }
 
 
-extractQuery : Route.Route -> Maybe Inputs.Query
+extractQuery : Route.Route -> Maybe Query
 extractQuery route =
     case route of
         Route.GetTextileSimulator (Ok query) ->


### PR DESCRIPTION
[Tech Debt] This patch splits the textile `Query` stuff from `Inputs` and moves it to a new dedicated module. This avoids an annoying cycling dependency issue when importing the static `Db` in the `Inputs` module. Also this matches what is done for Food with the `Recipe` and `Query` modules.