### PR TITLE
Use API token in OpenAPI interactive documentation page.

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ const app = Elm.Main.init({
   flags: {
     clientUrl: location.origin + location.pathname,
     enableFoodSection: process.env.ENABLE_FOOD_SECTION === "True",
-    rawStore: localStorage[storeKey] || "",
+    rawStore: localStorage[storeKey] || "null",
     matomo: {
       host: process.env.MATOMO_HOST || "",
       siteId: process.env.MATOMO_SITE_ID || "",

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -27,6 +27,8 @@ tags:
     externalDocs:
       description: À propos
       url: https://fabrique-numerique.gitbook.io/ecobalyse
+security:
+  - token: []
 paths:
   /:
     get:
@@ -445,6 +447,15 @@ paths:
   #             schema:
   #               $ref: "#/components/schemas/InvalidParametersError"
 components:
+  securitySchemes:
+    token:
+      description: >
+        Ce token d'API, permettant d'obtenir les impacts détaillés des calculs effectués,
+        peut être obtenu après [inscription préalable](https://ecobalyse.beta.gouv.fr/#/auth)
+        sur le site Ecobalyse. Vous trouverez le token dans la section *Mon compte*.
+      type: apiKey
+      name: token
+      in: header
   examples:
     tShirtFrance:
       summary: "T-Shirt France 100% Coton"

--- a/src/Data/Session.elm
+++ b/src/Data/Session.elm
@@ -367,7 +367,7 @@ logout ({ store } as session) =
                 |> notifyError "Impossible de recharger la db avec les procédés par défaut" err
 
 
-isAuthenticated : { a | store : Store } -> Bool
+isAuthenticated : Session -> Bool
 isAuthenticated { store } =
     case store.auth of
         Authenticated _ _ _ ->

--- a/src/Data/Session.elm
+++ b/src/Data/Session.elm
@@ -1,6 +1,5 @@
 module Data.Session exposing
     ( AllProcessesJson
-    , Auth(..)
     , Notification(..)
     , Session
     , Store
@@ -9,7 +8,7 @@ module Data.Session exposing
     , closeNotification
     , deleteBookmark
     , deserializeStore
-    , getUserApiToken
+    , getUser
     , isAuthenticated
     , login
     , logout
@@ -256,11 +255,11 @@ encodeAuth auth =
                 ]
 
 
-getUserApiToken : Session -> Maybe String
-getUserApiToken session =
-    case session.store.auth of
+getUser : Session -> Maybe User
+getUser { store } =
+    case store.auth of
         Authenticated user _ _ ->
-            Just user.token
+            Just user
 
         NotAuthenticated ->
             Nothing

--- a/src/Data/User.elm
+++ b/src/Data/User.elm
@@ -1,0 +1,28 @@
+module Data.User exposing
+    ( User
+    , decode
+    )
+
+import Json.Decode as Decode exposing (Decoder)
+import Json.Decode.Pipeline as Pipe
+
+
+type alias User =
+    { email : String
+    , firstname : String
+    , lastname : String
+    , company : String
+    , cgu : Bool
+    , token : String
+    }
+
+
+decode : Decoder User
+decode =
+    Decode.succeed User
+        |> Pipe.required "email" Decode.string
+        |> Pipe.required "first_name" Decode.string
+        |> Pipe.required "last_name" Decode.string
+        |> Pipe.optional "organization" Decode.string ""
+        |> Pipe.required "terms_of_use" Decode.bool
+        |> Pipe.required "token" Decode.string

--- a/src/Data/User.elm
+++ b/src/Data/User.elm
@@ -25,7 +25,7 @@ decode =
         |> Pipe.required "email" Decode.string
         |> Pipe.required "first_name" Decode.string
         |> Pipe.required "last_name" Decode.string
-        |> Pipe.required "organization" Decode.string
+        |> Pipe.optional "organization" Decode.string ""
         |> Pipe.required "terms_of_use" Decode.bool
         |> Pipe.required "token" Decode.string
 

--- a/src/Data/User.elm
+++ b/src/Data/User.elm
@@ -1,10 +1,12 @@
 module Data.User exposing
     ( User
     , decode
+    , encode
     )
 
 import Json.Decode as Decode exposing (Decoder)
 import Json.Decode.Pipeline as Pipe
+import Json.Encode as Encode
 
 
 type alias User =
@@ -26,3 +28,14 @@ decode =
         |> Pipe.optional "organization" Decode.string ""
         |> Pipe.required "terms_of_use" Decode.bool
         |> Pipe.required "token" Decode.string
+
+
+encode : User -> Encode.Value
+encode user =
+    Encode.object
+        [ ( "email", Encode.string user.email )
+        , ( "first_name", Encode.string user.firstname )
+        , ( "last_name", Encode.string user.lastname )
+        , ( "organization", Encode.string user.company )
+        , ( "terms_of_use", Encode.bool user.cgu )
+        ]

--- a/src/Data/User.elm
+++ b/src/Data/User.elm
@@ -25,7 +25,7 @@ decode =
         |> Pipe.required "email" Decode.string
         |> Pipe.required "first_name" Decode.string
         |> Pipe.required "last_name" Decode.string
-        |> Pipe.optional "organization" Decode.string ""
+        |> Pipe.required "organization" Decode.string
         |> Pipe.required "terms_of_use" Decode.bool
         |> Pipe.required "token" Decode.string
 
@@ -38,4 +38,5 @@ encode user =
         , ( "last_name", Encode.string user.lastname )
         , ( "organization", Encode.string user.company )
         , ( "terms_of_use", Encode.bool user.cgu )
+        , ( "token", Encode.string user.token )
         ]

--- a/src/Page/Api.elm
+++ b/src/Page/Api.elm
@@ -445,6 +445,9 @@ apiBrowser session =
         , attribute "allow-authentication" "false"
         , attribute "allow-server-selection" "false"
         , attribute "allow-api-list-style-selection" "false"
+        , attribute "api-key-name" "token"
+        , attribute "api-key-location" "header"
+        , attribute "api-key-value" "-"
         ]
         []
 

--- a/src/Page/Api.elm
+++ b/src/Page/Api.elm
@@ -6,7 +6,7 @@ module Page.Api exposing
     , view
     )
 
-import Data.Session exposing (Session)
+import Data.Session as Session exposing (Session)
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Ports
@@ -447,7 +447,7 @@ apiBrowser session =
         , attribute "allow-api-list-style-selection" "false"
         , attribute "api-key-name" "token"
         , attribute "api-key-location" "header"
-        , attribute "api-key-value" "-"
+        , attribute "api-key-value" (Session.getUserApiToken session |> Maybe.withDefault "-")
         ]
         []
 

--- a/src/Page/Api.elm
+++ b/src/Page/Api.elm
@@ -447,7 +447,11 @@ apiBrowser session =
         , attribute "allow-api-list-style-selection" "false"
         , attribute "api-key-name" "token"
         , attribute "api-key-location" "header"
-        , attribute "api-key-value" (Session.getUserApiToken session |> Maybe.withDefault "-")
+        , session
+            |> Session.getUser
+            |> Maybe.map .token
+            |> Maybe.withDefault "-"
+            |> attribute "api-key-value"
         ]
         []
 
