### PR TITLE
chore: connect to PG using tunnel

### DIFF
--- a/.github/actions/scalingo-cli/action.yml
+++ b/.github/actions/scalingo-cli/action.yml
@@ -1,0 +1,15 @@
+name: "Setup Scalingo CLI"
+description: "Installs the Scalingo CLI"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Scalingo cli
+      shell: bash
+      run: |
+        BIN_DIR="$HOME/bin"
+        mkdir -p $BIN_DIR
+        PATH=$BIN_DIR:$PATH
+        echo "$BIN_DIR" >> "$GITHUB_PATH"
+        wget https://cli-dl.scalingo.com/install
+        bash ./install -i $BIN_DIR

--- a/.github/workflows/score_history.yml
+++ b/.github/workflows/score_history.yml
@@ -84,9 +84,12 @@ jobs:
           SCALINGO_API_TOKEN: ${{ secrets.SCALINGO_API_TOKEN }}
         run: |
           npm run server:build
+          scalingo db-tunnel DATABASE_URL &
           npm run server:start &
           npm run start:backend &
+
           for attempt in {1..20}; do sleep 1; if curl -s http://localhost:8001/ > /dev/null; then echo "-> Node server is up and ready on port 8001"; break; fi; echo "-> Waiting for the Node server to boot..."; done
           for attempt in {1..20}; do sleep 1; if curl -s http://localhost:8002/ > /dev/null; then echo "-> Python server is up and ready on port 8002"; break; fi; echo "-> Waiting for the Python server to boot..."; done
-          scalingo db-tunnel DATABASE_URL &
+          for attempt in {1..20}; do sleep 1; if lsof -i:10000 > /dev/null; then echo "-> PG Tunnel to Scalingo is up and ready on port 10000"; break; fi; echo "-> Waiting for the PG tunnel to Scalingo..."; done
+
           python data/common/score_history/score_history.py http://localhost:8001 $GITHUB_REF_NAME $LAST_COMMIT_HASH $SCALINGO_POSTGRESQL_SCORE_URL

--- a/.github/workflows/score_history.yml
+++ b/.github/workflows/score_history.yml
@@ -20,6 +20,9 @@ jobs:
 
       - uses: actions/checkout@v4
 
+      - name: Install Scalingo CLI
+        uses: ./.github/actions/scalingo-cli
+
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
@@ -73,13 +76,17 @@ jobs:
         env:
           GITHUB_REF_NAME: ${{ github.ref_name }}
           LAST_COMMIT_HASH: ${{ github.sha }}
-          SCALINGO_POSTGRESQL_SCORE_URL: ${{ secrets.SCALINGO_POSTGRESQL_SCORE_URL }}
+          SCALINGO_POSTGRESQL_SCORE_URL: ${{ secrets.SCALINGO_POSTGRESQL_TUNNEL_SCORE_URL }}
           DJANGO_BYPASS_AUTH: True
           NODE_ENV: "test"
+          SCALINGO_REGION: ${{ secrets.SCALINGO_REGION }}
+          SCALINGO_APP: ecobalyse
+          SCALINGO_API_TOKEN: ${{ secrets.SCALINGO_API_TOKEN }}
         run: |
           npm run server:build
           npm run server:start &
           npm run start:backend &
           for attempt in {1..20}; do sleep 1; if curl -s http://localhost:8001/ > /dev/null; then echo "-> Node server is up and ready on port 8001"; break; fi; echo "-> Waiting for the Node server to boot..."; done
           for attempt in {1..20}; do sleep 1; if curl -s http://localhost:8002/ > /dev/null; then echo "-> Python server is up and ready on port 8002"; break; fi; echo "-> Waiting for the Python server to boot..."; done
+          scalingo db-tunnel DATABASE_URL &
           python data/common/score_history/score_history.py http://localhost:8001 $GITHUB_REF_NAME $LAST_COMMIT_HASH $SCALINGO_POSTGRESQL_SCORE_URL

--- a/.github/workflows/score_history.yml
+++ b/.github/workflows/score_history.yml
@@ -101,8 +101,8 @@ jobs:
           npm run server:start &
           npm run start:backend &
 
-          for attempt in {1..20}; do sleep 1; if curl -s http://localhost:8001/ > /dev/null; then echo "-> Node server is up and ready on port 8001"; break; fi; echo "-> Waiting for the Node server to boot..."; done
-          for attempt in {1..20}; do sleep 1; if curl -s http://localhost:8002/ > /dev/null; then echo "-> Python server is up and ready on port 8002"; break; fi; echo "-> Waiting for the Python server to boot..."; done
-          for attempt in {1..20}; do sleep 1; if lsof -i:10000 > /dev/null; then echo "-> PG Tunnel to Scalingo is up and ready on port 10000"; break; fi; echo "-> Waiting for the PG tunnel to Scalingo..."; done
+          for attempt in {1..20}; do if curl -s http://localhost:8001/ > /dev/null; then echo "-> Node server is up and ready on port 8001"; break; fi; echo "-> Waiting for the Node server to boot..."; sleep 1; done
+          for attempt in {1..20}; do if curl -s http://localhost:8002/ > /dev/null; then echo "-> Python server is up and ready on port 8002"; break; fi; echo "-> Waiting for the Python server to boot..."; sleep 1; done
+          for attempt in {1..20}; do if lsof -i:10000 > /dev/null; then echo "-> PG Tunnel to Scalingo is up and ready on port 10000"; break; fi; echo "-> Waiting for the PG tunnel to Scalingo..."; sleep 1; done
 
           python data/common/score_history/score_history.py http://localhost:8001 $GITHUB_REF_NAME $LAST_COMMIT_HASH $SCALINGO_POSTGRESQL_SCORE_URL

--- a/.github/workflows/score_history.yml
+++ b/.github/workflows/score_history.yml
@@ -72,6 +72,19 @@ jobs:
       - name: Install dependencies
         run: pip install numpy pandas requests python-dotenv GitPython sqlalchemy psycopg2
 
+
+      - name: Add scalingo to know hosts
+        run: echo "KNOWN_HOSTS=$(ssh-keyscan -H ssh.osc-fr1.scalingo.com)" >> $GITHUB_ENV
+
+      - name: Install SSH key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.SCALINGO_SSH_KEY }}
+          name: id_rsa # optional
+          known_hosts: ${{ env.KNOWN_HOSTS }}
+          config: ${{ secrets.CONFIG }} # ssh_config; optional
+          if_key_exists: fail # replace / ignore / fail; optional (defaults to fail)
+
       - name: Score History
         env:
           GITHUB_REF_NAME: ${{ github.ref_name }}


### PR DESCRIPTION
## :wrench: Problem

Currently we use a direct connection to the PostgreSQL exposed publicly. As we want to close the public access, we have to find another way to connect to PG.

## :cake: Solution

Use the scalingo CLI to create a tunnel between Github Actions and PG.

## :rotating_light:  Points to watch / comments

I am using a personal access token for the scalingo API access. We should change it as soon as we got the new `dev@ecobalyse.beta.gouv.fr` email and service account on Scalingo.

## :desert_island: How to test

The `score_history` action should not fail.