### PR TITLE
fix: yarnSize API param wasn't parsed when provided as float.

### DIFF
--- a/src/Data/Textile/Formula.elm
+++ b/src/Data/Textile/Formula.elm
@@ -465,7 +465,7 @@ computeThreadDensity surfaceMass yarnSize =
             1.08
     in
     toFloat (Unit.surfaceMassInGramsPerSquareMeters surfaceMass)
-        * toFloat (Unit.yarnSizeInKilometers yarnSize)
+        * Unit.yarnSizeInKilometers yarnSize
         -- the output surface is in (m2) so we would have the threadDensity is in (# fils / m) but we need it in (# fils / cm)
         / 100
         -- the thread is weaved horizontally and vertically, so the number of threads along one axis is only half of the total thread length

--- a/src/Data/Textile/Inputs.elm
+++ b/src/Data/Textile/Inputs.elm
@@ -250,7 +250,7 @@ stepsToStrings inputs =
         ]
     , case inputs.yarnSize of
         Just yarnSize ->
-            [ "titrage", String.fromInt (Unit.yarnSizeInKilometers yarnSize) ++ "Nm" ]
+            [ "titrage", String.fromFloat (Unit.yarnSizeInKilometers yarnSize) ++ "Nm" ]
 
         Nothing ->
             []

--- a/src/Data/Textile/Material/Spinning.elm
+++ b/src/Data/Textile/Material/Spinning.elm
@@ -147,7 +147,7 @@ getElec : Mass -> Unit.YarnSize -> Spinning -> Float
 getElec mass yarnSize spinning =
     -- See the formula in https://fabrique-numerique.gitbook.io/ecobalyse/textile/etapes-du-cycle-de-vie/etape-2-fabrication-du-fil-new-draft#consommation-delectricite
     -- Formula: kWh(Process) = YarnSize(Nm) / 50 * Normalization(Process) * OutputMass(kg)
-    (Unit.yarnSizeInKilometers yarnSize |> toFloat)
+    Unit.yarnSizeInKilometers yarnSize
         / 50
         * normalization spinning
         * Mass.inKilograms mass

--- a/src/Data/Textile/Step.elm
+++ b/src/Data/Textile/Step.elm
@@ -467,12 +467,12 @@ makingDeadStockToString makingDeadStock =
 
 yarnSizeToString : Unit.YarnSize -> String
 yarnSizeToString yarnSize =
-    "Titrage\u{00A0}: " ++ String.fromInt (Unit.yarnSizeInKilometers yarnSize) ++ "\u{202F}Nm (" ++ yarnSizeToDtexString yarnSize ++ ")"
+    "Titrage\u{00A0}: " ++ String.fromFloat (Unit.yarnSizeInKilometers yarnSize) ++ "\u{202F}Nm (" ++ yarnSizeToDtexString yarnSize ++ ")"
 
 
 yarnSizeToDtexString : Unit.YarnSize -> String
 yarnSizeToDtexString yarnSize =
-    String.fromInt (Unit.yarnSizeInGrams yarnSize) ++ "\u{202F}Dtex"
+    String.fromFloat (Unit.yarnSizeInGrams yarnSize) ++ "\u{202F}Dtex"
 
 
 encode : Step -> Encode.Value

