### PR TITLE
Data in backend

### DIFF
--- a/backend/authentication/models.py
+++ b/backend/authentication/models.py
@@ -1,15 +1,13 @@
 import uuid
 
-from django.db import models
+from django.db.models import BooleanField, CharField
 from django.utils.translation import gettext_lazy as _
 from mailauth.contrib.user.models import AbstractEmailUser
 
 
 class EcobalyseUser(AbstractEmailUser):
-    organization = models.CharField(
-        _("Organization"), max_length=150, blank=True, default=""
-    )
-    terms_of_use = models.BooleanField(default=False)
-    token = models.CharField(
+    organization = CharField(_("Organization"), max_length=150, blank=True, default="")
+    terms_of_use = BooleanField(default=False)
+    token = CharField(
         _("TOKEN"), max_length=36, default=uuid.uuid4, editable=False, db_index=True
     )

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -50,8 +50,7 @@ INSTALLED_APPS = [
     # # don't use the provided mailauth user, it's redefined in the authentication module
     # "mailauth.contrib.user",
     "authentication.apps.AuthenticationConfig",
-    # # disable textile for now
-    # "textile.apps.TextileConfig",
+    "textile.apps.TextileConfig",
     # #  the original admin config is replaced by custom AdminConfig
     # "django.contrib.admin",
     "backend.apps.AdminConfig",

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -50,7 +50,7 @@ INSTALLED_APPS = [
     # # don't use the provided mailauth user, it's redefined in the authentication module
     # "mailauth.contrib.user",
     "authentication.apps.AuthenticationConfig",
-    "textile.apps.TextileConfig",
+    # "textile.apps.TextileConfig", # TODO disable textile for now
     # #  the original admin config is replaced by custom AdminConfig
     # "django.contrib.admin",
     "backend.apps.AdminConfig",

--- a/backend/templates/admin/textile/example/change_list.html
+++ b/backend/templates/admin/textile/example/change_list.html
@@ -1,0 +1,11 @@
+{% extends "admin/change_list.html" %}
+{% load i18n static %}
+
+{% block object-tools-items %}
+  {{ block.super }}
+  <li>
+    <a href="{% url 'admin:from-json' %}" class="button">
+      {% trans "Create from JSON" %}
+    </a>
+  </li>
+{% endblock %}

--- a/backend/templates/admin/textile/example/from_json.html
+++ b/backend/templates/admin/textile/example/from_json.html
@@ -1,7 +1,7 @@
 {% extends "admin/base_site.html" %}
 {% load i18n static %}
 {% block content %}
-  <h1>{% trans "Copy the JSON content below" %}</h1>
+  <h1>{% trans "Create the Example from the provided JSON block in Ecobalyse" %}</h1>
   <div class="module">
     <form method="post">
       {% csrf_token %}

--- a/backend/templates/admin/textile/example/from_json.html
+++ b/backend/templates/admin/textile/example/from_json.html
@@ -1,0 +1,13 @@
+{% extends "admin/base_site.html" %}
+{% load i18n static %}
+{% block content %}
+  <h1>{% trans "Copy the JSON content below" %}</h1>
+  <div class="module">
+    <form method="post">
+      {% csrf_token %}
+      {{ form.as_p }}
+
+      <input type="submit" value="{% trans 'Submit' %}">
+    </form>
+  </div>
+{% endblock %}

--- a/backend/textile/admin.py
+++ b/backend/textile/admin.py
@@ -1,5 +1,6 @@
 import json
 
+from backend.admin import admin_site
 from django import forms
 from django.contrib import admin, messages
 from django.http import HttpResponseRedirect
@@ -7,7 +8,6 @@ from django.shortcuts import render
 from django.urls import path
 from django.utils.translation import gettext_lazy as _
 
-from backend.admin import admin_site
 from textile.models import Example, Material, Process, Product
 
 
@@ -43,7 +43,11 @@ class ExampleAdmin(admin.ModelAdmin):
 
     def get_urls(self):
         return [
-            path("from-json/", self.from_json, name="from-json")
+            path(
+                "from-json/",
+                self.admin_site.admin_view(self.from_json),
+                name="from-json",
+            )
         ] + super().get_urls()
 
     def from_json(self, request):

--- a/backend/textile/admin.py
+++ b/backend/textile/admin.py
@@ -1,6 +1,5 @@
 import json
 
-from backend.admin import admin_site
 from django import forms
 from django.contrib import admin, messages
 from django.http import HttpResponseRedirect
@@ -8,6 +7,7 @@ from django.shortcuts import render
 from django.urls import path
 from django.utils.translation import gettext_lazy as _
 
+from backend.admin import admin_site
 from textile.models import Example, Material, Process, Product
 
 

--- a/backend/textile/admin.py
+++ b/backend/textile/admin.py
@@ -1,10 +1,17 @@
+import json
+
+from django import forms
 from django.contrib import admin
+from django.http import HttpResponseRedirect
+from django.shortcuts import render
+from django.urls import path
 
 from backend.admin import admin_site
 from textile.models import Example, Material, Process, Product
 
 
 class ProductAdmin(admin.ModelAdmin):
+    save_on_top = True
     search_fields = ["name"]
 
 
@@ -13,20 +20,49 @@ class MaterialsInline(admin.TabularInline):
 
 
 class MaterialAdmin(admin.ModelAdmin):
+    save_on_top = True
     search_fields = ["name"]
     # inlines = [MaterialsInline]
 
 
 class ProcessAdmin(admin.ModelAdmin):
+    save_on_top = True
     search_fields = ["name"]
 
 
-class ExempleAdmin(admin.ModelAdmin):
+class ExampleJSONForm(forms.Form):
+    example = forms.JSONField()
+
+
+class ExampleAdmin(admin.ModelAdmin):
     search_fields = ["name"]
     inlines = [MaterialsInline]
+    change_list_template = "admin/textile/example/change_list.html"
+    save_on_top = True
+
+    def get_urls(self):
+        return [
+            path("from-json/", self.from_json, name="from-json")
+        ] + super().get_urls()
+
+    def from_json(self, request):
+        if request.method == "POST":
+            form = ExampleJSONForm(request.POST)
+            if form.is_valid():
+                json_example = json.loads(request.POST["example"])
+                example = Example._fromJSON(json_example)
+                example.save()
+                for share in json_example["query"]["materials"]:
+                    example.add_material(share)
+                self.message_user(request, "Your Example has been recorded")
+                return HttpResponseRedirect("..")
+        else:
+            form = ExampleJSONForm()
+        context = dict(self.admin_site.each_context(request), form=form)
+        return render(request, "admin/textile/example/from_json.html", context)
 
 
 admin_site.register(Product, ProductAdmin)
 admin_site.register(Material, MaterialAdmin)
 admin_site.register(Process, ProcessAdmin)
-admin_site.register(Example, ExempleAdmin)
+admin_site.register(Example, ExampleAdmin)

--- a/backend/textile/admin.py
+++ b/backend/textile/admin.py
@@ -34,7 +34,7 @@ class ProcessAdmin(admin.ModelAdmin):
 class ExampleJSONForm(forms.ModelForm):
     class Meta:
         model = Example
-        fields = ["id", "name", "category"]
+        fields = ["id", "name"]
 
     query = forms.JSONField()
 

--- a/backend/textile/admin.py
+++ b/backend/textile/admin.py
@@ -133,7 +133,7 @@ class ProcessAdmin(admin.ModelAdmin):
 class ExampleJSONForm(forms.ModelForm):
     class Meta:
         model = Example
-        fields = ["id", "name"]
+        fields = ["id", "name", "product"]
 
     query = forms.JSONField()
 
@@ -218,7 +218,7 @@ class ExampleAdmin(admin.ModelAdmin):
                 json_example = {
                     "id": request.POST["id"],
                     "name": request.POST["name"],
-                    "category": request.POST["category"],
+                    "product": request.POST["product"],
                     "query": json.loads(request.POST["query"]),
                 }
                 try:

--- a/backend/textile/admin.py
+++ b/backend/textile/admin.py
@@ -23,7 +23,6 @@ class MaterialsInline(admin.TabularInline):
 class MaterialAdmin(admin.ModelAdmin):
     save_on_top = True
     search_fields = ["name"]
-    # inlines = [MaterialsInline]
 
 
 class ProcessAdmin(admin.ModelAdmin):
@@ -44,6 +43,62 @@ class ExampleAdmin(admin.ModelAdmin):
     inlines = [MaterialsInline]
     change_list_template = "admin/textile/example/change_list.html"
     save_on_top = True
+    fieldsets = [
+        (None, {"fields": ["id", "name", "mass"]}),
+        (
+            "Durabilité non-physique",
+            {
+                "fields": [
+                    "product",
+                    "numberOfReferences",
+                    "price",
+                    "marketingDuration",
+                    "business",
+                    "traceability",
+                    "repairCost",
+                ],
+                "description": "Paramètres de durabilité non-physique. Voir la <a href='https://fabrique-numerique.gitbook.io/ecobalyse/textile/durabilite'>Documentation</a>",
+            },
+        ),
+        (
+            "Filature",
+            {
+                "fields": [
+                    "countrySpinning",
+                ],
+                "description": "<a href='https://fabrique-numerique.gitbook.io/ecobalyse/textile/etapes-du-cycle-de-vie/etape-2-fabrication-du-fil-new'>Documentation</a>",
+            },
+        ),
+        (
+            "Fabrication",
+            {
+                "fields": [
+                    "fabricProcess",
+                    "countryFabric",
+                ],
+                "description": "<a href='https://fabrique-numerique.gitbook.io/ecobalyse/textile/cycle-de-vie-des-produits-textiles/etape-2-fabrication-du-fil'>Documentation</a>",
+            },
+        ),
+        (
+            "Confection",
+            {
+                "fields": [
+                    "airTransportRatio",
+                    "countryMaking",
+                ],
+                "description": "<a href='https://fabrique-numerique.gitbook.io/ecobalyse/textile/etapes-du-cycle-de-vie/confection'>Documentation</a>",
+            },
+        ),
+        (
+            "Ennoblissement",
+            {
+                "fields": [
+                    "countryDyeing",
+                ],
+                "description": "<a href='https://fabrique-numerique.gitbook.io/ecobalyse/textile/etapes-du-cycle-de-vie/ennoblissement'>Documentation</a>",
+            },
+        ),
+    ]
 
     def get_urls(self):
         return [

--- a/backend/textile/admin.py
+++ b/backend/textile/admin.py
@@ -1,7 +1,7 @@
 import json
 
 from django import forms
-from django.contrib import admin
+from django.contrib import admin, messages
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
 from django.urls import path
@@ -46,16 +46,23 @@ class ExampleAdmin(admin.ModelAdmin):
         ] + super().get_urls()
 
     def from_json(self, request):
+        """/admin/textile/example/from-json/ form"""
         if request.method == "POST":
             form = ExampleJSONForm(request.POST)
             if form.is_valid():
                 json_example = json.loads(request.POST["example"])
-                example = Example._fromJSON(json_example)
-                example.save()
-                for share in json_example["query"]["materials"]:
-                    example.add_material(share)
-                self.message_user(request, "Your Example has been recorded")
-                return HttpResponseRedirect("..")
+                try:
+                    example = Example._fromJSON(json_example)
+                    example.save()
+
+                    for share in json_example["query"]["materials"]:
+                        example.add_material(share)
+                    self.message_user(request, "Your Example has been recorded")
+                    return HttpResponseRedirect("..")
+                except TypeError:
+                    self.message_user(
+                        request, "Your JSON doesn't seem valid", level=messages.ERROR
+                    )
         else:
             form = ExampleJSONForm()
         context = dict(self.admin_site.each_context(request), form=form)

--- a/backend/textile/admin.py
+++ b/backend/textile/admin.py
@@ -5,6 +5,7 @@ from django.contrib import admin, messages
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
 from django.urls import path
+from django.utils.translation import gettext_lazy as _
 
 from backend.admin import admin_site
 from textile.models import Example, Material, Process, Product
@@ -57,11 +58,13 @@ class ExampleAdmin(admin.ModelAdmin):
 
                     for share in json_example["query"]["materials"]:
                         example.add_material(share)
-                    self.message_user(request, "Your Example has been recorded")
+                    self.message_user(request, _("Your Example has been recorded"))
                     return HttpResponseRedirect("..")
                 except TypeError:
                     self.message_user(
-                        request, "Your JSON doesn't seem valid", level=messages.ERROR
+                        request,
+                        _("Your JSON doesn't look like a valid example"),
+                        level=messages.ERROR,
                     )
         else:
             form = ExampleJSONForm()

--- a/backend/textile/admin.py
+++ b/backend/textile/admin.py
@@ -31,8 +31,12 @@ class ProcessAdmin(admin.ModelAdmin):
     search_fields = ["name"]
 
 
-class ExampleJSONForm(forms.Form):
-    example = forms.JSONField()
+class ExampleJSONForm(forms.ModelForm):
+    class Meta:
+        model = Example
+        fields = ["id", "name", "category"]
+
+    query = forms.JSONField()
 
 
 class ExampleAdmin(admin.ModelAdmin):
@@ -55,7 +59,12 @@ class ExampleAdmin(admin.ModelAdmin):
         if request.method == "POST":
             form = ExampleJSONForm(request.POST)
             if form.is_valid():
-                json_example = json.loads(request.POST["example"])
+                json_example = {
+                    "id": request.POST["id"],
+                    "name": request.POST["name"],
+                    "category": request.POST["category"],
+                    "query": json.loads(request.POST["query"]),
+                }
                 try:
                     example = Example._fromJSON(json_example)
                     example.save()

--- a/backend/textile/choices.py
+++ b/backend/textile/choices.py
@@ -17,7 +17,7 @@ BUSINESSES = {
     "large-business-without-services": "Grande entreprise ne proposant pas de service de réparation ou de garantie",
 }
 DYEINGMEDIA = {"article": "Article", "fabric": "Tissu", "yarn": "Fil"}
-MAXKINGCOMPLEXITIES = {
+MAKINGCOMPLEXITIES = {
     "very-high": "Très élevée",
     "high": "Élevée",
     "medium": "Moyenne",

--- a/backend/textile/choices.py
+++ b/backend/textile/choices.py
@@ -57,15 +57,3 @@ STEPUSAGES = {
         "Utilisation",
     ]
 }
-CATEGORIES = {
-    k: k
-    for k in [
-        "Chemise",
-        "Jean",
-        "Jupe / Robe",
-        "Manteau / Veste",
-        "Pantalon / Short",
-        "Pull / Couche intermédiaire",
-        "Tshirt / Polo",
-    ]
-}

--- a/backend/textile/init.py
+++ b/backend/textile/init.py
@@ -54,8 +54,6 @@ def init():
     ):
         sys.exit()
 
-    # return  # FIXME don't load textile data yet
-
     # PROCESSES
     with open(
         join(

--- a/backend/textile/models.py
+++ b/backend/textile/models.py
@@ -177,6 +177,33 @@ class Product(models.Model):
         return self.name
 
     @classmethod
+    def _fromJSON(self, product):
+        """takes a json of a product, return an instance of Product"""
+        # all fields except the foreignkeys
+        p = Product(
+            **flatten(
+                "endOfLife",
+                flatten(
+                    "use",
+                    flatten(
+                        "making",
+                        flatten(
+                            "dyeing",
+                            flatten(
+                                "economics",
+                                delkey("use.nonIroningProcessUuid", deepcopy(product)),
+                            ),
+                        ),
+                    ),
+                ),
+            )
+        )
+        p.nonIroningProcessUuid = Process.objects.get(
+            pk=product["use"]["nonIroningProcessUuid"]
+        )
+        return p
+
+    @classmethod
     def allToJSON(cls):
         return json.dumps(
             [

--- a/backend/textile/models.py
+++ b/backend/textile/models.py
@@ -2,6 +2,7 @@ import json
 from copy import deepcopy
 
 from django.db import models
+from django.utils.translation import gettext_lazy as _
 
 from .choices import (
     BUSINESSES,
@@ -342,21 +343,42 @@ class Example(models.Model):
 
     mass = models.FloatField()
     materials = models.ManyToManyField(Material, through="Share")
-    product = models.ForeignKey(Product, on_delete=models.CASCADE, null=True)
-    # fields of products (?)
-    business = models.CharField(max_length=50, choices=BUSINESSES)
-    marketingDuration = models.FloatField(null=True)
-    numberOfReferences = models.IntegerField(null=True)
-    price = models.FloatField(null=True)
-    repairCost = models.FloatField(null=True, blank=True)
-    traceability = models.BooleanField(null=True)
-    airTransportRatio = models.FloatField(null=True)
+    product = models.ForeignKey(
+        Product, on_delete=models.CASCADE, null=True, verbose_name=_("Category")
+    )
+    business = models.CharField(
+        max_length=50, choices=BUSINESSES, verbose_name=_("Company type")
+    )
+    marketingDuration = models.FloatField(
+        null=True, verbose_name=_("Marketing Duration")
+    )
+    numberOfReferences = models.IntegerField(
+        null=True, verbose_name=_("Number Of References")
+    )
+    price = models.FloatField(null=True, verbose_name=_("Price"))
+    repairCost = models.FloatField(null=True, blank=True, verbose_name=_("Repair Cost"))
+    traceability = models.BooleanField(
+        null=True, verbose_name=_("Traceability Displayed?")
+    )
+    airTransportRatio = models.FloatField(
+        null=True, verbose_name=_("Air Transport Ratio")
+    )
 
-    countrySpinning = models.CharField(max_length=50, choices=COUNTRIES)
-    countryFabric = models.CharField(max_length=50, choices=COUNTRIES)
-    countryDyeing = models.CharField(max_length=50, choices=COUNTRIES)
-    countryMaking = models.CharField(max_length=50, choices=COUNTRIES)
-    fabricProcess = models.ForeignKey(Process, on_delete=models.CASCADE, null=True)
+    countrySpinning = models.CharField(
+        max_length=50, choices=COUNTRIES, verbose_name=_("Spinning Country")
+    )
+    countryFabric = models.CharField(
+        max_length=50, choices=COUNTRIES, verbose_name=_("Fabric Country")
+    )
+    countryDyeing = models.CharField(
+        max_length=50, choices=COUNTRIES, verbose_name=_("Country Of Dyeing")
+    )
+    countryMaking = models.CharField(
+        max_length=50, choices=COUNTRIES, verbose_name=_("Country Of Manufacture")
+    )
+    fabricProcess = models.ForeignKey(
+        Process, on_delete=models.CASCADE, null=True, verbose_name=_("Fabric Process")
+    )
 
     def __str__(self):
         return self.name
@@ -447,6 +469,9 @@ class Example(models.Model):
 
 class Share(models.Model):
     """m2m relation of Example with an extra field"""
+
+    class Meta:
+        verbose_name_plural = _("Materials")
 
     example = models.ForeignKey(Example, on_delete=models.CASCADE)
     material = models.ForeignKey(Material, on_delete=models.CASCADE)

--- a/backend/textile/models.py
+++ b/backend/textile/models.py
@@ -19,7 +19,7 @@ from .choices import (
     COUNTRIES,
     DYEINGMEDIA,
     FABRICS,
-    MAXKINGCOMPLEXITIES,
+    MAKINGCOMPLEXITIES,
     ORIGINS,
     STEPUSAGES,
     UNITS,
@@ -178,7 +178,7 @@ class Product(Model):
     defaultMedium = CharField(50, choices=DYEINGMEDIA)
     # making
     pcrWaste = FloatField()
-    complexity = CharField(50, choices=MAXKINGCOMPLEXITIES)
+    complexity = CharField(50, choices=MAKINGCOMPLEXITIES)
     # use
     ironingElecInMJ = FloatField()
     nonIroningProcessUuid = ForeignKey(

--- a/backend/textile/models.py
+++ b/backend/textile/models.py
@@ -56,6 +56,9 @@ def delkey(key, record):
 
 
 class Process(models.Model):
+    class Meta:
+        verbose_name_plural = "Processes"
+
     search = models.CharField(max_length=200, blank=True)
     name = models.CharField(max_length=200)
     source = models.CharField(max_length=200)

--- a/backend/textile/models.py
+++ b/backend/textile/models.py
@@ -1,7 +1,17 @@
 import json
 from copy import deepcopy
 
-from django.db import models
+from django.db.models import (
+    CASCADE,
+    SET_NULL,
+    BooleanField,
+    CharField,
+    FloatField,
+    ForeignKey,
+    IntegerField,
+    ManyToManyField,
+    Model,
+)
 from django.utils.translation import gettext_lazy as _
 
 from .choices import (
@@ -55,50 +65,50 @@ def delkey(key, record):
 # textile
 
 
-class Process(models.Model):
+class Process(Model):
     class Meta:
         verbose_name_plural = "Processes"
 
-    search = models.CharField(max_length=200, blank=True)
-    name = models.CharField(max_length=200)
-    source = models.CharField(max_length=200)
-    info = models.CharField(max_length=200)
-    unit = models.CharField(max_length=50, choices=UNITS)
-    uuid = models.CharField(max_length=50, primary_key=True)
-    acd = models.FloatField()
-    cch = models.FloatField()
-    etf = models.FloatField()
-    etfc = models.FloatField()
-    fru = models.FloatField()
-    fwe = models.FloatField()
-    htc = models.FloatField()
-    htcc = models.FloatField()
-    htn = models.FloatField()
-    htnc = models.FloatField()
-    ior = models.FloatField()
-    ldu = models.FloatField()
-    mru = models.FloatField()
-    ozd = models.FloatField()
-    pco = models.FloatField()
-    pma = models.FloatField()
-    swe = models.FloatField()
-    tre = models.FloatField()
-    wtu = models.FloatField()
-    pef = models.FloatField()
-    ecs = models.FloatField()
-    heat_MJ = models.FloatField(default=0)
-    elec_pppm = models.FloatField()
-    elec_MJ = models.FloatField()
-    waste = models.FloatField()
-    alias = models.CharField(max_length=50, null=True)
-    step_usage = models.CharField(max_length=50, choices=STEPUSAGES)
-    correctif = models.CharField(max_length=200)
+    search = CharField(200, blank=True)
+    name = CharField(200)
+    source = CharField(200)
+    info = CharField(200)
+    unit = CharField(50, choices=UNITS)
+    uuid = CharField(50, primary_key=True)
+    acd = FloatField()
+    cch = FloatField()
+    etf = FloatField()
+    etfc = FloatField()
+    fru = FloatField()
+    fwe = FloatField()
+    htc = FloatField()
+    htcc = FloatField()
+    htn = FloatField()
+    htnc = FloatField()
+    ior = FloatField()
+    ldu = FloatField()
+    mru = FloatField()
+    ozd = FloatField()
+    pco = FloatField()
+    pma = FloatField()
+    swe = FloatField()
+    tre = FloatField()
+    wtu = FloatField()
+    pef = FloatField()
+    ecs = FloatField()
+    heat_MJ = FloatField(default=0)
+    elec_pppm = FloatField()
+    elec_MJ = FloatField()
+    waste = FloatField()
+    alias = CharField(50, null=True)
+    step_usage = CharField(50, choices=STEPUSAGES)
+    correctif = CharField(200)
 
     def __str__(self):
         return self.name
 
     @classmethod
-    def _fromJSON(self, process):
+    def _fromJSON(cls, process):
         """Takes a json of a process, returns a Process instance"""
         return Process(
             **delkey("bvi", delchar("-", flatten("impacts", deepcopy(process))))
@@ -150,44 +160,44 @@ class Process(models.Model):
         )
 
 
-class Product(models.Model):
-    id = models.CharField(max_length=50, primary_key=True)
-    name = models.CharField(max_length=200)
-    mass = models.FloatField()
-    surfaceMass = models.FloatField()
-    yarnSize = models.FloatField()
-    fabric = models.CharField(max_length=50, choices=FABRICS)
+class Product(Model):
+    id = CharField(50, primary_key=True)
+    name = CharField(200)
+    mass = FloatField()
+    surfaceMass = FloatField()
+    yarnSize = FloatField()
+    fabric = CharField(50, choices=FABRICS)
     # economics
-    business = models.CharField(max_length=50, choices=BUSINESSES)
-    marketingDuration = models.FloatField()
-    numberOfReferences = models.IntegerField()
-    price = models.FloatField()
-    repairCost = models.FloatField()
-    traceability = models.BooleanField()
+    business = CharField(50, choices=BUSINESSES)
+    marketingDuration = FloatField()
+    numberOfReferences = IntegerField()
+    price = FloatField()
+    repairCost = FloatField()
+    traceability = BooleanField()
     # dyeing
-    defaultMedium = models.CharField(max_length=50, choices=DYEINGMEDIA)
+    defaultMedium = CharField(50, choices=DYEINGMEDIA)
     # making
-    pcrWaste = models.FloatField()
-    complexity = models.CharField(max_length=50, choices=MAXKINGCOMPLEXITIES)
+    pcrWaste = FloatField()
+    complexity = CharField(50, choices=MAXKINGCOMPLEXITIES)
     # use
-    ironingElecInMJ = models.FloatField()
-    nonIroningProcessUuid = models.ForeignKey(
-        Process, on_delete=models.SET_NULL, null=True, related_name="productsNonIroning"
+    ironingElecInMJ = FloatField()
+    nonIroningProcessUuid = ForeignKey(
+        Process, SET_NULL, null=True, related_name="productsNonIroning"
     )
-    daysOfWear = models.IntegerField()
-    defaultNbCycles = models.IntegerField()
-    ratioDryer = models.FloatField()
-    ratioIroning = models.FloatField()
-    timeIroning = models.FloatField()
-    wearsPerCycle = models.FloatField()
+    daysOfWear = IntegerField()
+    defaultNbCycles = IntegerField()
+    ratioDryer = FloatField()
+    ratioIroning = FloatField()
+    timeIroning = FloatField()
+    wearsPerCycle = FloatField()
     # enf of life
-    volume = models.FloatField()
+    volume = FloatField()
 
     def __str__(self):
         return self.name
 
     @classmethod
-    def _fromJSON(self, product):
+    def _fromJSON(cls, product):
         """takes a json of a product, return an instance of Product"""
         # all fields except the foreignkeys
         p = Product(
@@ -257,32 +267,30 @@ class Product(models.Model):
         )
 
 
-class Material(models.Model):
-    id = models.CharField(max_length=50, primary_key=True)
-    materialProcessUuid = models.ForeignKey(
-        Process, on_delete=models.SET_NULL, null=True, related_name="materials"
+class Material(Model):
+    id = CharField(50, primary_key=True)
+    materialProcessUuid = ForeignKey(
+        Process, SET_NULL, null=True, related_name="materials"
     )
-    recycledProcessUuid = models.ForeignKey(
-        Process, on_delete=models.SET_NULL, null=True, related_name="recycledMaterials"
+    recycledProcessUuid = ForeignKey(
+        Process, SET_NULL, null=True, related_name="recycledMaterials"
     )
-    recycledFrom = models.ForeignKey(
-        "self", null=True, on_delete=models.SET_NULL, blank=True
-    )
-    name = models.CharField(max_length=200)
-    shortName = models.CharField(max_length=50)
-    origin = models.CharField(max_length=50, choices=ORIGINS)
-    geographicOrigin = models.CharField(max_length=200)
-    defaultCountry = models.CharField(max_length=3, choices=COUNTRIES)
-    priority = models.IntegerField()
+    recycledFrom = ForeignKey("self", SET_NULL, null=True, blank=True)
+    name = CharField(200)
+    shortName = CharField(50)
+    origin = CharField(50, choices=ORIGINS)
+    geographicOrigin = CharField(200)
+    defaultCountry = CharField(3, choices=COUNTRIES)
+    priority = IntegerField()
     # cff
-    manufacturerAllocation = models.FloatField(null=True, blank=True)
-    recycledQualityRatio = models.FloatField(null=True, blank=True)
+    manufacturerAllocation = FloatField(null=True, blank=True)
+    recycledQualityRatio = FloatField(null=True, blank=True)
 
     def __str__(self):
         return self.name
 
     @classmethod
-    def _fromJSON(self, material):
+    def _fromJSON(cls, material):
         """takes a json of a material, returns a Material instance, without recursive FK"""
         m = Material(
             **delkey(
@@ -333,58 +341,48 @@ class Material(models.Model):
         )
 
 
-class Example(models.Model):
-    id = models.CharField(max_length=50, primary_key=True)
-    name = models.CharField(max_length=200)
+class Example(Model):
+    id = CharField(50, primary_key=True)
+    name = CharField(200)
 
     @property
     def category(self):
         return self.product.name
 
-    mass = models.FloatField()
-    materials = models.ManyToManyField(Material, through="Share")
-    product = models.ForeignKey(
-        Product, on_delete=models.CASCADE, null=True, verbose_name=_("Category")
-    )
-    business = models.CharField(
+    mass = FloatField()
+    materials = ManyToManyField(Material, through="Share")
+    product = ForeignKey(Product, CASCADE, null=True, verbose_name=_("Category"))
+    business = CharField(
         max_length=50, choices=BUSINESSES, verbose_name=_("Company type")
     )
-    marketingDuration = models.FloatField(
-        null=True, verbose_name=_("Marketing Duration")
-    )
-    numberOfReferences = models.IntegerField(
-        null=True, verbose_name=_("Number Of References")
-    )
-    price = models.FloatField(null=True, verbose_name=_("Price"))
-    repairCost = models.FloatField(null=True, blank=True, verbose_name=_("Repair Cost"))
-    traceability = models.BooleanField(
-        null=True, verbose_name=_("Traceability Displayed?")
-    )
-    airTransportRatio = models.FloatField(
-        null=True, verbose_name=_("Air Transport Ratio")
-    )
+    marketingDuration = FloatField(null=True, verbose_name=_("Marketing Duration"))
+    numberOfReferences = IntegerField(null=True, verbose_name=_("Number Of References"))
+    price = FloatField(null=True, verbose_name=_("Price"))
+    repairCost = FloatField(null=True, blank=True, verbose_name=_("Repair Cost"))
+    traceability = BooleanField(null=True, verbose_name=_("Traceability Displayed?"))
+    airTransportRatio = FloatField(null=True, verbose_name=_("Air Transport Ratio"))
 
-    countrySpinning = models.CharField(
+    countrySpinning = CharField(
         max_length=50, choices=COUNTRIES, verbose_name=_("Spinning Country")
     )
-    countryFabric = models.CharField(
+    countryFabric = CharField(
         max_length=50, choices=COUNTRIES, verbose_name=_("Fabric Country")
     )
-    countryDyeing = models.CharField(
+    countryDyeing = CharField(
         max_length=50, choices=COUNTRIES, verbose_name=_("Country Of Dyeing")
     )
-    countryMaking = models.CharField(
+    countryMaking = CharField(
         max_length=50, choices=COUNTRIES, verbose_name=_("Country Of Manufacture")
     )
-    fabricProcess = models.ForeignKey(
-        Process, on_delete=models.CASCADE, null=True, verbose_name=_("Fabric Process")
+    fabricProcess = ForeignKey(
+        Process, CASCADE, null=True, verbose_name=_("Fabric Process")
     )
 
     def __str__(self):
         return self.name
 
     @classmethod
-    def _fromJSON(self, example):
+    def _fromJSON(cls, example):
         """takes a json of an example, return an instance of Example"""
         # all fields except some
         e = Example(
@@ -467,12 +465,12 @@ class Example(models.Model):
         return json.dumps(output)
 
 
-class Share(models.Model):
+class Share(Model):
     """m2m relation of Example with an extra field"""
 
     class Meta:
         verbose_name_plural = _("Materials")
 
-    example = models.ForeignKey(Example, on_delete=models.CASCADE)
-    material = models.ForeignKey(Material, on_delete=models.CASCADE)
-    share = models.FloatField()
+    example = ForeignKey(Example, CASCADE)
+    material = ForeignKey(Material, CASCADE)
+    share = FloatField()

--- a/backend/textile/models.py
+++ b/backend/textile/models.py
@@ -69,37 +69,37 @@ class Process(Model):
     class Meta:
         verbose_name_plural = "Processes"
 
-    search = CharField(_("Search term"), max_length=200, blank=True)
+    search = CharField(_("Brightway Search term"), max_length=200, blank=True)
     name = CharField(_("Name"), max_length=200)
     source = CharField(_("Source Database"), max_length=200)
     info = CharField(_("Informations"), max_length=200)
     unit = CharField(_("Unit"), max_length=50, choices=UNITS)
     uuid = CharField("UUID", max_length=50, primary_key=True)
-    acd = FloatField()
-    cch = FloatField()
-    etf = FloatField()
-    etfc = FloatField()
-    fru = FloatField()
-    fwe = FloatField()
-    htc = FloatField()
-    htcc = FloatField()
-    htn = FloatField()
-    htnc = FloatField()
-    ior = FloatField()
-    ldu = FloatField()
-    mru = FloatField()
-    ozd = FloatField()
-    pco = FloatField()
-    pma = FloatField()
-    swe = FloatField()
-    tre = FloatField()
-    wtu = FloatField()
-    pef = FloatField()
-    ecs = FloatField()
-    heat_MJ = FloatField(default=0)
-    elec_pppm = FloatField()
-    elec_MJ = FloatField()
-    waste = FloatField()
+    acd = FloatField(_("Acidification (acd)"))
+    cch = FloatField(_("Climate Change (cch)"))
+    etf = FloatField(_("Ecotoxicity, freshwater (etf)"))
+    etfc = FloatField(_("Ecotoxicity, freshwater, corrected (etf-c)"))
+    fru = FloatField(_("Resource use, fossils (fru)"))
+    fwe = FloatField(_("Eutrophication, freshwater (fwe)"))
+    htc = FloatField(_("Human toxicity, cancer (htc)"))
+    htcc = FloatField(_("Human toxicity, cancer, corrected (htc-c)"))
+    htn = FloatField(_("Human toxicity, non-cancer (htn)"))
+    htnc = FloatField(_("Human toxicity, non-cancer, corrected (htn-c)"))
+    ior = FloatField(_("Ionising radiation (ior)"))
+    ldu = FloatField(_("Land use (ldu)"))
+    mru = FloatField(_("Resource use, minerals and metals (mru)"))
+    ozd = FloatField(_("Ozone depletion (ozd)"))
+    pco = FloatField(_("Photochemical ozone formation (pco)"))
+    pma = FloatField(_("Particulate matter (pma)"))
+    swe = FloatField(_("Eutrophication, marine (swe)"))
+    tre = FloatField(_("Eutrophication, terrestrial (tre)"))
+    wtu = FloatField(_("Water use"))
+    pef = FloatField(_("PEF Score"))
+    ecs = FloatField(_("Environmental Cost"))
+    heat_MJ = FloatField(_("Heat MJ"), default=0)
+    elec_pppm = FloatField(_("Elec pppm"))
+    elec_MJ = FloatField(_("Elec MJ"))
+    waste = FloatField(_("Waste"))
     alias = CharField(_("Alias"), max_length=50, null=True)
     step_usage = CharField(_("Step Usage"), max_length=50, choices=STEPUSAGES)
     correctif = CharField(_("Correction"), max_length=200)
@@ -163,33 +163,33 @@ class Process(Model):
 class Product(Model):
     id = CharField("ID", max_length=50, primary_key=True)
     name = CharField(_("Name"), max_length=200)
-    mass = FloatField()
-    surfaceMass = FloatField()
-    yarnSize = FloatField()
+    mass = FloatField(_("Mass"))
+    surfaceMass = FloatField(_("Surface Mass"))
+    yarnSize = FloatField(_("Yarn Size"))
     fabric = CharField(_("Fabric"), max_length=50, choices=FABRICS)
     # economics
     business = CharField(_("Business Type"), max_length=50, choices=BUSINESSES)
-    marketingDuration = FloatField()
-    numberOfReferences = IntegerField()
-    price = FloatField()
-    repairCost = FloatField()
-    traceability = BooleanField()
+    marketingDuration = FloatField(_("Marketing Duration"))
+    numberOfReferences = IntegerField(_("Nb Of Recerences"))
+    price = FloatField(_("Price"))
+    repairCost = FloatField(_("Repair Cost"))
+    traceability = BooleanField(_("Traceability"))
     # dyeing
     defaultMedium = CharField(_("Default Medium"), max_length=50, choices=DYEINGMEDIA)
     # making
-    pcrWaste = FloatField()
+    pcrWaste = FloatField(_("PCR Waste"))
     complexity = CharField(_("Complexity"), max_length=50, choices=MAKINGCOMPLEXITIES)
     # use
-    ironingElecInMJ = FloatField()
+    ironingElecInMJ = FloatField(_("Ironing Elec in MJ"))
     nonIroningProcessUuid = ForeignKey(
         Process, SET_NULL, null=True, related_name="productsNonIroning"
     )
-    daysOfWear = IntegerField()
-    defaultNbCycles = IntegerField()
-    ratioDryer = FloatField()
-    ratioIroning = FloatField()
-    timeIroning = FloatField()
-    wearsPerCycle = FloatField()
+    daysOfWear = IntegerField(_("Days Of Wear"))
+    defaultNbCycles = IntegerField(_("Default Nb Of Cycles"))
+    ratioDryer = FloatField(_("Ratio Dryer"))
+    ratioIroning = FloatField(_("Ratio Ironing"))
+    timeIroning = FloatField(_("Time Ironing"))
+    wearsPerCycle = FloatField(_("Wears Per Cycle"))
     # enf of life
     volume = FloatField()
 
@@ -270,12 +270,22 @@ class Product(Model):
 class Material(Model):
     id = CharField("ID", max_length=50, primary_key=True)
     materialProcessUuid = ForeignKey(
-        Process, SET_NULL, null=True, related_name="materials"
+        Process,
+        SET_NULL,
+        null=True,
+        related_name="materials",
+        verbose_name=_("Process"),
     )
     recycledProcessUuid = ForeignKey(
-        Process, SET_NULL, null=True, related_name="recycledMaterials"
+        Process,
+        SET_NULL,
+        null=True,
+        related_name="recycledMaterials",
+        verbose_name=_("Recycled Process"),
     )
-    recycledFrom = ForeignKey("self", SET_NULL, null=True, blank=True)
+    recycledFrom = ForeignKey(
+        "self", SET_NULL, null=True, blank=True, verbose_name=_("Recycled From")
+    )
     name = CharField(_("Name"), max_length=200)
     shortName = CharField(_("Short Name"), max_length=50)
     origin = CharField(_("Origin"), max_length=50, choices=ORIGINS)
@@ -283,8 +293,12 @@ class Material(Model):
     defaultCountry = CharField(_("Default Country"), max_length=3, choices=COUNTRIES)
     priority = IntegerField()
     # cff
-    manufacturerAllocation = FloatField(null=True, blank=True)
-    recycledQualityRatio = FloatField(null=True, blank=True)
+    manufacturerAllocation = FloatField(
+        _("Manufacturer Allocation"), null=True, blank=True
+    )
+    recycledQualityRatio = FloatField(
+        _("Recycled Quality Ratio"), null=True, blank=True
+    )
 
     def __str__(self):
         return self.name

--- a/backend/textile/models.py
+++ b/backend/textile/models.py
@@ -69,12 +69,12 @@ class Process(Model):
     class Meta:
         verbose_name_plural = "Processes"
 
-    search = CharField(200, blank=True)
-    name = CharField(200)
-    source = CharField(200)
-    info = CharField(200)
-    unit = CharField(50, choices=UNITS)
-    uuid = CharField(50, primary_key=True)
+    search = CharField(_("Search term"), max_length=200, blank=True)
+    name = CharField(_("Name"), max_length=200)
+    source = CharField(_("Source Database"), max_length=200)
+    info = CharField(_("Informations"), max_length=200)
+    unit = CharField(_("Unit"), max_length=50, choices=UNITS)
+    uuid = CharField("UUID", max_length=50, primary_key=True)
     acd = FloatField()
     cch = FloatField()
     etf = FloatField()
@@ -100,9 +100,9 @@ class Process(Model):
     elec_pppm = FloatField()
     elec_MJ = FloatField()
     waste = FloatField()
-    alias = CharField(50, null=True)
-    step_usage = CharField(50, choices=STEPUSAGES)
-    correctif = CharField(200)
+    alias = CharField(_("Alias"), max_length=50, null=True)
+    step_usage = CharField(_("Step Usage"), max_length=50, choices=STEPUSAGES)
+    correctif = CharField(_("Correction"), max_length=200)
 
     def __str__(self):
         return self.name
@@ -161,24 +161,24 @@ class Process(Model):
 
 
 class Product(Model):
-    id = CharField(50, primary_key=True)
-    name = CharField(200)
+    id = CharField("ID", max_length=50, primary_key=True)
+    name = CharField(_("Name"), max_length=200)
     mass = FloatField()
     surfaceMass = FloatField()
     yarnSize = FloatField()
-    fabric = CharField(50, choices=FABRICS)
+    fabric = CharField(_("Fabric"), max_length=50, choices=FABRICS)
     # economics
-    business = CharField(50, choices=BUSINESSES)
+    business = CharField(_("Business Type"), max_length=50, choices=BUSINESSES)
     marketingDuration = FloatField()
     numberOfReferences = IntegerField()
     price = FloatField()
     repairCost = FloatField()
     traceability = BooleanField()
     # dyeing
-    defaultMedium = CharField(50, choices=DYEINGMEDIA)
+    defaultMedium = CharField(_("Default Medium"), max_length=50, choices=DYEINGMEDIA)
     # making
     pcrWaste = FloatField()
-    complexity = CharField(50, choices=MAKINGCOMPLEXITIES)
+    complexity = CharField(_("Complexity"), max_length=50, choices=MAKINGCOMPLEXITIES)
     # use
     ironingElecInMJ = FloatField()
     nonIroningProcessUuid = ForeignKey(
@@ -268,7 +268,7 @@ class Product(Model):
 
 
 class Material(Model):
-    id = CharField(50, primary_key=True)
+    id = CharField("ID", max_length=50, primary_key=True)
     materialProcessUuid = ForeignKey(
         Process, SET_NULL, null=True, related_name="materials"
     )
@@ -276,11 +276,11 @@ class Material(Model):
         Process, SET_NULL, null=True, related_name="recycledMaterials"
     )
     recycledFrom = ForeignKey("self", SET_NULL, null=True, blank=True)
-    name = CharField(200)
-    shortName = CharField(50)
-    origin = CharField(50, choices=ORIGINS)
-    geographicOrigin = CharField(200)
-    defaultCountry = CharField(3, choices=COUNTRIES)
+    name = CharField(_("Name"), max_length=200)
+    shortName = CharField(_("Short Name"), max_length=50)
+    origin = CharField(_("Origin"), max_length=50, choices=ORIGINS)
+    geographicOrigin = CharField(_("Geographic Origin"), max_length=200)
+    defaultCountry = CharField(_("Default Country"), max_length=3, choices=COUNTRIES)
     priority = IntegerField()
     # cff
     manufacturerAllocation = FloatField(null=True, blank=True)
@@ -342,8 +342,8 @@ class Material(Model):
 
 
 class Example(Model):
-    id = CharField(50, primary_key=True)
-    name = CharField(200)
+    id = CharField("ID", max_length=50, primary_key=True)
+    name = CharField(_("Name"), max_length=200)
 
     @property
     def category(self):
@@ -352,30 +352,22 @@ class Example(Model):
     mass = FloatField()
     materials = ManyToManyField(Material, through="Share")
     product = ForeignKey(Product, CASCADE, null=True, verbose_name=_("Category"))
-    business = CharField(
-        max_length=50, choices=BUSINESSES, verbose_name=_("Company type")
-    )
-    marketingDuration = FloatField(null=True, verbose_name=_("Marketing Duration"))
-    numberOfReferences = IntegerField(null=True, verbose_name=_("Number Of References"))
-    price = FloatField(null=True, verbose_name=_("Price"))
-    repairCost = FloatField(null=True, blank=True, verbose_name=_("Repair Cost"))
-    traceability = BooleanField(null=True, verbose_name=_("Traceability Displayed?"))
-    airTransportRatio = FloatField(null=True, verbose_name=_("Air Transport Ratio"))
+    business = CharField(_("Company type"), max_length=50, choices=BUSINESSES)
+    marketingDuration = FloatField(_("Marketing Duration"), null=True)
+    numberOfReferences = IntegerField(_("Number Of References"), null=True)
+    price = FloatField(_("Price"), null=True)
+    repairCost = FloatField(_("Repair Cost"), null=True, blank=True)
+    traceability = BooleanField(_("Traceability Displayed?"), null=True)
+    airTransportRatio = FloatField(_("Air Transport Ratio"), null=True)
 
-    countrySpinning = CharField(
-        max_length=50, choices=COUNTRIES, verbose_name=_("Spinning Country")
-    )
-    countryFabric = CharField(
-        max_length=50, choices=COUNTRIES, verbose_name=_("Fabric Country")
-    )
-    countryDyeing = CharField(
-        max_length=50, choices=COUNTRIES, verbose_name=_("Country Of Dyeing")
-    )
+    countrySpinning = CharField(_("Spinning Country"), max_length=50, choices=COUNTRIES)
+    countryFabric = CharField(_("Fabric Country"), max_length=50, choices=COUNTRIES)
+    countryDyeing = CharField(_("Country Of Dyeing"), max_length=50, choices=COUNTRIES)
     countryMaking = CharField(
-        max_length=50, choices=COUNTRIES, verbose_name=_("Country Of Manufacture")
+        _("Country Of Manufacture"), max_length=50, choices=COUNTRIES
     )
     fabricProcess = ForeignKey(
-        Process, CASCADE, null=True, verbose_name=_("Fabric Process")
+        Process, CASCADE, verbose_name=_("Fabric Process"), null=True
     )
 
     def __str__(self):

--- a/backend/update.sh
+++ b/backend/update.sh
@@ -5,9 +5,9 @@ pushd $( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # update the l10n and DB
 which gettext && django-admin compilemessages # commit mo files
-python manage.py makemigrations mailauth authentication #textile
+python manage.py makemigrations mailauth authentication textile
 python manage.py migrate
 
 # Populate the DB
 python manage.py shell -c "from authentication.init import init; init()"
-#python manage.py shell -c "from textile.init import init; init()"
+python manage.py shell -c "from textile.init import init; init()"

--- a/backend/update.sh
+++ b/backend/update.sh
@@ -4,10 +4,10 @@ pushd $( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 # this script is used at startup on scalingo (see start.sh)
 
 # update the l10n and DB
-which gettext && django-admin compilemessages # commit mo files
-python manage.py makemigrations mailauth authentication textile
+which gettext && django-admin compilemessages
+python manage.py makemigrations mailauth authentication #textile # TODO disable textile for now
 python manage.py migrate
 
 # Populate the DB
 python manage.py shell -c "from authentication.init import init; init()"
-python manage.py shell -c "from textile.init import init; init()"
+#python manage.py shell -c "from textile.init import init; init()"  # TODO disable textile for now


### PR DESCRIPTION
The staging branch already contains code to manage [textile](https://github.com/MTES-MCT/ecobalyse/tree/staging/backend/textile) data on the backend, but it is disabled.
This PR adds improvements to flush the work already done. It is still disabled but reverting the last commit allows to enable it again. I'll enable it in another branch and then work on something else.

- Store and modify textile json in the backend
- naming and fieldsets improvements on the forms
- allow to create an example by copying example json as is, from the frontend to the backend