### PR TITLE
chore: provide a way to synchronise a branch of `ecobalyse-private` with a PR

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,5 +1,5 @@
 https://github.com/Scalingo/ssh-private-key-buildpack.git
+https://github.com/Scalingo/python-buildpack
 https://github.com/MTES-MCT/ecobalyse-buildpack-run.git
 https://github.com/Scalingo/nodejs-buildpack
-https://github.com/Scalingo/python-buildpack
 https://github.com/Scalingo/nginx-buildpack.git

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -75,6 +75,13 @@ jobs:
         # The corresponding public key must be set as a deploy key of the private repo
         ssh-add - <<< '${{ secrets.PRIVATE_SSH_KEY }}'
         git clone git@github.com:MTES-MCT/ecobalyse-private.git
+        DATA_BRANCH_NAME=$(./bin/extract-data-branch-from-pr.sh $GITHUB_SHA)
+        if [ $? -eq 0 ]; then
+          cd ecobalyse-private
+          echo "-> Checkout branch $DATA_BRANCH_NAME of ecobalyse-private"
+          git checkout $DATA_BRANCH_NAME && git pull
+          cd ..
+        fi
 
     - name: Build app
       run: npm run build --if-present

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -69,18 +69,24 @@ jobs:
         sudo apt-get install -y gettext
 
     - name: Clone the detailed impacts
+      env:
+        GITHUB_SHA: ${{ github.sha }}
       run: |
         eval `ssh-agent -s`
         # Private ssh key used by this Github action to clone the private repo
         # The corresponding public key must be set as a deploy key of the private repo
         ssh-add - <<< '${{ secrets.PRIVATE_SSH_KEY }}'
         git clone git@github.com:MTES-MCT/ecobalyse-private.git
+
         DATA_BRANCH_NAME=$(./bin/extract-data-branch-from-pr.sh $GITHUB_SHA)
-        if [ $? -eq 0 ]; then
+
+        if [ ! -z $DATA_BRANCH_NAME ]; then
           cd ecobalyse-private
           echo "-> Checkout branch $DATA_BRANCH_NAME of ecobalyse-private"
           git checkout $DATA_BRANCH_NAME && git pull
           cd ..
+        else
+          echo "-> No specific ecobalyse-data branch found for $GITHUB_SHA. Using master."
         fi
 
     - name: Build app

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -81,9 +81,9 @@ jobs:
     - name: Checkout specific ecobalyse-private branch
       if: ${{ github.event_name == 'pull_request' }}
       env:
-        GITHUB_SHA: ${{ github.event.pull_request.head.sha }}
+        LAST_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
       run: |
-        DATA_BRANCH_NAME=$(./bin/extract-data-branch-from-pr.sh $GITHUB_SHA)
+        DATA_BRANCH_NAME=$(./bin/extract-data-branch-from-pr.sh $LAST_COMMIT_SHA)
 
         if [ ! -z $DATA_BRANCH_NAME ]; then
           cd ecobalyse-private
@@ -91,7 +91,7 @@ jobs:
           git checkout $DATA_BRANCH_NAME && git pull
           cd ..
         else
-          echo "-> No specific ecobalyse-data branch found for $GITHUB_SHA. Using master."
+          echo "-> No specific ecobalyse-data branch found for $LAST_COMMIT_SHA. Using master."
         fi
 
     - name: Build app

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -85,16 +85,7 @@ jobs:
         # Private ssh key used by this Github action to clone the private repo
         # The corresponding public key must be set as a deploy key of the private repo
         ssh-add - <<< '${{ secrets.PRIVATE_SSH_KEY }}'
-        DATA_BRANCH_NAME=$(./bin/extract-data-branch-from-pr.sh $LAST_COMMIT_SHA)
-
-        if [ ! -z $DATA_BRANCH_NAME ]; then
-          cd ecobalyse-private
-          echo "-> Checkout branch $DATA_BRANCH_NAME of ecobalyse-private"
-          git checkout $DATA_BRANCH_NAME && git pull
-          cd ..
-        else
-          echo "-> No specific ecobalyse-data branch found for $LAST_COMMIT_SHA. Using master."
-        fi
+        ./bin/checkout-ecobalyse-private-branch.sh $LAST_COMMIT_SHA
 
     - name: Build app
       run: npm run build --if-present

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -78,6 +78,11 @@ jobs:
         ssh-add - <<< '${{ secrets.PRIVATE_SSH_KEY }}'
         git clone git@github.com:MTES-MCT/ecobalyse-private.git
 
