### PR TITLE
Add missing `gettext` in CI build

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -60,6 +60,12 @@ jobs:
     - name: Install Python dependencies
       run: pip install pipenv && pipenv install
 
+
+    - name: Install Ubuntu dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y gettext
+
     - name: Build app
       run: npm run build --if-present
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ L'application est accessible [à cette adresse](https://ecobalyse.beta.gouv.fr/)
 
 ## Socle technique et prérequis
 
-Cette application est écrite en [Elm](https://elm-lang.org/). Vous devez disposer d'un environnement [NodeJS](https://nodejs.org/fr/) 14+ et `npm`, ainsi que d'un environnement [python](https://www.python.org/) >=3.11 et [pipenv](https://pipenv.pypa.io/) sur votre machine :
+Cette application est écrite en [Elm](https://elm-lang.org/). Vous devez disposer d'un environnement [NodeJS](https://nodejs.org/fr/) 14+ et `npm`, ainsi que d'un environnement [python](https://www.python.org/) >=3.11, [pipenv](https://pipenv.pypa.io/) et [gettext](https://www.gnu.org/software/gettext/) sur votre machine :
 
 ## Installation
 


### PR DESCRIPTION
## :wrench: Problem

Currently, there is a silent error in the CI due to the absence of `gettext`.

![image](https://github.com/MTES-MCT/ecobalyse/assets/154904/5e284dd8-421c-49ab-9ec6-c46bfd29cffc)

## :cake: Solution

Install `gettext` in the CI build.