### PR TITLE
Fail test suite when product examples are invalid.

### DIFF
--- a/src/Data/Food/Query.elm
+++ b/src/Data/Food/Query.elm
@@ -10,7 +10,7 @@ module Data.Food.Query exposing
     , decode
     , deleteIngredient
     , deletePreparation
-    , emptyQuery
+    , empty
     , encode
     , parseBase64Query
     , serialize
@@ -175,6 +175,16 @@ deleteIngredient id query =
             query.ingredients |> List.filter (.id >> (/=) id)
     }
         |> updateTransformMass
+
+
+empty : Query
+empty =
+    { ingredients = []
+    , transform = Nothing
+    , packaging = []
+    , distribution = Nothing
+    , preparation = []
+    }
 
 
 encode : Query -> Encode.Value
@@ -353,13 +363,3 @@ parseBase64Query =
         b64decode
             >> Result.toMaybe
             >> Just
-
-
-emptyQuery : Query
-emptyQuery =
-    { ingredients = []
-    , transform = Nothing
-    , packaging = []
-    , distribution = Nothing
-    , preparation = []
-    }

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -94,7 +94,7 @@ init flags url navKey =
                             , matomo = flags.matomo
                             , notifications = []
                             , queries =
-                                { food = FoodQuery.emptyQuery
+                                { food = FoodQuery.empty
                                 , textile = TextileQuery.default
                                 }
                             }

--- a/src/Page/Food.elm
+++ b/src/Page/Food.elm
@@ -532,7 +532,7 @@ selectExample autocompleteState ( model, session, _ ) =
     let
         example =
             Autocomplete.selectedValue autocompleteState
-                |> Maybe.withDefault Query.emptyQuery
+                |> Maybe.withDefault Query.empty
 
         msg =
             LoadQuery example

--- a/tests/Data/Textile/QueryTest.elm
+++ b/tests/Data/Textile/QueryTest.elm
@@ -24,7 +24,7 @@ sampleQuery =
 
 suite : Test
 suite =