+    - name: Checkout specific ecobalyse-private branch
+      if: ${{ github.event_name == 'pull_request' }}
+      env:
+        GITHUB_SHA: ${{ github.event.pull_request.head.sha }}
+      run: |
         DATA_BRANCH_NAME=$(./bin/extract-data-branch-from-pr.sh $GITHUB_SHA)
 
         if [ ! -z $DATA_BRANCH_NAME ]; then

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -69,8 +69,6 @@ jobs:
         sudo apt-get install -y gettext
 
     - name: Clone the detailed impacts
-      env:
-        GITHUB_SHA: ${{ github.sha }}
       run: |
         eval `ssh-agent -s`
         # Private ssh key used by this Github action to clone the private repo
@@ -83,6 +81,10 @@ jobs:
       env:
         LAST_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
       run: |
+        eval `ssh-agent -s`
+        # Private ssh key used by this Github action to clone the private repo
+        # The corresponding public key must be set as a deploy key of the private repo
+        ssh-add - <<< '${{ secrets.PRIVATE_SSH_KEY }}'
         DATA_BRANCH_NAME=$(./bin/extract-data-branch-from-pr.sh $LAST_COMMIT_SHA)
 
         if [ ! -z $DATA_BRANCH_NAME ]; then

--- a/.github/workflows/score_history.yml
+++ b/.github/workflows/score_history.yml
@@ -84,6 +84,16 @@ jobs:
           ssh-add - <<< '${{ secrets.PRIVATE_SSH_KEY }}'
           git clone git@github.com:MTES-MCT/ecobalyse-private.git
 
+      - name: Checkout specific ecobalyse-private branch
+        run: |
+          eval `ssh-agent -s`
+          # Private ssh key used by this Github action to clone the private repo
+          # The corresponding public key must be set as a deploy key of the private repo
+          ssh-add - <<< '${{ secrets.PRIVATE_SSH_KEY }}'
+          # As this action is not triggered by the pull_request event, the current sha
+          # can be found in $GITHUB_SHA (setup by github actions)
+          ./bin/checkout-ecobalyse-private-branch.sh $GITHUB_SHA
+
       - name: Add scalingo to know hosts
         run: echo "KNOWN_HOSTS=$(ssh-keyscan -H ssh.osc-fr1.scalingo.com)" >> $GITHUB_ENV
 

--- a/bin/checkout-ecobalyse-private-branch.sh
+++ b/bin/checkout-ecobalyse-private-branch.sh
@@ -28,7 +28,7 @@ fi
 if [ ! -z $DATA_BRANCH_NAME ]; then
   cd ecobalyse-private
   echo "-> Checkout branch $DATA_BRANCH_NAME of ecobalyse-private"
-  git checkout $DATA_BRANCH_NAME && git pull
+  git checkout $DATA_BRANCH_NAME
   cd ..
 else
   echo "-> No specific ecobalyse-data branch found for $COMMIT. Using main."

--- a/bin/checkout-ecobalyse-private-branch.sh
+++ b/bin/checkout-ecobalyse-private-branch.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+COMMIT=$1
+
+# Be sure to exit as soon as something goes wrong
+set -eo pipefail
+
+if [ -z "$COMMIT" ]
+then
+  echo "Missing commit hash parameter. You should provide a commit belonging to the PR you want to check."
+  echo ""
+  echo "Usage : $0 <commit_hash>"
+  exit
+fi
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+ROOT_DIR=$( dirname $SCRIPT_DIR )
+
+cd $ROOT_DIR
+
+DATA_BRANCH_NAME=$(./bin/extract-data-branch-from-pr.sh $COMMIT)
+
+if [ ! -d ecobalyse-private ]; then
+  echo "No ecobalyse-private directory found. You need to clone the private repository first."
+  exit 1;
+fi
+
+if [ ! -z $DATA_BRANCH_NAME ]; then
+  cd ecobalyse-private
+  echo "-> Checkout branch $DATA_BRANCH_NAME of ecobalyse-private"
+  git checkout $DATA_BRANCH_NAME && git pull
+  cd ..
+else
+  echo "-> No specific ecobalyse-data branch found for $COMMIT. Using main."
+fi