@@ -468,6 +472,17 @@ view session _ =
                                 [ """Cette API est en version *alpha*, l'implémentation et le contrat d'interface sont susceptibles
                              de changer à tout moment. Vous êtes vivement invité à **ne pas exploiter cette API en production**."""
                                     |> Markdown.simple []
+                                , if Session.isAuthenticated session then
+                                    text ""
+
+                                  else
+                                    div []
+                                        [ text "Les requêtes non authentifiées à l'API retournent uniquement les impacts aggrégés."
+                                        , "Pour avoir le détail des impacts, il est nécessaire de fournir un `TOKEN`, accessible dans votre "
+                                            |> Markdown.simple []
+                                        , a [ Route.href (Route.Auth { authenticated = False }) ] [ text "compte utilisateur" ]
+                                        , text " une fois connecté."
+                                        ]
                                 ]
                             ]
                         }
@@ -481,13 +496,6 @@ view session _ =
                         , text " au format "
                         , a [ href "https://swagger.io/specification/", target "_blank" ] [ text "OpenAPI" ]
                         , text "."
-                        ]
-                    , p []
-                        [ text "Les requêtes non authentifiées à l'API retournent uniquement les impacts aggrégés."
-                        , "Pour avoir le détail des impacts, il est nécessaire de fournir un `TOKEN`, accessible dans votre "
-                            |> Markdown.simple []
-                        , a [ Route.href (Route.Auth { authenticated = False }) ] [ text "compte utilisateur" ]
-                        , text " une fois connecté."
                         ]
                     , div [ class "height-auto" ] [ apiBrowser session ]
                     ]

