### PR TITLE
docs: enhance README

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,7 @@
+ALLOWED_HOSTS=localhost,127.0.0.1
 BACKEND_ADMINS=foo@bar.baz,baz@bar.foo
 DEFAULT_FROM_EMAIL=bar@foo.baz
-DJANGO_DEBUG=False
+DJANGO_DEBUG=True
 DJANGO_SECRET_KEY=please-change-this
 DJANGO_BYPASS_AUTH=False
 EMAIL_HOST_PASSWORD=please-change-this

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -36,13 +36,11 @@ SECRET_KEY = config("DJANGO_SECRET_KEY", "dev_not_so_secret_key")
 # SECURITY WARNING: don't bypass auth in production
 BYPASS_AUTH = config("DJANGO_BYPASS_AUTH", cast=bool, default=False)
 
-ALLOWED_HOSTS = [
-    HOSTNAME,
-    "localhost",
-    "127.0.0.1",
-    ".osc-fr1.scalingo.io",
-    "staging-ecobalyse.incubateur.net",
-]
+ALLOWED_HOSTS = config(
+    "ALLOWED_HOSTS",
+    f"{HOSTNAME},localhost,127.0.0.1",
+    cast=lambda v: [s.strip() for s in v.split(",")],
+)
 
 
 # Application definition


### PR DESCRIPTION
# Proposed changes

- [x] As `env.sample` should be used for dev purposes, having debug enabled by default seems to make sense.
- [x] Add simple docker setup for PG in the README
- [x] Allow ALLOWED_HOSTS to be overridden by a config value
- [x] Listen only on `127.0.0.1` when starting the backend to be aligned with the default `ALLOWED_HOSTS` 
- [x] Add ALLOWED_HOSTS env variable to scalingo 