### PR TITLE
Set textile explorer default tab to product examples.

### DIFF
--- a/src/Views/Page.elm
+++ b/src/Views/Page.elm
@@ -136,7 +136,7 @@ mainMenuLinks { enableFoodSection } =
 
           else
             Nothing
-        , Just <| Internal "Explorateur" (Route.Explore Scope.Textile (Dataset.Impacts Nothing)) Explore
+        , Just <| Internal "Explorateur" (Route.Explore Scope.Textile (Dataset.TextileExamples Nothing)) Explore
         , Just <| Internal "API" Route.Api Api
         ]
 


### PR DESCRIPTION
[User story](https://www.notion.so/Dans-l-explorateur-rebasculer-par-d-faut-sur-les-exemples-4b32805fc18e45f78ddd7d2651579d7d?d=23567da9dc644c40bb2ea9ffa6b99917)