--- a/bin/extract-data-branch-from-pr.sh
+++ b/bin/extract-data-branch-from-pr.sh
@@ -17,7 +17,7 @@ SEARCH_RESULT=$(curl -sL "https://api.github.com/search/issues?q=$COMMIT")
 # Extract the state of the PR "state": "open"
 STATE=$(echo $SEARCH_RESULT | sed -E 's/.*"state": "([^"]*).*/\1/')
 # Check if the response contains, on a single line, a pattern of type data: branch_name
-# (that should be bart of the body)
+# (it should be part of the body)
 DATA_BRANCH=$(echo $SEARCH_RESULT | sed -E 's/.*ecobalyse_data: ([^\R]*).*/\1/g')
 
 # If the PR is open and we've found a data: branch_name value, display it

--- a/bin/extract-data-branch-from-pr.sh
+++ b/bin/extract-data-branch-from-pr.sh
@@ -14,8 +14,6 @@ fi
 
 SEARCH_RESULT=$(curl -sL "https://api.github.com/search/issues?q=$COMMIT&per_page=1&page=1&sort=updated&direction=desc")
 
-echo $SEARCH_RESULT
-
 # Extract the state of the PR "state": "open"
 STATE=$(echo $SEARCH_RESULT | sed -E 's/.*"state": "([^"]*).*/\1/')
 # Check if the response contains, on a single line, a pattern of type data: branch_name

--- a/bin/extract-data-branch-from-pr.sh
+++ b/bin/extract-data-branch-from-pr.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+COMMIT=$1
+
+# Be sure to exit as soon as something goes wrong
+set -eo pipefail
+
+if [ -z "$COMMIT" ]
+then
+  echo "Missing commit hash parameter. You should provide a commit belonging to the PR you want to check."
+  echo ""
+  echo "Usage : $0 <commit_hash>"
+  exit
+fi
+
+SEARCH_RESULT=$(curl -sL "https://api.github.com/search/issues?q=$COMMIT")
+
+# Extract the state of the PR "state": "open"
+STATE=$(echo $SEARCH_RESULT | sed -E 's/.*"state": "([^"]*).*/\1/')
+# Check if the response contains, on a single line, a pattern of type data: branch_name
+# (that should be bart of the body)
+DATA_BRANCH=$(echo $SEARCH_RESULT | sed -E 's/.*ecobalyse_data: ([^\R]*).*/\1/g')
+
+# If the PR is open and we've found a data: branch_name value, display it
+if [[ "$STATE" == "open" && ! -z $DATA_BRANCH ]]; then
+  echo $DATA_BRANCH
+else
+  exit 1;
+fi
+

--- a/bin/extract-data-branch-from-pr.sh
+++ b/bin/extract-data-branch-from-pr.sh
@@ -14,11 +14,15 @@ fi
 
 SEARCH_RESULT=$(curl -sL "https://api.github.com/search/issues?q=$COMMIT&per_page=1&page=1&sort=updated&direction=desc")
 
+echo $SEARCH_RESULT
+
 # Extract the state of the PR "state": "open"
 STATE=$(echo $SEARCH_RESULT | sed -E 's/.*"state": "([^"]*).*/\1/')
 # Check if the response contains, on a single line, a pattern of type data: branch_name
 # (it should be part of the body)
-DATA_BRANCH=$(echo $SEARCH_RESULT | sed -E 's/.*ecobalyse_data: ([^\R]*).*/\1/g')
+# Branch names format: https://docs.github.com/en/get-started/using-git/dealing-with-special-characters-in-branch-and-tag-names#naming-branches-and-tags
+# The English alphabet (a to z and A to Z), Numbers (0 to 9), period (.), hyphen (-), underscore (_), forward slash (/)
+DATA_BRANCH=$(echo $SEARCH_RESULT | sed -E 's/.*ecobalyse_data: ([[:alnum:]./_-]*).*/\1/g')
 
 # If the PR is open and we've found a data: branch_name value, display it
 if [[ "$STATE" == "open" && ! -z $DATA_BRANCH ]]; then

--- a/bin/extract-data-branch-from-pr.sh
+++ b/bin/extract-data-branch-from-pr.sh
@@ -12,7 +12,7 @@ then
   exit
 fi
 
