### PR TITLE
fix: add missing condition in `release-please` workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -41,12 +41,14 @@ jobs:
           npm run build:standalone-app
 
       - name: Clone the detailed impacts
+        if: ${{ steps.release.outputs.release_created }}
         run: |
           eval `ssh-agent -s`
           ssh-add - <<< '${{ secrets.PRIVATE_SSH_KEY }}'
           git clone git@github.com:MTES-MCT/ecobalyse-private.git
 
       - name: Encrypt the impacts files
+        if: ${{ steps.release.outputs.release_created }}
         env:
           ENCRYPTION_KEY: ${{ secrets.ENCRYPTION_KEY }}
         run : |


### PR DESCRIPTION
## :wrench: Problem

`release-please` tries to encrypt the files even if no release was created.

## :cake: Solution

Add the missing `if`.

## :desert_island: How to test

After the merge on master, the next release-please build should be ok.