-    suiteWithDb "Data.Inputs"
+    suiteWithDb "Data.Query"
         (\db ->
             [ describe "Base64"
                 [ describe "Encoding and decoding queries"

--- a/tests/Server/RouteTest.elm
+++ b/tests/Server/RouteTest.elm
@@ -72,7 +72,7 @@ foodEndpoints db =
         ]
     , describe "POST endpoints"
         [ "/food/recipe"
-            |> testEndpoint db "POST" (FoodQuery.encode FoodQuery.emptyQuery)
+            |> testEndpoint db "POST" (FoodQuery.encode FoodQuery.empty)
             |> Expect.equal (Just Route.PostFoodRecipe)
             |> asTest "should map the POST /food/recipe endpoint"
         , "/food/recipe"

--- a/tests/Server/ServerTest.elm
+++ b/tests/Server/ServerTest.elm
@@ -52,7 +52,7 @@ suite =
                     |> Expect.equal 400
                     |> asTest "should reject an invalid POST query"
                 , "/food/recipe"
-                    |> request "POST" (FoodQuery.encode FoodQuery.emptyQuery)
+                    |> request "POST" (FoodQuery.encode FoodQuery.empty)
                     |> Server.handleRequest dbs
                     |> Tuple.first
                     |> Expect.equal 200

--- a/tests/server.spec.js
+++ b/tests/server.spec.js
@@ -344,6 +344,7 @@ describe("API", () => {
       for (const { name, query } of textileExamples) {
         it(name, async () => {
           const response = await makePostRequest("/api/textile/simulator", query);
+          expect(response.body.error).toBeUndefined();
           expectStatus(response, 200);
         });
       }
@@ -532,6 +533,7 @@ describe("API", () => {
       for (const { name, query } of foodExamples) {
         it(name, async () => {
           const response = await makePostRequest("/api/food/recipe", query);
+          expect(response.body.error).toBeUndefined();
           expectStatus(response, 200);
         });
       }

--- a/tests/server.spec.js
+++ b/tests/server.spec.js
@@ -322,7 +322,7 @@ describe("API", () => {
     });
 
     describe("End to end textile simulations", () => {
-      const e2eTextile = JSON.parse(fs.readFileSync(`${__dirname}/e2e-textile.json`).toString());
+      const e2eTextile = require(`${__dirname}/e2e-textile.json`);
 
       for (const { name, query, impacts } of e2eTextile) {
         it(name, async () => {
@@ -334,6 +334,17 @@ describe("API", () => {
             impacts: response.body.impacts,
           });
           expect(response.body.impacts).toEqual(impacts);
+        });
+      }
+    });
+
+    describe("Textile product examples checks", () => {
+      const textileExamples = require(`${__dirname}/../public/data/textile/examples.json`);
+
+      for (const { name, query } of textileExamples) {
+        it(name, async () => {
+          const response = await makePostRequest("/api/textile/simulator", query);
+          expectStatus(response, 200);
         });
       }
     });
@@ -497,7 +508,7 @@ describe("API", () => {
     });
 
     describe("End to end food simulations", () => {
-      const e2eFood = JSON.parse(fs.readFileSync(`${__dirname}/e2e-food.json`).toString());
+      const e2eFood = require(`${__dirname}/e2e-food.json`);
 
       for (const { name, query, impacts, scoring } of e2eFood) {
         it(name, async () => {
@@ -515,52 +526,15 @@ describe("API", () => {
       }
     });
 
-    describe("Food ingredients ecoscore deviation", () => {
-      async function requestDev(path, body) {
-        return await request(app).post(path).send(body);
-      }
+    describe("Food product examples checks", () => {
+      const foodExamples = require(`${__dirname}/../public/data/food/examples.json`);
 
-      async function requestProd(path, body) {
-        return await superagent
-          .post(`https://ecobalyse.beta.gouv.fr${path}`)
-          .send(body)
-          .set("accept", "json");
+      for (const { name, query } of foodExamples) {
+        it(name, async () => {
+          const response = await makePostRequest("/api/food/recipe", query);
+          expectStatus(response, 200);
+        });
       }
-
-      // The purpose of these checks is to ensure we don't inadvertandly introduce
-      // unoticed large deviations for ingredients impacts.
-      // Procedure in case of test failure:
-      // - check if the large deviation is legit or not
-      // - if it's not, fix it
-      // - if it's intended, comment the test below, commit, push
-      // - merge your branch onto master
-      // - uncomment this test on master, commit, push
-      // - done.
-      //for (const { id } of ingredients.filter(({ visible }) => visible)) {
-      //  it(`${id} should not have ecoscore deviating with production more than 5%`, async () => {
-      //    const path = "/api/food/recipe";
-      //    const query = { ingredients: [{ id, mass: 0.1 }] };
-      //    try {
-      //      const dev = await requestDev(path, query);
-      //      const prod = await requestProd(path, query);
-      //      const devEcs = dev.body.results.total.ecs;
-      //      const prodEcs = prod.body.results.total.ecs;
-      //      const deviation = 100 - (devEcs / prodEcs) * 100;
-      //      expect(deviation).toBeLessThan(5);
-      //    } catch (err) {
-      //      // Check for an HTTP error
-      //      if (err.status && err.response && err.response.text) {
-      //        // Only process ingredients existing in production, skip otherwise
-      //        if (!err.response.text.includes(`Ingrédient introuvable par id : ${id}`)) {
-      //          throw `${err.status} ${err.message}: ${err.response.text}`;
-      //        }
-      //      } else {
-      //        // Not an HTTP error, re-raise
-      //        throw err;
-      //      }
-      //    }
-      //  });
-      //}
     });
   });
 });


### PR DESCRIPTION
[User Story](https://www.notion.so/Ajouter-une-v-rification-de-validit-des-exemples-de-produits-a722f2317ee142f2a3bb668c901b1594)

The idea is to fail the test suite on any invalid product example so we can be notified about it.

Sample failure output example:

![image](https://github.com/MTES-MCT/ecobalyse/assets/41547/dcb910bf-8205-436c-8dde-831b61a6a563)
