### PR TITLE
Temporarily hide login/out & food links, remove food API docs.

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -290,160 +290,160 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/InvalidParametersError"
-  /food/countries:
-    get:
-      tags:
-        - Alimentaire
-      summary: Liste des pays utilisables pour les simulations alimentairess.
-      responses:
-        200:
-          description: Opération réussie
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/CountryListResponse"
-  /food/ingredients:
-    get:
-      tags:
-        - Alimentaire
-      summary: Liste des ingrédients disponibles pour élaborer une recette
-      responses:
-        200:
-          description: Opération réussie
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/IngredientListResponse"
-  /food/transforms:
-    get:
-      tags:
-        - Alimentaire
-      summary: Liste des procédés de transformation alimentaire
-      responses:
-        200:
-          description: Opération réussie
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/TransformListResponse"
-  /food/packagings:
-    get:
-      tags:
-        - Alimentaire
-      summary: Liste des emballages disponibles pour conditionner une recette
-      responses:
-        200:
-          description: Opération réussie
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/PackagingListResponse"
-  /food/recipe:
-    get:
-      tags:
-        - Alimentaire
-      summary: Calcul des impacts environnementaux d'une recette alimentaire
-      parameters:
-        - $ref: "#/components/parameters/ingredientsParam"
-        - $ref: "#/components/parameters/transformParam"
-        - $ref: "#/components/parameters/packagingParam"
-        - $ref: "#/components/parameters/distributionParam"
-        - $ref: "#/components/parameters/preparationParam"
-      responses:
-        200:
-          description: Opération réussie
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/RecipeResultsResponse"
-        400:
-          description: Paramètres invalides
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/InvalidParametersError"
-    post:
-      tags:
-        - Alimentaire
-      summary: Calcul des impacts environnementaux d'une recette alimentaire
-      requestBody:
-        description: Requête modélisant les éléments de la recette à évaluer
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/FoodQuery"
-            examples:
-              CarrotCake:
-                summary: "Carrot cake conventionnel"
-                value:
-                  ingredients:
-                  - id: egg
-                    mass: 120
-                  - id: wheat
-                    mass: 140
-                  - id: milk
-                    mass: 60
-                  - id: carrot
-                    mass: 225
-                  transform:
-                    code: AGRIBALU000000003103966
-                    mass: 545
-                  packaging:
-                  - code: AGRIBALU000000003104019
-                    mass: 105
-                  distribution: ambient
-                  preparation:
-                  - refrigeration
-              SpanishOrganicCarrotCake:
-                summary: "Carrot cake bio, origine Espagne"
-                value:
-                  ingredients:
-                  - id: egg-organic
-                    mass: 120
-                    country: ES
-                  - id: wheat-organic
-                    mass: 140
-                    country: ES
-                  - id: milk-organic
-                    mass: 60
-                    country: ES
-                  - id: carrot-organic
-                    mass: 225
-                    country: ES
-                  transform:
-                    code: AGRIBALU000000003103966
-                    mass: 545
-                  packaging:
-                  - code: AGRIBALU000000003104019
-                    mass: 105
-                  distribution: ambient
-                  preparation:
-                  - refrigeration
-              BrazilianMango:
-                summary: "Mangue du Brésil"
-                value:
-                  ingredients:
-                  - id: mango
-                    mass: 500
-                    country: BR
-                  transform: null
-                  packaging: []
-                  distribution: ambient
-                  preparation: []
-      responses:
-        200:
-          description: Opération réussie
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/RecipeResultsResponse"
-        400:
-          description: Paramètres invalides
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/InvalidParametersError"
+  # /food/countries:
+  #   get:
+  #     tags:
+  #       - Alimentaire
+  #     summary: Liste des pays utilisables pour les simulations alimentairess.
+  #     responses:
+  #       200:
+  #         description: Opération réussie
+  #         content:
+  #           application/json:
+  #             schema:
+  #               $ref: "#/components/schemas/CountryListResponse"
+  # /food/ingredients:
+  #   get:
+  #     tags:
+  #       - Alimentaire
+  #     summary: Liste des ingrédients disponibles pour élaborer une recette
+  #     responses:
+  #       200:
+  #         description: Opération réussie
+  #         content:
+  #           application/json:
+  #             schema:
+  #               $ref: "#/components/schemas/IngredientListResponse"
+  # /food/transforms:
+  #   get:
+  #     tags:
+  #       - Alimentaire
+  #     summary: Liste des procédés de transformation alimentaire
+  #     responses:
+  #       200:
+  #         description: Opération réussie
+  #         content:
+  #           application/json:
+  #             schema:
+  #               $ref: "#/components/schemas/TransformListResponse"
+  # /food/packagings:
+  #   get:
+  #     tags:
+  #       - Alimentaire
+  #     summary: Liste des emballages disponibles pour conditionner une recette
+  #     responses:
+  #       200:
+  #         description: Opération réussie
+  #         content:
+  #           application/json:
+  #             schema:
+  #               $ref: "#/components/schemas/PackagingListResponse"
+  # /food/recipe:
+  #   get:
+  #     tags:
+  #       - Alimentaire
+  #     summary: Calcul des impacts environnementaux d'une recette alimentaire
+  #     parameters:
+  #       - $ref: "#/components/parameters/ingredientsParam"
+  #       - $ref: "#/components/parameters/transformParam"
+  #       - $ref: "#/components/parameters/packagingParam"
+  #       - $ref: "#/components/parameters/distributionParam"
+  #       - $ref: "#/components/parameters/preparationParam"
+  #     responses:
+  #       200:
+  #         description: Opération réussie
+  #         content:
+  #           application/json:
+  #             schema:
+  #               $ref: "#/components/schemas/RecipeResultsResponse"
+  #       400:
+  #         description: Paramètres invalides
+  #         content:
+  #           application/json:
+  #             schema:
+  #               $ref: "#/components/schemas/InvalidParametersError"
+  #   post:
+  #     tags:
+  #       - Alimentaire
+  #     summary: Calcul des impacts environnementaux d'une recette alimentaire
+  #     requestBody:
+  #       description: Requête modélisant les éléments de la recette à évaluer
+  #       required: true
+  #       content:
+  #         application/json:
+  #           schema:
+  #             $ref: "#/components/schemas/FoodQuery"
+  #           examples:
+  #             CarrotCake:
+  #               summary: "Carrot cake conventionnel"
+  #               value:
+  #                 ingredients:
+  #                 - id: egg
+  #                   mass: 120
+  #                 - id: wheat
+  #                   mass: 140
+  #                 - id: milk
+  #                   mass: 60
+  #                 - id: carrot
+  #                   mass: 225
+  #                 transform:
+  #                   code: AGRIBALU000000003103966
+  #                   mass: 545
+  #                 packaging:
+  #                 - code: AGRIBALU000000003104019
+  #                   mass: 105
+  #                 distribution: ambient
+  #                 preparation:
+  #                 - refrigeration
+  #             SpanishOrganicCarrotCake:
+  #               summary: "Carrot cake bio, origine Espagne"
+  #               value:
+  #                 ingredients:
+  #                 - id: egg-organic
+  #                   mass: 120
+  #                   country: ES
+  #                 - id: wheat-organic
+  #                   mass: 140
+  #                   country: ES
+  #                 - id: milk-organic
+  #                   mass: 60
+  #                   country: ES
+  #                 - id: carrot-organic
+  #                   mass: 225
+  #                   country: ES
+  #                 transform:
+  #                   code: AGRIBALU000000003103966
+  #                   mass: 545
+  #                 packaging:
+  #                 - code: AGRIBALU000000003104019
+  #                   mass: 105
+  #                 distribution: ambient
+  #                 preparation:
+  #                 - refrigeration
+  #             BrazilianMango:
+  #               summary: "Mangue du Brésil"
+  #               value:
+  #                 ingredients:
+  #                 - id: mango
+  #                   mass: 500
+  #                   country: BR
+  #                 transform: null
+  #                 packaging: []
+  #                 distribution: ambient
+  #                 preparation: []
+  #     responses:
+  #       200:
+  #         description: Opération réussie
+  #         content:
+  #           application/json:
+  #             schema:
+  #               $ref: "#/components/schemas/RecipeResultsResponse"
+  #       400:
+  #         description: Paramètres invalides
+  #         content:
+  #           application/json:
+  #             schema:
+  #               $ref: "#/components/schemas/InvalidParametersError"
 components:
   examples:
     tShirtFrance:

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -170,6 +170,9 @@ setRoute url ( { state } as model, cmds ) =
                     FoodBuilder.init session trigram maybeQuery
                         |> toPage FoodBuilderPage FoodBuilderMsg
 
