### PR TITLE
chore: keep track of data-dir hash

### DIFF
--- a/bin/update-version.sh
+++ b/bin/update-version.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+ROOT_DIR=$( dirname $SCRIPT_DIR )
 
 # Default JSON value for the TAG
 TAG=null
+DATA_DIR_HASH=null
 
 # If the SOURCE_VERSION is provided (usually by scalingo), search for a corresponding TAG
 # Using the github API
@@ -23,4 +25,14 @@ if [[ ! -z $TAG_FOUND ]]; then
   TAG=\"$TAG_FOUND\"
 fi
 
-echo "{\"hash\": \"$HASH\", \"tag\": $TAG}" > public/version.json
+
+# If the data dir is set and it's a git repository, keep track of git hash used
+# in this version
+if [[ ! -z $ECOBALYSE_DATA_DIR && -d "$ECOBALYSE_DATA_DIR/.git" ]]; then
+  cd $ECOBALYSE_DATA_DIR
+  DATA_DIR_HASH_FOUND=$(git rev-parse HEAD)
+  DATA_DIR_HASH=\"$DATA_DIR_HASH_FOUND\"
+  cd $ROOT_DIR
+fi
+
+echo "{\"hash\": \"$HASH\", \"tag\": $TAG, \"dataDirHash\": $DATA_DIR_HASH}" > public/version.json


### PR DESCRIPTION
## :wrench: Problem

As our versions depend on a private repository, we may need later on to be sure what commit hash of this private repository was used to build the specific version. For example, it will be useful for the version history system.

## :cake: Solution

Just add an entry in the `public/version.json` file containing the hash of the private repository.

## :rotating_light:  Points to watch / comments

We don't use it/decode it on the elm side as it's not useful for the end user.

## :desert_island: How to test

Once deployed go to https://ecobalyse-pr686.osc-fr1.scalingo.io/version.json and check that `dataDirHash` key is present and that the sha is the same than the latest commit on https://github.com/MTES-MCT/ecobalyse-private

ecobalyse_data: test1