### PR TITLE
Fix style issue with the `selector-example`

### DIFF
--- a/styles.scss
+++ b/styles.scss
@@ -181,17 +181,13 @@ input[type="number"].no-arrows {
 }
 
 .form-select {
-  min-height: 37px;
-  line-height: initial;
-  &-sm {
-    min-height: 31px;
-  }
   &:disabled {
     opacity: 0.65;
   }
 }
 
 .form-select, .form-control, .input-group-text {
+  line-height: initial;
   border: 0 !important;
   box-shadow: inset 0 -2px 0 0 #3a3a3a;
 }


### PR DESCRIPTION
Hi, there was a little style issue with the `selector-example`:

![image](https://github.com/MTES-MCT/ecobalyse/assets/44124798/3eaad3d2-6445-438a-9503-012c561868ff)

After:

![image](https://github.com/MTES-MCT/ecobalyse/assets/44124798/f053adc4-db32-4731-b935-011444478ec3)