--- a/src/Page/Api.elm
+++ b/src/Page/Api.elm
@@ -463,34 +463,7 @@ view session _ =
             [ h1 [ class "mb-3" ] [ text "API Ecobalyse" ]
             , div [ class "row" ]
                 [ div [ class "col-xl-8" ]
-                    [ Alert.simple
-                        { level = Alert.Info
-                        , close = Nothing
-                        , title = Nothing
-                        , content =
-                            [ div [ class "fs-7" ]
-                                [ """Cette API est en version *alpha*, l'implémentation et le contrat d'interface sont susceptibles
-                             de changer à tout moment. Vous êtes vivement invité à **ne pas exploiter cette API en production**."""
-                                    |> Markdown.simple [ class "mb-3" ]
-                                , case Session.getUser session of
-                                    Just user ->
-                                        p [ class "mb-0" ]
-                                            [ text "Vous êtes connecté, votre jeton d'API est "
-                                            , code [] [ text user.token ]
-                                            , text ". Il sera automatiquement utilisé dans les exemples interactifs ci-dessous."
-                                            ]
-
-                                    Nothing ->
-                                        p [ class "mb-0" ]
-                                            [ text "Les requêtes non authentifiées à l'API retournent uniquement les impacts aggrégés. "
-                                            , text "Pour avoir le détail des impacts, il est nécessaire de fournir un jeton d'API, accessible dans votre "
-                                            , a [ Route.href (Route.Auth { authenticated = False }) ] [ text "compte utilisateur" ]
-                                            , text " une fois connecté."
-                                            ]
-                                ]
-                            ]
-                        }
-                    , p [ class "fw-bold" ]
+                    [ p [ class "fw-bold" ]
                         [ text "L'API HTTP Ecobalyse permet de calculer les impacts environnementaux des produits textiles et alimentaires." ]
                     , p []
                         [ text "Elle est accessible à l'adresse "
@@ -501,6 +474,12 @@ view session _ =
                         , a [ href "https://swagger.io/specification/", target "_blank" ] [ text "OpenAPI" ]
                         , text "."
                         ]
+                    , Alert.simple
+                        { level = Alert.Info
+                        , close = Nothing
+                        , title = Nothing
+                        , content = [ apiDocumentationNotice session ]
+                        }
                     , div [ class "height-auto" ] [ apiBrowser session ]
                     ]
                 , div [ class "col-xl-4" ]
@@ -539,3 +518,27 @@ view session _ =
             ]
       ]
     )
+
+
+apiDocumentationNotice : Session -> Html msg
+apiDocumentationNotice session =
+    div [ class "fs-7" ]
+        [ """Cette API est **expérimentale** et n’offre à ce stade **aucune garantie de disponibilité ni de
+             stabilité** du service, le contrat d’interface restant susceptible de changer à tout moment en
+             fonction des retours et demandes d’évolutions. **Il est vivement déconseillé de vous reposer sur
+             cette API en production et/ou sur des missions critiques.**"""
+            |> Markdown.simple [ class "mb-3" ]
+        , case Session.getUser session of
+            Just user ->
+                """Vous êtes connecté, votre jeton d'API est `{token}`. Il sera automatiquement
+                   utilisé dans les exemples interactifs ci-dessous."""
+                    |> String.replace "{token}" user.token
+                    |> Markdown.simple []
+
+            Nothing ->
+                """Les requêtes non authentifiées à l'API retournent uniquement les impacts agrégés.
+                   **Pour accéder au détail des impacts, il est nécessaire de fournir un jeton d'API**,
+                   accessible dans votre [compte utilisateur]({route}) une fois connecté."""
+                    |> String.replace "{route}" (Route.toString <| Route.Auth { authenticated = False })
+                    |> Markdown.simple []
+        ]

