### PR TITLE
Revert waste computation fix temporarily (refs #577)

### DIFF
--- a/src/Data/Textile/Simulator.elm
+++ b/src/Data/Textile/Simulator.elm
@@ -573,7 +573,14 @@ computeFabricStepWaste { textile } ({ inputs, lifeCycle } as simulator) =
         { mass, waste } =
             lifeCycle
                 |> LifeCycle.getStepProp Label.Making .inputMass Quantity.zero
-                |> Formula.genericWaste (Fabric.getProcess textile.wellKnown inputs.product.fabric |> .waste)
+                |> Formula.genericWaste
+                    -- FIXME: we should rather use inputs.fabricProcess here, but we must
+                    --        avoid updating results in production until next milestone.
+                    --        @see https://github.com/MTES-MCT/ecobalyse/pull/577
+                    (inputs.product.fabric
+                        |> Fabric.getProcess textile.wellKnown
+                        |> .waste
+                    )
     in
     simulator
         |> updateLifeCycleStep Label.Fabric (Step.updateWaste waste mass)

--- a/src/Data/Textile/Simulator.elm
+++ b/src/Data/Textile/Simulator.elm
@@ -573,11 +573,7 @@ computeFabricStepWaste { textile } ({ inputs, lifeCycle } as simulator) =
         { mass, waste } =
             lifeCycle
                 |> LifeCycle.getStepProp Label.Making .inputMass Quantity.zero
-                |> Formula.genericWaste
-                    (inputs.fabricProcess
-                        |> Fabric.getProcess textile.wellKnown
-                        |> .waste
-                    )
+                |> Formula.genericWaste (Fabric.getProcess textile.wellKnown inputs.product.fabric |> .waste)
     in
     simulator
         |> updateLifeCycleStep Label.Fabric (Step.updateWaste waste mass)


### PR DESCRIPTION
This patch temporarily reverts #577 because we must not land code changing computation results in production until next official release.