### PR TITLE
chore: dont't format `*.md` files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,7 @@
 *.yml
 *.yaml
 *.html
+*.md
 package-lock.json
 public/icomoon/*
 public/vendor/*


### PR DESCRIPTION
## :wrench: Problem

Prettier formats the upcoming CHANGELOG.md automatically and breaks the automatic release.

## :cake: Solution

Add `*.md` file to `.prettierignore`