--- a/src/Page/Api.elm
+++ b/src/Page/Api.elm
@@ -471,18 +471,22 @@ view session _ =
                             [ div [ class "fs-7" ]
                                 [ """Cette API est en version *alpha*, l'implémentation et le contrat d'interface sont susceptibles
                              de changer à tout moment. Vous êtes vivement invité à **ne pas exploiter cette API en production**."""
-                                    |> Markdown.simple []
-                                , if Session.isAuthenticated session then
-                                    text ""
+                                    |> Markdown.simple [ class "mb-3" ]
+                                , case Session.getUser session of
+                                    Just user ->
+                                        p [ class "mb-0" ]
+                                            [ text "Vous êtes connecté, votre jeton d'API est "
+                                            , code [] [ text user.token ]
+                                            , text ". Il sera automatiquement utilisé dans les exemples interactifs ci-dessous."
+                                            ]
 
-                                  else
-                                    div []
-                                        [ text "Les requêtes non authentifiées à l'API retournent uniquement les impacts aggrégés."
-                                        , "Pour avoir le détail des impacts, il est nécessaire de fournir un `TOKEN`, accessible dans votre "
-                                            |> Markdown.simple []
-                                        , a [ Route.href (Route.Auth { authenticated = False }) ] [ text "compte utilisateur" ]
-                                        , text " une fois connecté."
-                                        ]
+                                    Nothing ->
+                                        p [ class "mb-0" ]
+                                            [ text "Les requêtes non authentifiées à l'API retournent uniquement les impacts aggrégés. "
+                                            , text "Pour avoir le détail des impacts, il est nécessaire de fournir un jeton d'API, accessible dans votre "
+                                            , a [ Route.href (Route.Auth { authenticated = False }) ] [ text "compte utilisateur" ]
+                                            , text " une fois connecté."
+                                            ]
                                 ]
                             ]
                         }

--- a/src/Page/Auth.elm
+++ b/src/Page/Auth.elm
@@ -112,7 +112,7 @@ type Action
 
 type Msg
     = AskForRegistration
-    | Authenticated (Result String Session.AllProcessesJson)
+    | Authenticated User (Result String Session.AllProcessesJson)
     | ChangeAction Action
     | GotUserInfo (Result Http.Error User)
     | LoggedOut
@@ -143,17 +143,17 @@ update session msg model =
                 }
             )
 
-        Authenticated (Ok newProcessesJson) ->
+        Authenticated user (Ok newProcessesJson) ->
             let
                 newSession =
-                    Session.authenticated session newProcessesJson
+                    Session.authenticated session user newProcessesJson
             in
             ( model
             , newSession
             , newSession.store |> Session.serializeStore |> Ports.saveStore
             )
 
-        Authenticated (Err error) ->
+        Authenticated _ (Err error) ->
             let
                 newSession =
                     session
@@ -173,7 +173,7 @@ update session msg model =
         GotUserInfo (Ok user) ->
             ( { model | user = user }
             , session
-            , Session.login Authenticated
+            , Session.login (Authenticated user)
             )
 
         GotUserInfo (Err err) ->

--- a/src/Page/Auth.elm
+++ b/src/Page/Auth.elm
@@ -303,7 +303,16 @@ viewAccount { user } =
           , ( "Nom", text user.lastname )
           , ( "Prénom", text user.firstname )
           , ( "Organisation", text user.company )
-          , ( "Jeton d'API", code [] [ text user.token ] )
+          , ( "Jeton d'API"
+            , div []
+                [ code [] [ text user.token ]
+                , br [] []
+                , small [ class "text-muted" ]
+                    [ text "Nécessaire pour obtenir les impacts détaillés dans "
+                    , a [ Route.href Route.Api ] [ text "l'API" ]
+                    ]
+                ]
+            )
           ]
             |> List.concatMap
                 (\( label, htmlValue ) ->

--- a/src/Views/Alert.elm
+++ b/src/Views/Alert.elm
@@ -25,6 +25,7 @@ type alias Config msg =
 type Level
     = Danger
     | Info
+    | Success
 
 
 icon : Level -> Html msg
@@ -35,6 +36,9 @@ icon level =
 
         Info ->
             span [ class "me-1" ] [ Icon.info ]
+
+        Success ->
+            span [ class "me-1" ] [ Icon.checkCircle ]
 
 
 httpError : Http.Error -> Html msg
@@ -118,3 +122,6 @@ levelToClass level =
 
         Info ->
             "info"
+
+        Success ->
+            "success"


### PR DESCRIPTION
This patch stores the user profile information in the session store, so we can pass it to the rapidoc component in the Api page, allowing to access detailed impacts when authenticated on the website.