+                Just Route.Login ->
+                    ( model, Session.login LoggedIn )
+
                 Just Route.Stats ->
                     Stats.init session
                         |> toPage StatsPage StatsMsg

--- a/src/Page/Api.elm
+++ b/src/Page/Api.elm
@@ -54,7 +54,12 @@ getApiServerUrl { clientUrl } =
 
 changelog : List News
 changelog =
-    [ { date = "21 février 2024"
+    [ { date = "25 mars 2024"
+      , level = "major"
+      , domains = [ "Alimentaire" ]
+      , md = "La documentation de l'API alimentaire est temporairement mise hors-ligne."
+      }
+    , { date = "21 février 2024"
       , level = "major"
       , domains = [ "Textile" ]
       , md =

--- a/src/Page/Explore.elm
+++ b/src/Page/Explore.elm
@@ -185,8 +185,8 @@ scopesMenuView model =
                     ]
             )
         |> (::) (strong [ class "d-block d-sm-inline" ] [ text "Secteur d'activité" ])
-        |> nav
-            []
+        -- FIXME: all food-related stuff temporarily hidden
+        |> nav [ class "d-none" ]
 
 
 detailsModal : Html Msg -> Html Msg
@@ -502,7 +502,7 @@ view session model =
     , [ Container.centered [ class "pb-3" ]
             [ div []
                 [ h1 [] [ text "Explorateur" ]
-                , div [ class "row d-flex align-items-stretch mt-5 mx-0" ]
+                , div [ class "row d-flex align-items-stretch mt-1 mx-0" ]
                     [ div [ class "col-12 col-lg-5 d-flex align-items-center pb-2 pb-lg-0 mb-4 mb-lg-0 border-bottom ps-0 ms-0" ] [ scopesMenuView model ]
                     , div [ class "col-12 col-lg-7 pe-0 me-0" ] [ datasetsMenuView model ]
                     ]

--- a/src/Page/Home.elm
+++ b/src/Page/Home.elm
@@ -71,9 +71,12 @@ viewHero modal =
             , div [ class "fs-5 mt-3 mb-5" ]
                 [ text "Ecobalyse permet de comprendre et de calculer les impacts écologiques des produits distribués en France." ]
             , div [ class "d-flex flex-column flex-sm-row gap-3 mb-4" ]
-                [ button
+                [ a
                     [ class "btn btn-lg btn-primary"
-                    , onClick OpenCalculatorPickerModal
+
+                    -- FIXME: all food-related stuff temporarily removed
+                    --, onClick OpenCalculatorPickerModal
+                    , Route.href Route.TextileSimulatorHome
                     ]
                     [ text "Lancer le calculateur" ]
                 , button

--- a/src/Route.elm
+++ b/src/Route.elm
@@ -57,10 +57,9 @@ parser =
         --
         -- Food specific routes
         --
-        , Parser.map FoodBuilderHome (Parser.s "food" </> Parser.s "build")
+        , Parser.map FoodBuilderHome (Parser.s "food")
         , Parser.map FoodBuilder
             (Parser.s "food"
-                </> Parser.s "build"
                 </> Impact.parseTrigram
                 </> FoodQuery.parseBase64Query
             )

--- a/src/Route.elm
+++ b/src/Route.elm
@@ -25,6 +25,7 @@ type Route
     | Explore Scope Dataset
     | FoodBuilderHome
     | FoodBuilder Definition.Trigram (Maybe FoodQuery.Query)
+    | Login
     | TextileSimulatorHome
     | TextileSimulator Definition.Trigram (Maybe TextileQuery.Query)
     | Stats
@@ -41,6 +42,9 @@ parser =
         , Parser.map Changelog (Parser.s "changelog")
         , Parser.map Editorial (Parser.s "pages" </> Parser.string)
         , Parser.map Stats (Parser.s "stats")
+
+        -- Login (FIXME: this is a temporary route, remove after launch)
+        , Parser.map Login (Parser.s "login")
 
         --  Explorer
         , Parser.map (\scope -> Explore scope (Dataset.Impacts Nothing))
@@ -72,12 +76,11 @@ parseTextileSimulator : Parser (Route -> a) a
 parseTextileSimulator =
     Parser.oneOf
         [ deprecatedTextileRouteParser
-        , (Parser.s "textile"
-            </> Parser.s "simulator"
-            </> Impact.parseTrigram
-            </> TextileQuery.parseBase64Query
-          )
-            |> Parser.map TextileSimulator
+        , Parser.map TextileSimulator <|
+            Parser.s "textile"
+                </> Parser.s "simulator"
+                </> Impact.parseTrigram
+                </> TextileQuery.parseBase64Query
         ]
 
 
@@ -86,16 +89,15 @@ deprecatedTextileRouteParser =
     -- We keep this parser for backwards compatible reasons: we used to have the choice
     -- for a view mode between `simple` and `detailed`, but now it's only `simple`,
     -- and we used to have a functional unit parameter
-    (Parser.s "textile"
-        </> Parser.s "simulator"
-        </> Impact.parseTrigram
-        -- This is the unused "functional unit" parameter
-        </> Parser.string
-        -- This is the unused "viewmode" parameter
-        </> Parser.string
-        </> TextileQuery.parseBase64Query
-    )
-        |> Parser.map (\trigram _ _ query -> TextileSimulator trigram query)
+    Parser.map (\trigram _ _ query -> TextileSimulator trigram query) <|
+        Parser.s "textile"
+            </> Parser.s "simulator"
+            </> Impact.parseTrigram
+            -- This is the unused "functional unit" parameter
+            </> Parser.string
+            -- This is the unused "viewmode" parameter
+            </> Parser.string
+            </> TextileQuery.parseBase64Query
 
 
 toExploreWithId : Scope -> Dataset -> String -> Route
@@ -174,6 +176,9 @@ toString route =
 
                 FoodBuilder trigram (Just query) ->
                     [ "food", "build", Definition.toString trigram, FoodQuery.b64encode query ]
+
+                Login ->
+                    [ "login" ]
 
                 TextileSimulatorHome ->
                     [ "textile", "simulator" ]

--- a/src/Views/Page.elm
+++ b/src/Views/Page.elm
@@ -306,7 +306,9 @@ pageHeader config =
                                 button [ class "nav-link flex-fill text-end", onClick config.logout ] [ text "Déconnexion" ]
 
                              else
-                                button [ class "nav-link flex-fill text-end", onClick config.login ] [ text "Connexion" ]
+                                -- FIXME: login and out links are temprarily hidden by default
+                                -- button [ class "nav-link flex-fill text-end", onClick config.login ] [ text "Connexion" ]
+                                text ""
                            ]
                         |> div [ class "HeaderNavigation d-none d-sm-flex navbar-nav flex-row overflow-auto" ]
                     ]

--- a/src/Views/Page.elm
+++ b/src/Views/Page.elm
@@ -132,7 +132,9 @@ mainMenuLinks : List MenuLink
 mainMenuLinks =
     [ Internal "Accueil" Route.Home Home
     , Internal "Textile" Route.TextileSimulatorHome TextileSimulator
-    , Internal "Alimentaire" Route.FoodBuilderHome FoodBuilder
+
+    -- FIXME: all food-related stuff temporarily removed
+    -- , Internal "Alimentaire" Route.FoodBuilderHome FoodBuilder
     , Internal "Explorateur" (Route.Explore Scope.Textile (Dataset.Impacts Nothing)) Explore
     , Internal "API" Route.Api Api
     ]
@@ -188,7 +190,7 @@ pageFooter { currentVersion } =
                         [ text label ]
 
                 MailTo label email ->
-                    a [ class "text-decoration-none link-email", href <| "mailto:" ++ email ]
+                    a [ class "text-decoration-none", href <| "mailto:" ++ email ]
                         [ text label ]
     in
     footer [ class "Footer" ]


### PR DESCRIPTION
This is part of the ongoing v2 work ([card](https://www.notion.so/Pr-paration-mise-en-ligne-V2Beta-textile-04bc56c5436e407ab093469250f15a52)). Note to the curious reader: these will be reinstated later on.

- [x] Hide domain selector in the homepage, defaults to Textile
- [x] Hide Food link in the header 
- [x] Hide Food link in the footer
- [x] Hide domain selector in the explorer
- [x] Hide Food API documentation (endpoints still active)
- [x] Hide login link, add an autologin route (`/#/login`)
- [x] Update internal food route path