### PR TITLE
Fix backend tests

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -76,4 +76,4 @@ jobs:
       run: npm run test:client
 
     - name: Run server tests
-      run: pipenv run backend/update.sh && npm run test:server-ci
+      run: pipenv run backend/update.sh && npm run test:server-ci && npm run test:backend

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Ensure having a PostgreSQL >=16 server running locally.
 
 Pour initialiser la base de données (attention, toutes les données présentes, si il y en a, seront supprimées) :
 
-    $ npm run backend:start
+    $ npm run start:backend
 
 ## Configuration
 

--- a/backend/authentication/tests.py
+++ b/backend/authentication/tests.py
@@ -88,11 +88,14 @@ class DjangoAuthenticationTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(json.loads(response.content).get("success"), True)
 
-        # wrong json login url
-        response = self.client.get(
-            "/accounts/login/1::1ru4fl:Z3XQ1tyORtolai5tycqK99BjUgzefc7o-mfui0DQFa0?next=/"
-        )
-        self.assertEqual(response.status_code, 403)
+        with self.assertLogs(logger="mailauth.backends", level="ERROR") as cm:
+            # wrong json login url
+            response = self.client.get(
+                "/accounts/login/1::1ru4fl:Z3XQ1tyORtolai5tycqK99BjUgzefc7o-mfui0DQFa0?next=/"
+            )
+            self.assertEqual(response.status_code, 403)
+
+            self.assertIn("BadSignature", " ".join(cm.output))
 
         # right json login url (it's transmitted through environ in test mode)
         self.assertEqual(len(mail.outbox), 1)

--- a/backend/authentication/tests.py
+++ b/backend/authentication/tests.py
@@ -90,9 +90,7 @@ class DjangoAuthenticationTests(TestCase):
 
         with self.assertLogs(logger="mailauth.backends", level="ERROR") as cm:
             # wrong json login url
-            response = self.client.get(
-                "/accounts/login/1::1ru4fl:Z3XQ1tyORtolai5tycqK99BjUgzefc7o-mfui0DQFa0?next=/"
-            )
+            response = self.client.get("/accounts/login/invalid-token?next=/")
             self.assertEqual(response.status_code, 403)
 
             self.assertIn("BadSignature", " ".join(cm.output))

--- a/package.json
+++ b/package.json
@@ -6,8 +6,6 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "backend:test": "pipenv run backend/manage.py test authentication",
-    "backend:start": "cd backend && pipenv run ./update.sh && pipenv run ./manage.py runserver 0.0.0.0:8002",
     "build": "npm run server:build && rimraf dist && npm run build:init && parcel build index.html --public-url ./",
     "build:init": "./bin/update-version.sh && mkdir -p dist && cp -r public/* dist/ && npm run db:build",
     "processes:build": "elm make src/ComputeAggregated.elm --output=compute-aggregated-app.js && node compute-aggregated.js",
@@ -26,14 +24,16 @@
     "server:dev": "npm run server:build && nodemon server.js --config nodemon.json",
     "server:debug": "elm make src/Server.elm --output=server-app.js && nodemon server.js --config nodemon.json",
     "server:start": "node server.js",
+    "start:backend": "cd backend && pipenv run ./update.sh && pipenv run ./manage.py runserver 0.0.0.0:8002",
     "start:parcel": "parcel serve index.html --no-cache",
-    "start:dev": "npm run build:init && concurrently -k -n \"parcel,server,backend\" -c \"green,cyan,yellow\" \"npm run start:parcel\" \"npm run server:dev\" \"npm run backend:start\"",
+    "start:dev": "npm run build:init && concurrently -k -n \"parcel,server,backend\" -c \"green,cyan,yellow\" \"npm run start:parcel\" \"npm run server:dev\" \"npm run start:backend\"",
     "start": "PARCEL_ELM_NO_DEBUG=1 npm run start:dev",
+    "test:backend": "pipenv run backend/manage.py test authentication",
     "test:client": "npx elm-test",
     "test:review": "npx elm-review",
     "test:server": "npm run server:build && jest",
-    "test:server-ci": "concurrently -k -s first -n \"django,test\" \"npm run backend:start\" \"while ! lsof -i:8002; do sleep 1; done && npm run server:build && jest\"",
-    "test": "npm run db:build && npm run test:review && npm run test:client && npm run backend:test && npm run test:server"
+    "test:server-ci": "concurrently -k -s first -n \"django,test\" \"npm run start:backend\" \"while ! lsof -i:8002; do sleep 1; done && npm run server:build && jest\"",
+    "test": "npm run db:build && npm run test:review && npm run test:client && npm run test:backend && npm run test:server"
   },
   "dependencies": {
     "@parcel/transformer-elm": "^2.12.0",


### PR DESCRIPTION
## :wrench: Problem

- Backend tests are not run in the CI
- `npm` command/scripts naming is inconsistent between the front and the back
- We display a stack track in the Django tests and don't check for the exact exception thrown

## :cake: Solution

Run the tests in the CI by adding an entry into the `node.js.yml` file and rename the inconsistent commands in `package.json`.

As the authenticate can fail for many reasons (expired token, user missing) we test that it's the appropriate exception that is raised in the python logs and silent the output at the same time.

## :desert_island: How to test

- The CI should pass
- `npm test`, `start:dev` and `npm test:server-ci` should work as usual