### PR TITLE
fix: add missing run command for score history [score_history]

### DIFF
--- a/.github/workflows/score_history.yml
+++ b/.github/workflows/score_history.yml
@@ -92,7 +92,7 @@ jobs:
           ssh-add - <<< '${{ secrets.PRIVATE_SSH_KEY }}'
           # As this action is not triggered by the pull_request event, the current sha
           # can be found in $GITHUB_SHA (setup by github actions)
-          pipenv ./bin/checkout-ecobalyse-private-branch.sh $GITHUB_SHA
+          pipenv run ./bin/checkout-ecobalyse-private-branch.sh $GITHUB_SHA
 
       - name: Add scalingo to know hosts
         run: echo "KNOWN_HOSTS=$(ssh-keyscan -H ssh.osc-fr1.scalingo.com)" >> $GITHUB_ENV
@@ -109,7 +109,6 @@ jobs:
       - name: Score History
         env:
           GITHUB_REF_NAME: ${{ github.ref_name }}
-          LAST_COMMIT_HASH: ${{ github.sha }}
           SCALINGO_POSTGRESQL_SCORE_URL: ${{ secrets.SCALINGO_POSTGRESQL_TUNNEL_SCORE_URL }}
           SCALINGO_REGION: ${{ secrets.SCALINGO_REGION }}
           SCALINGO_APP: ecobalyse
@@ -124,4 +123,4 @@ jobs:
           for attempt in {1..20}; do if curl -s http://localhost:8002/ > /dev/null; then echo "-> Python server is up and ready on port 8002"; break; fi; echo "-> Waiting for the Python server to boot..."; sleep 1; done
           for attempt in {1..20}; do if lsof -i:10000 > /dev/null; then echo "-> PG Tunnel to Scalingo is up and ready on port 10000"; break; fi; echo "-> Waiting for the PG tunnel to Scalingo..."; sleep 1; done
 
-          python data/common/score_history/score_history.py http://localhost:8001 $GITHUB_REF_NAME $LAST_COMMIT_HASH $SCALINGO_POSTGRESQL_SCORE_URL
+          python data/common/score_history/score_history.py http://localhost:8001 $GITHUB_REF_NAME $GITHUB_SHA $SCALINGO_POSTGRESQL_SCORE_URL

--- a/packages/python/ecobalyse/ecobalyse/github.py
+++ b/packages/python/ecobalyse/ecobalyse/github.py
@@ -7,6 +7,9 @@ from github import Auth, Github
 
 
 def extract_branch_name(content: str) -> str | None:
+    if not content:
+        return
+
     # Check if the response contains, on a single line, a pattern of type data: branch_name
     # (it should be part of the body)
     # Branch names format: https://docs.github.com/en/get-started/using-git/dealing-with-special-characters-in-branch-and-tag-names#naming-branches-and-tags


### PR DESCRIPTION
## :wrench: Problem

The CI build fails on master because the `run` parameter is missing in the `score_history` workflow.

## :cake: Solution

We add the missing parameter.

## :rotating_light:  Points to watch / comments

A bug in the python code was fixed at the same time when a PR is opened without a body.

## :desert_island: How to test

Run the `score_history` workflow dispatch by hand in the Github Actions.