-SEARCH_RESULT=$(curl -sL "https://api.github.com/search/issues?q=$COMMIT")
+SEARCH_RESULT=$(curl -sL "https://api.github.com/search/issues?q=$COMMIT&per_page=1&page=1&sort=updated&direction=desc")
 
 # Extract the state of the PR "state": "open"
 STATE=$(echo $SEARCH_RESULT | sed -E 's/.*"state": "([^"]*).*/\1/')

--- a/bin/extract-data-branch-from-pr.sh
+++ b/bin/extract-data-branch-from-pr.sh
@@ -23,7 +23,4 @@ DATA_BRANCH=$(echo $SEARCH_RESULT | sed -E 's/.*ecobalyse_data: ([^\R]*).*/\1/g'
 # If the PR is open and we've found a data: branch_name value, display it
 if [[ "$STATE" == "open" && ! -z $DATA_BRANCH ]]; then
   echo $DATA_BRANCH
-else
-  exit 1;
 fi
-

--- a/buildpack-run.sh
+++ b/buildpack-run.sh
@@ -1,1 +1,13 @@
+#!/usr/bin/env bash
+
 git clone git@github.com:MTES-MCT/ecobalyse-private.git
+
+# Scalingo should set the $SOURCE_VERSION variable
+DATA_BRANCH_NAME=$(./bin/extract-data-branch-from-pr.sh $SOURCE_VERSION)
+
+if [ $? -eq 0 ]; then
+  cd ecobalyse-private
+  echo "-> Checkout branch $DATA_BRANCH_NAME of ecobalyse-private"
+  git checkout $DATA_BRANCH_NAME && git pull
+  cd ..
+fi

--- a/buildpack-run.sh
+++ b/buildpack-run.sh
@@ -5,9 +5,11 @@ git clone git@github.com:MTES-MCT/ecobalyse-private.git
 # Scalingo should set the $SOURCE_VERSION variable
 DATA_BRANCH_NAME=$(./bin/extract-data-branch-from-pr.sh $SOURCE_VERSION)
 
-if [ $? -eq 0 ]; then
+if [ ! -z $DATA_BRANCH_NAME ]; then
   cd ecobalyse-private
   echo "-> Checkout branch $DATA_BRANCH_NAME of ecobalyse-private"
   git checkout $DATA_BRANCH_NAME && git pull
   cd ..
+else
+  echo "-> No specific ecobalyse-data branch found for $SOURCE_VERSION. Using master."
 fi

--- a/buildpack-run.sh
+++ b/buildpack-run.sh
@@ -3,13 +3,4 @@
 git clone git@github.com:MTES-MCT/ecobalyse-private.git
 
 # Scalingo should set the $SOURCE_VERSION variable
-DATA_BRANCH_NAME=$(./bin/extract-data-branch-from-pr.sh $SOURCE_VERSION)
-
-if [ ! -z $DATA_BRANCH_NAME ]; then
-  cd ecobalyse-private
-  echo "-> Checkout branch $DATA_BRANCH_NAME of ecobalyse-private"
-  git checkout $DATA_BRANCH_NAME && git pull
-  cd ..
-else
-  echo "-> No specific ecobalyse-data branch found for $SOURCE_VERSION. Using master."
-fi
+./bin/checkout-ecobalyse-private-branch.sh $SOURCE_VERSION

--- a/buildpack-run.sh
+++ b/buildpack-run.sh
@@ -4,3 +4,5 @@ git clone git@github.com:MTES-MCT/ecobalyse-private.git
 
 # Scalingo should set the $SOURCE_VERSION variable
 ./bin/checkout-ecobalyse-private-branch.sh $SOURCE_VERSION
+
+python --version


### PR DESCRIPTION
## :wrench: Problem

We need a way to be able to test a PR with a specific branch of the `ecobalyse-private` repo.

## :cake: Solution

Parse the body of the PR for a line with `ecobalyse_data: <branch_name>` pattern. When deploying on scalingo, check if the current deployed commit is part of an opened PR and check if there is a `ecobalyse_data: <branch_name>` line. If so, we checkout the corresponding branch of `ecobalyse-private`.

We do the same when running the tests and score_history in the Github Workflows.

## :desert_island: How to test

Create a branch in the `ecobalyse-private`, create a PR (or use this one) with the specific line. Check that the app contains the data of the `ecobalyse-private` branch.

## :memo: Data

ecobalyse_data: organic_tomato