--- a/src/Page/Explore/TextileProducts.elm
+++ b/src/Page/Explore/TextileProducts.elm
@@ -60,7 +60,7 @@ table db { detailed, scope } =
           , toCell = .name >> text
           }
         , { label = "Titrage*"
-          , toValue = Table.IntValue <| .yarnSize >> Unit.yarnSizeInKilometers
+          , toValue = Table.FloatValue <| .yarnSize >> Unit.yarnSizeInKilometers
           , toCell =
                 \product ->
                     div [ classList [ ( "text-center", not detailed ) ] ]

--- a/src/Server/Query.elm
+++ b/src/Server/Query.elm
@@ -732,18 +732,18 @@ parseYarnSize str =
                 |> Regex.find withUnitRegex
                 |> List.map .submatches
     in
-    case String.toInt str of
-        Just int ->
-            Just <| Unit.yarnSizeKilometersPerKg int
+    case String.toFloat str of
+        Just float ->
+            Just <| Unit.yarnSizeKilometersPerKg float
 
         Nothing ->
             case subMatches of
-                [ [ Just intStr, Just "Nm" ] ] ->
-                    String.toInt intStr
+                [ [ Just floatStr, Just "Nm" ] ] ->
+                    String.toFloat floatStr
                         |> Maybe.map Unit.yarnSizeKilometersPerKg
 
-                [ [ Just intStr, Just "Dtex" ] ] ->
-                    String.toInt intStr
+                [ [ Just floatStr, Just "Dtex" ] ] ->
+                    String.toFloat floatStr
                         |> Maybe.map Unit.yarnSizeGramsPer10km
 
                 _ ->
@@ -759,17 +759,21 @@ maybeYarnSizeParser key =
                     case parseYarnSize str of
                         Just yarnSize ->
                             if (yarnSize |> Quantity.lessThan Unit.minYarnSize) || (yarnSize |> Quantity.greaterThan Unit.maxYarnSize) then
+                                let
+                                    format fn =
+                                        fn >> floor >> String.fromInt
+                                in
                                 Err
                                     ( key
                                     , "Le titrage (yarnSize) doit être compris entre "
-                                        ++ String.fromInt (Unit.yarnSizeInKilometers Unit.minYarnSize)
+                                        ++ (Unit.minYarnSize |> format Unit.yarnSizeInKilometers)
                                         ++ " et "
-                                        ++ String.fromInt (Unit.yarnSizeInKilometers Unit.maxYarnSize)
+                                        ++ (Unit.maxYarnSize |> format Unit.yarnSizeInKilometers)
                                         ++ " Nm (entre "
                                         -- The following two are reversed in Dtex because the unit is "reversed"
-                                        ++ String.fromInt (Unit.yarnSizeInGrams Unit.maxYarnSize)
+                                        ++ (Unit.maxYarnSize |> format Unit.yarnSizeInGrams)
                                         ++ " et "
-                                        ++ String.fromInt (Unit.yarnSizeInGrams Unit.minYarnSize)
+                                        ++ (Unit.minYarnSize |> format Unit.yarnSizeInGrams)
                                         ++ " Dtex)"
                                     )
 

--- a/src/Views/Format.elm
+++ b/src/Views/Format.elm
@@ -210,7 +210,7 @@ picking =
 
 yarnSize : Unit.YarnSize -> Html msg
 yarnSize =
-    Unit.yarnSizeInKilometers >> toFloat >> formatRichFloat 0 "Nm"
+    Unit.yarnSizeInKilometers >> formatRichFloat 0 "Nm"
 
 
 ratio : Unit.Ratio -> Html msg

--- a/src/Views/RangeSlider.elm
+++ b/src/Views/RangeSlider.elm
@@ -84,14 +84,14 @@ yarnSize config =
         { id = config.id
         , label = config.toString config.value
         , attributes =
-            [ onInput (String.toInt >> Maybe.map Unit.yarnSizeKilometersPerKg >> config.update)
-            , Attr.min (String.fromInt (Unit.yarnSizeInKilometers Unit.minYarnSize))
-            , Attr.max (String.fromInt (Unit.yarnSizeInKilometers Unit.maxYarnSize))
+            [ onInput (String.toFloat >> Maybe.map Unit.yarnSizeKilometersPerKg >> config.update)
+            , Attr.min (String.fromFloat (Unit.yarnSizeInKilometers Unit.minYarnSize))
+            , Attr.max (String.fromFloat (Unit.yarnSizeInKilometers Unit.maxYarnSize))
 
             -- WARNING: be careful when reordering attributes: for obscure reasons,
             -- the `value` one MUST be set AFTER the `step` one.
             , step "1"
-            , value (String.fromInt (Unit.yarnSizeInKilometers config.value))
+            , value (String.fromFloat (Unit.yarnSizeInKilometers config.value))
             , Attr.disabled config.disabled
             ]
         }

--- a/tests/Data/UnitTest.elm
+++ b/tests/Data/UnitTest.elm
@@ -110,5 +110,15 @@ suite =
                     |> expectImpactFloat 0.5
                     |> asTest "should compute impact from ratioed impact and energy in MJ"
                 ]
+            , describe "Unit.decodeYarnSize"
+                [ "27"
+                    |> Decode.decodeString Unit.decodeYarnSize
+                    |> Expect.equal (Ok (Unit.yarnSizeKilometersPerKg 27))
+                    |> asTest "should decode an int yarnSize value"
+                , "27.04"
+                    |> Decode.decodeString Unit.decodeYarnSize
+                    |> Expect.equal (Ok (Unit.yarnSizeKilometersPerKg 27.04))
+                    |> asTest "should decode a float yarnSize value"
+                ]
             ]
         ]


### PR DESCRIPTION
This patch partially address [this user story](https://www.notion.so/Bug-API-52a9084b9f404f1faf14b9d27a2339cf), most notably the bug regarding the `yarnSize` API param parsing. Yes at some point we'll want one single card per bug.

## 🐛 Understanding the bug

```elm
> import Json.Decode as D
> import Data.Unit as U
> "27.04"|>D.decodeString U.decodeYarnSize
Err (Failure ("Expecting an INT") <internals>)
    : Result D.Error U.YarnSize
> "27"|>D.decodeString U.decodeYarnSize
Ok (Quantity 27000) : Result D.Error U.YarnSize
```

Yarn size cannot be expressed as floats while they should.

## 💡 Solution

Accept a yarn size to be expressed as a float.