### PR TITLE
chore: serve version file with relative path

### DIFF
--- a/src/Request/Version.elm
+++ b/src/Request/Version.elm
@@ -56,7 +56,7 @@ versionDataDecoder =
 
 loadVersion : (WebData VersionData -> msg) -> Cmd msg
 loadVersion event =
-    Http.get "/version.json" event versionDataDecoder
+    Http.get "version.json" event versionDataDecoder
 
 
 pollVersion : msg -> Sub msg


### PR DESCRIPTION
## :wrench: Problem

With the upcoming versioning system https://github.com/MTES-MCT/ecobalyse/pull/627 we will need to serve the app from a relative path like `/versions`, so we should serve the version file from a relative path instead of the root path.

## :cake: Solution

Use relative path when doing the HTTP request.

## :desert_island: How to test

Go to https://ecobalyse-pr693.osc-fr1.scalingo.io/ and the version at the bottom should still display the latest commit of this branch.