### PR TITLE
fix(ui): Round Dtex number in the web UI.

### DIFF
--- a/src/Data/Textile/Step.elm
+++ b/src/Data/Textile/Step.elm
@@ -472,7 +472,7 @@ yarnSizeToString yarnSize =
 
 yarnSizeToDtexString : Unit.YarnSize -> String
 yarnSizeToDtexString yarnSize =
-    String.fromFloat (Unit.yarnSizeInGrams yarnSize) ++ "\u{202F}Dtex"
+    Format.formatFloat 2 (Unit.yarnSizeInGrams yarnSize) ++ "\u{202F}Dtex"
 
 
 encode : Step -> Encode.Value


### PR DESCRIPTION
[User story](https://www.notion.so/Arrondir-le-nombre-Dtex-dans-l-UI-Web-a5d957cc6acb4940a7c95d268ea7ac51)

![image](https://github.com/MTES-MCT/ecobalyse/assets/41547/d01c87c3-d6d3-4e32-b3ea-379d38dd24ed)
