### PR TITLE
fix: add ecobalyse-private to release please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,6 +9,9 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  ECOBALYSE_DATA_DIR: ./ecobalyse-private
+
 jobs:
   release-please:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## :wrench: Problem

Release please build is failing because the `ECOBALYSE_DATA_DIR` is missing.

## :cake: Solution

Add the env variable to the github workflow.

## :desert_island: How to test

Merge to master and rerun the release-build workflow that should be green.