### PR TITLE
feat: Brightway explorer download buttons

### DIFF
--- a/data/notebooks/explore.py
+++ b/data/notebooks/explore.py
@@ -579,7 +579,6 @@ def display_main_data(method, impact_category, activity):
                     activity,
                 ) in bw2analyzer.ContributionAnalysis().annotated_top_emissions(lca)
             ]
-            print(bw2analyzer.ContributionAnalysis().annotated_top_emissions(lca))
             top_emissions = pandas.io.formats.style.Styler(
                 pandas.DataFrame(top_emissions_tuples, columns=top_emissions_columns)
             )

--- a/data/notebooks/explore.py
+++ b/data/notebooks/explore.py
@@ -77,12 +77,12 @@ setattr(w_back_button, "search", "")
 w_back_button.on_click(go_back)
 
 
-def w_csv_button(database, search, limit):
+def w_csv_button(contents, columns):
     csvfile = io.StringIO()
-    writer = csv.DictWriter(csvfile, fieldnames=["name"])
+    writer = csv.DictWriter(csvfile, fieldnames=columns)
     writer.writeheader()
-    for name in list(bw2data.Database(database).search(search, limit=limit)):
-        writer.writerow({"name": name["name"]})
+    for item in contents:
+        writer.writerow({key: item[key] for key in columns})
     csvfile.seek(0)
     contents = csvfile.read()
     return ipywidgets.HTML(
@@ -111,11 +111,12 @@ def display_results(database, search, limit):
         display(
             Markdown(f"## {('+' if len(results)==LIMIT else '')}{len(results)} results")
         )
+        columns = ["name", "code", "location"]
         html = pandas.io.formats.style.Styler(
-            pandas.DataFrame(results, columns=["name", "code", "location"])
+            pandas.DataFrame(results, columns=columns)
         )
         html.set_properties(**{"background-color": "#EEE"})
-        display(w_csv_button(database, search, limit))
+        display(w_csv_button(results, columns))
         display(ipywidgets.HTML(html.to_html()))
 
 

--- a/data/notebooks/explore.py
+++ b/data/notebooks/explore.py
@@ -570,26 +570,27 @@ def display_main_data(method, impact_category, activity):
             analysis = "Nothing to display. Maybe you selected the biosphere?"
         else:
             lca.lcia()
-            top_emissions_columns = ["Score", "Amount", "Unit", "Elementary flow"]
+            top_emissions_columns = ["Amount", "Score", "Unit", "Elementary flow"]
             top_emissions_tuples = [
-                (score, amount, activity["unit"], activity)
+                (amount, score, activity["unit"], activity)
                 for (
                     score,
                     amount,
                     activity,
                 ) in bw2analyzer.ContributionAnalysis().annotated_top_emissions(lca)
             ]
+            print(bw2analyzer.ContributionAnalysis().annotated_top_emissions(lca))
             top_emissions = pandas.io.formats.style.Styler(
                 pandas.DataFrame(top_emissions_tuples, columns=top_emissions_columns)
             )
             top_emissions.format(
-                formatter={"Score": "{:.4g}".format, "Amount": "{:.4g}".format}
+                formatter={"Amount": "{:.4g}".format, "Score": "{:.4g}".format}
             )
             top_emissions.set_properties(**{"background-color": "#EEE"})
             # TOP PROCESSES
-            top_processes_columns = ["Score", "Amount", "Unit", "Activity"]
+            top_processes_columns = ["Amount", "Score", "Unit", "Activity"]
             top_processes_tuples = [
-                (score, amount, activity["unit"], activity)
+                (amount, score, activity["unit"], activity)
                 for (
                     score,
                     amount,
@@ -601,12 +602,12 @@ def display_main_data(method, impact_category, activity):
             )
             top_processes.set_properties(**{"background-color": "#EEE"})
             top_processes.format(
-                formatter={"Score": "{:.4g}".format, "Amount": "{:.4g}".format}
+                formatter={"Amount": "{:.4g}".format, "Score": "{:.4g}".format}
             )
             analysis = (
                 f"<h2>{', '.join(lca.method[1:])}</h2>"
+                f"<h3>Top Emissions</h3>{w_csv_button(top_emissions_tuples, top_emissions_columns)}{top_emissions.to_html()}"
                 f"<h3>Top Processes</h3>{w_csv_button(top_processes_tuples, top_processes_columns)}{top_processes.to_html()}"
-                f"<h3>Top Emissions</h3>{w_csv_button(top_processes_tuples, top_emissions_columns)}{top_emissions.to_html()}"
             )
     else:
         analysis = "💡 Please select an impact category"


### PR DESCRIPTION
There is only one download button on the brightway explorer, to download the list of processes that appears in the search result.

This PR improves the button to include the same three columns as seen in the search result.
It also add two download buttons in the Analysis tab which allows to download the top processes and emissions as CSV.
It also reorders the amount and score columns in the analysis