### PR TITLE
Ensure loading detailed impacts from session store.

### DIFF
--- a/src/Data/Session.elm
+++ b/src/Data/Session.elm
@@ -1,5 +1,6 @@
 module Data.Session exposing
     ( AllProcessesJson
+    , Auth(..)
     , Notification(..)
     , Session
     , Store

--- a/src/Page/Api.elm
+++ b/src/Page/Api.elm
@@ -486,7 +486,7 @@ view session _ =
                             [ """Cette API est **expérimentale** et n’offre à ce stade **aucune garantie de disponibilité ni de
              stabilité** du service, le contrat d’interface restant susceptible de changer à tout moment en
              fonction des retours et demandes d’évolutions. **Il est vivement déconseillé de vous reposer sur
-             cette API en production et/ou sur des missions critiques.**"""
+             cette API en production et/ou pour des missions critiques.**"""
                                 |> Markdown.simple [ class "fs-7" ]
                             ]
                         }


### PR DESCRIPTION
Right now on staging, refreshing the browser when authenticated keeps the authentication status but loses the detailed impacts. This patch ensures loading the detailed process impacts from localStorage when they're available at app init so there's no inconsistent behavior and authenticated users will always get their detailed impacts even if they close/reopen their browser.