### PR TITLE
refactor: use python to patch files

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -19,5 +19,6 @@ pytest-django = "*"
 pygithub = "*"
 ecobalyse = {file = "packages/python/ecobalyse"}
 typer = "*"
+pytest-mock = "*"
 
 [dev-packages]

--- a/Pipfile
+++ b/Pipfile
@@ -18,5 +18,6 @@ numpy = ">=1,<2"
 pytest-django = "*"
 pygithub = "*"
 ecobalyse = {file = "packages/python/ecobalyse"}
+typer = "*"
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e84cc831736b908da1e6ee4662a6463faaa2bdc7f5984ff9178f225c119d03a7"
+            "sha256": "14236ffed157d1e84479350eb98a47b630063d7cb6f480bd6735047dee264dc1"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -207,6 +207,14 @@
             "markers": "python_full_version >= '3.7.0'",
             "version": "==3.3.2"
         },
+        "click": {
+            "hashes": [
+                "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28",
+                "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==8.1.7"
+        },
         "cryptography": {
             "hashes": [
                 "sha256:0663585d02f76929792470451a5ba64424acc3cd5227b03921dab0e2f27b1709",
@@ -300,6 +308,70 @@
             "markers": "python_version >= '3.7'",
             "version": "==3.1.43"
         },
+        "greenlet": {
+            "hashes": [
+                "sha256:01bc7ea167cf943b4c802068e178bbf70ae2e8c080467070d01bfa02f337ee67",
+                "sha256:0448abc479fab28b00cb472d278828b3ccca164531daab4e970a0458786055d6",
+                "sha256:086152f8fbc5955df88382e8a75984e2bb1c892ad2e3c80a2508954e52295257",
+                "sha256:098d86f528c855ead3479afe84b49242e174ed262456c342d70fc7f972bc13c4",
+                "sha256:149e94a2dd82d19838fe4b2259f1b6b9957d5ba1b25640d2380bea9c5df37676",
+                "sha256:1551a8195c0d4a68fac7a4325efac0d541b48def35feb49d803674ac32582f61",
+                "sha256:15d79dd26056573940fcb8c7413d84118086f2ec1a8acdfa854631084393efcc",
+                "sha256:1996cb9306c8595335bb157d133daf5cf9f693ef413e7673cb07e3e5871379ca",
+                "sha256:1a7191e42732df52cb5f39d3527217e7ab73cae2cb3694d241e18f53d84ea9a7",
+                "sha256:1ea188d4f49089fc6fb283845ab18a2518d279c7cd9da1065d7a84e991748728",
+                "sha256:1f672519db1796ca0d8753f9e78ec02355e862d0998193038c7073045899f305",
+                "sha256:2516a9957eed41dd8f1ec0c604f1cdc86758b587d964668b5b196a9db5bfcde6",
+                "sha256:2797aa5aedac23af156bbb5a6aa2cd3427ada2972c828244eb7d1b9255846379",
+                "sha256:2dd6e660effd852586b6a8478a1d244b8dc90ab5b1321751d2ea15deb49ed414",
+                "sha256:3ddc0f794e6ad661e321caa8d2f0a55ce01213c74722587256fb6566049a8b04",
+                "sha256:3ed7fb269f15dc662787f4119ec300ad0702fa1b19d2135a37c2c4de6fadfd4a",
+                "sha256:419b386f84949bf0e7c73e6032e3457b82a787c1ab4a0e43732898a761cc9dbf",
+                "sha256:43374442353259554ce33599da8b692d5aa96f8976d567d4badf263371fbe491",
+                "sha256:52f59dd9c96ad2fc0d5724107444f76eb20aaccb675bf825df6435acb7703559",
+                "sha256:57e8974f23e47dac22b83436bdcf23080ade568ce77df33159e019d161ce1d1e",
+                "sha256:5b51e85cb5ceda94e79d019ed36b35386e8c37d22f07d6a751cb659b180d5274",
+                "sha256:649dde7de1a5eceb258f9cb00bdf50e978c9db1b996964cd80703614c86495eb",
+                "sha256:64d7675ad83578e3fc149b617a444fab8efdafc9385471f868eb5ff83e446b8b",
+                "sha256:68834da854554926fbedd38c76e60c4a2e3198c6fbed520b106a8986445caaf9",
+                "sha256:6b66c9c1e7ccabad3a7d037b2bcb740122a7b17a53734b7d72a344ce39882a1b",
+                "sha256:70fb482fdf2c707765ab5f0b6655e9cfcf3780d8d87355a063547b41177599be",
+                "sha256:7170375bcc99f1a2fbd9c306f5be8764eaf3ac6b5cb968862cad4c7057756506",
+                "sha256:73a411ef564e0e097dbe7e866bb2dda0f027e072b04da387282b02c308807405",
+                "sha256:77457465d89b8263bca14759d7c1684df840b6811b2499838cc5b040a8b5b113",
+                "sha256:7f362975f2d179f9e26928c5b517524e89dd48530a0202570d55ad6ca5d8a56f",
+                "sha256:81bb9c6d52e8321f09c3d165b2a78c680506d9af285bfccbad9fb7ad5a5da3e5",
+                "sha256:881b7db1ebff4ba09aaaeae6aa491daeb226c8150fc20e836ad00041bcb11230",
+                "sha256:894393ce10ceac937e56ec00bb71c4c2f8209ad516e96033e4b3b1de270e200d",
+                "sha256:99bf650dc5d69546e076f413a87481ee1d2d09aaaaaca058c9251b6d8c14783f",
+                "sha256:9da2bd29ed9e4f15955dd1595ad7bc9320308a3b766ef7f837e23ad4b4aac31a",
+                "sha256:afaff6cf5200befd5cec055b07d1c0a5a06c040fe5ad148abcd11ba6ab9b114e",
+                "sha256:b1b5667cced97081bf57b8fa1d6bfca67814b0afd38208d52538316e9422fc61",
+                "sha256:b37eef18ea55f2ffd8f00ff8fe7c8d3818abd3e25fb73fae2ca3b672e333a7a6",
+                "sha256:b542be2440edc2d48547b5923c408cbe0fc94afb9f18741faa6ae970dbcb9b6d",
+                "sha256:b7dcbe92cc99f08c8dd11f930de4d99ef756c3591a5377d1d9cd7dd5e896da71",
+                "sha256:b7f009caad047246ed379e1c4dbcb8b020f0a390667ea74d2387be2998f58a22",
+                "sha256:bba5387a6975598857d86de9eac14210a49d554a77eb8261cc68b7d082f78ce2",
+                "sha256:c5e1536de2aad7bf62e27baf79225d0d64360d4168cf2e6becb91baf1ed074f3",
+                "sha256:c5ee858cfe08f34712f548c3c363e807e7186f03ad7a5039ebadb29e8c6be067",
+                "sha256:c9db1c18f0eaad2f804728c67d6c610778456e3e1cc4ab4bbd5eeb8e6053c6fc",
+                "sha256:d353cadd6083fdb056bb46ed07e4340b0869c305c8ca54ef9da3421acbdf6881",
+                "sha256:d46677c85c5ba00a9cb6f7a00b2bfa6f812192d2c9f7d9c4f6a55b60216712f3",
+                "sha256:d4d1ac74f5c0c0524e4a24335350edad7e5f03b9532da7ea4d3c54d527784f2e",
+                "sha256:d73a9fe764d77f87f8ec26a0c85144d6a951a6c438dfe50487df5595c6373eac",
+                "sha256:da70d4d51c8b306bb7a031d5cff6cc25ad253affe89b70352af5f1cb68e74b53",
+                "sha256:daf3cb43b7cf2ba96d614252ce1684c1bccee6b2183a01328c98d36fcd7d5cb0",
+                "sha256:dca1e2f3ca00b84a396bc1bce13dd21f680f035314d2379c4160c98153b2059b",
+                "sha256:dd4f49ae60e10adbc94b45c0b5e6a179acc1736cf7a90160b404076ee283cf83",
+                "sha256:e1f145462f1fa6e4a4ae3c0f782e580ce44d57c8f2c7aae1b6fa88c0b2efdb41",
+                "sha256:e3391d1e16e2a5a1507d83e4a8b100f4ee626e8eca43cf2cadb543de69827c4c",
+                "sha256:fcd2469d6a2cf298f198f0487e0a5b1a47a42ca0fa4dfd1b6862c999f018ebbf",
+                "sha256:fd096eb7ffef17c456cfa587523c5f92321ae02427ff955bebe9e3c63bc9f0da",
+                "sha256:fe754d231288e1e64323cfad462fcee8f0288654c10bdf4f603a39ed923bef33"
+            ],
+            "markers": "platform_machine == 'aarch64' or (platform_machine == 'ppc64le' or (platform_machine == 'x86_64' or (platform_machine == 'amd64' or (platform_machine == 'AMD64' or (platform_machine == 'win32' or platform_machine == 'WIN32')))))",
+            "version": "==3.0.3"
+        },
         "gunicorn": {
             "hashes": [
                 "sha256:350679f91b24062c86e386e198a15438d53a7a8207235a78ba1b53df4c4378d9",
@@ -332,6 +404,22 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==2.0.0"
+        },
+        "markdown-it-py": {
+            "hashes": [
+                "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1",
+                "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==3.0.0"
+        },
+        "mdurl": {
+            "hashes": [
+                "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8",
+                "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==0.1.2"
         },
         "nodeenv": {
             "hashes": [
@@ -547,6 +635,14 @@
             "markers": "python_version >= '3.7'",
             "version": "==2.3.0"
         },
+        "pygments": {
+            "hashes": [
+                "sha256:786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199",
+                "sha256:b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==2.18.0"
+        },
         "pyjwt": {
             "extras": [
                 "crypto"
@@ -681,30 +777,46 @@
             "markers": "python_version >= '3.8'",
             "version": "==2.32.3"
         },
+        "rich": {
+            "hashes": [
+                "sha256:4edbae314f59eb482f54e9e30bf00d33350aaa94f4bfcd4e9e3110e64d0d7222",
+                "sha256:9be308cb1fe2f1f57d67ce99e95af38a1e2bc71ad9813b0e247cf7ffbcc3a432"
+            ],
+            "markers": "python_full_version >= '3.7.0'",
+            "version": "==13.7.1"
+        },
         "ruff": {
             "hashes": [
-                "sha256:00cc8872331055ee017c4f1071a8a31ca0809ccc0657da1d154a1d2abac5c0be",
-                "sha256:083bbcbe6fadb93cd86709037acc510f86eed5a314203079df174c40bbbca6b3",
-                "sha256:2dca26154ff9571995107221d0aeaad0e75a77b5a682d6236cf89a58c70b76f4",
-                "sha256:33d61fc0e902198a3e55719f4be6b375b28f860b09c281e4bdbf783c0566576a",
-                "sha256:4a09ea2c3f7778cc635e7f6edf57d566a8ee8f485f3c4454db7771efb692c499",
-                "sha256:548992d342fc404ee2e15a242cdbea4f8e39a52f2e7752d0e4cbe88d2d2f416a",
-                "sha256:7e31c9bad4ebf8fdb77b59cae75814440731060a09a0e0077d559a556453acbb",
-                "sha256:7f70284e73f36558ef51602254451e50dd6cc479f8b6f8413a95fcb5db4a55fc",
-                "sha256:8d796327eed8e168164346b769dd9a27a70e0298d667b4ecee6877ce8095ec8e",
-                "sha256:8dfc0a458797f5d9fb622dd0efc52d796f23f0a1493a9527f4e49a550ae9a7e5",
-                "sha256:9369c218f789eefbd1b8d82a8cf25017b523ac47d96b2f531eba73770971c9e5",
-                "sha256:9ccd078c66a8e419475174bfe60a69adb36ce04f8d4e91b006f1329d5cd44bcf",
-                "sha256:a01c34400097b06cf8a6e61b35d6d456d5bd1ae6961542de18ec81eaf33b4cb8",
-                "sha256:a36d8dcf55b3a3bc353270d544fb170d75d2dff41eba5df57b4e0b67a95bb64e",
-                "sha256:a78ad870ae3c460394fc95437d43deb5c04b5c29297815a2a1de028903f19692",
-                "sha256:b88ca3db7eb377eb24fb7c82840546fb7acef75af4a74bd36e9ceb37a890257e",
-                "sha256:eaf3d86a1fdac1aec8a3417a63587d93f906c678bb9ed0b796da7b59c1114a1e",
-                "sha256:fcc8054f1a717e2213500edaddcf1dbb0abad40d98e1bd9d0ad364f75c763eea"
+                "sha256:2c7477c3b9da822e2db0b4e0b59e61b8a23e87886e727b327e7dcaf06213c5cf",
+                "sha256:392688dbb50fecf1bf7126731c90c11a9df1c3a4cdc3f481b53e851da5634fa5",
+                "sha256:3a0af7ab3f86e3dc9f157a928e08e26c4b40707d0612b01cd577cc84b8905cc9",
+                "sha256:3bc81074971b0ffad1bd0c52284b22411f02a11a012082a76ac6da153536e014",
+                "sha256:45efaae53b360c81043e311cdec8a7696420b3d3e8935202c2846e7a97d4edae",
+                "sha256:5278d3e095ccc8c30430bcc9bc550f778790acc211865520f3041910a28d0024",
+                "sha256:99d7ae0df47c62729d58765c593ea54c2546d5de213f2af2a19442d50a10cec9",
+                "sha256:9eb18dfd7b613eec000e3738b3f0e4398bf0153cb80bfa3e351b3c1c2f6d7b15",
+                "sha256:9fb4c4e8b83f19c9477a8745e56d2eeef07a7ff50b68a6998f7d9e2e3887bdc4",
+                "sha256:af3ffd8c6563acb8848d33cd19a69b9bfe943667f0419ca083f8ebe4224a3436",
+                "sha256:b2e0dd11e2ae553ee5c92a81731d88a9883af8db7408db47fc81887c1f8b672e",
+                "sha256:b4bb7de6a24169dc023f992718a9417380301b0c2da0fe85919f47264fb8add9",
+                "sha256:bc60c7d71b732c8fa73cf995efc0c836a2fd8b9810e115be8babb24ae87e0850",
+                "sha256:c2ebfc8f51ef4aca05dad4552bbcf6fe8d1f75b2f6af546cc47cc1c1ca916b5b",
+                "sha256:c62bc04c6723a81e25e71715aa59489f15034d69bf641df88cb38bdc32fd1dbb",
+                "sha256:d812615525a34ecfc07fd93f906ef5b93656be01dfae9a819e31caa6cfe758a1",
+                "sha256:faaa4060f4064c3b7aaaa27328080c932fa142786f8142aff095b42b6a2eb631",
+                "sha256:fe6d5f65d6f276ee7a0fc50a0cecaccb362d30ef98a110f99cac1c7872df2f18"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.7'",
-            "version": "==0.5.7"
+            "version": "==0.6.1"
+        },
+        "shellingham": {
+            "hashes": [
+                "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686",
+                "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.5.4"
         },
         "six": {
             "hashes": [
@@ -785,6 +897,15 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==0.5.1"
+        },
+        "typer": {
+            "hashes": [
+                "sha256:819aa03699f438397e876aa12b0d63766864ecba1b579092cc9fe35d886e34b6",
+                "sha256:c9c1613ed6a166162705b3347b8d10b661ccc5d95692654d0fb628118f2c34e6"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.7'",
+            "version": "==0.12.4"
         },
         "typing-extensions": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "14236ffed157d1e84479350eb98a47b630063d7cb6f480bd6735047dee264dc1"
+            "sha256": "9fc750a355fe9b80eda270865ec2d3366737413d689c16781ff0739e6aa7661d"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -686,6 +686,15 @@
             "index": "pypi",
             "markers": "python_version >= '3.8'",
             "version": "==4.8.0"
+        },
+        "pytest-mock": {
+            "hashes": [
+                "sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f",
+                "sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==3.14.0"
         },
         "python-dateutil": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -155,3 +155,15 @@ importer et exporter les données du projet [Ecobalyse](https://github.com/MTES-
 
 Ces scripts se trouvent dans `data/`, et un fichier [README](data/README.md) spécifique
 en détaille l'installation et l'utilisation.
+
+# Versioning
+
+Le versioning de l'application permet de revenir à des anciennes versions d'Ecobalyse. Pour que ce versioning puisse fonctionner, les anciennes versions (<= 2.0.0) doivent être patchées rétroactivement. Le script `./bin/build-specific-app-version.sh` permet de générer une version spécifique de l'application et d'appliquer les patchs si nécessaire. Par exemple, pour générer la version `1.3.2` (le deuxième paramètre est le commit du répertoire data associé) :
+
+    pipenv run ./bin/build-specific-app-version.sh v1.3.2 3531c73f23a1eb6f1fc6b9c256a5344742230fcf
+
+Un fichier `v1.3.2-dist.tar.gz` sera disponible à la racine du projet et un répertoire `v1.3.2` aura été créé dans `versions/`.
+
+Le script python permettant de patcher les fichiers est disponible ici : `./bin/patch_files_for_versions_compat.py`.
+
+Toutes les versions disponibles dans les releases Github ont été patchées comme il se doit.

--- a/README.md
+++ b/README.md
@@ -123,6 +123,12 @@ L'application est déployée automatiquement sur la plateforme [Scalingo](https:
 
 Chaque _Pull Request_ effectuée sur le dépôt est également automatiquement déployée sur une instance de revue spécifique, par exemple `https://ecobalyse-pr44.osc-fr1.scalingo.io/` pour la pull request #44. **Ces instances de recette restent actives 72 heures, puis sont automatiquement décommisionnées passé ce délai ou si la pull request correspondante est mergée.**
 
+### Ajout d'une variable d'environnement
+
+Pour ajouter une variable d'environnement sur une application, il est recommandé d'utiliser le CLI scalingo qui permet d'ajouter des valeurs qui contiennent plusieurs lignes (à la différence de l'interface graphique qui ne le permet pas) :
+
+    scalingo --app ecobalyse env-set "MY_VAR=$(cat fichier.key)"
+
 ### Lien avec ecobalyse_private
 
 Lorsqu'un déploiement est effectué sur une branche, les données utilisées du dépôt `ecobalyse_private` sont celles de la branche `main`. Cependant, si la description de la Pull Request sur le repo `ecobalyse` mentionne `ecobalyse_data: branch-a` avec branch-a étant une branche du dépôt `ecobalyse_private`, alors la PR utilisera les données de la branche `branch-a` du dépôt `ecobalyse_private`.

--- a/bin/build-specific-app-version.sh
+++ b/bin/build-specific-app-version.sh
@@ -171,29 +171,20 @@ npm run server:build
 # Always put the tag name in the version.json file to help debugging if needed later on
 # If TAG is defined
 if [[ ! -z "$TAG" ]]; then
-  # If no tag is present in the file
-  if [[ -z "$(grep tag dist/version.json)" ]]; then
-    sed -ri "s/\{(.*)\}/{\1, \"tag\": \"$TAG\"}/" dist/version.json
-  fi
+  $ROOT_DIR/bin/patch_files_for_versions_compat.py add-entry-to-version dist/version.json tag $TAG
 fi
+
 
 # If a data dir commit was specified, put it in the version file if needed
 # it will to keep track of the commit used to build the version
 if [[ ! -z "$ECOBALYSE_DATA_DIR_COMMIT" ]]; then
-
-  if [[ -z "$(grep dataDirHash dist/version.json >/dev/null 2>&1)" ]]; then
-    # version file is missing the dataDirHash parameter (old version of the app, before 2.0.0)
-    # patch the file to add it
-    sed -i "s/}/, \"dataDirHash\": \"$ECOBALYSE_DATA_DIR_COMMIT\"}/" dist/version.json
-  fi
+  $ROOT_DIR/bin/patch_files_for_versions_compat.py add-entry-to-version dist/version.json dataDirHash $ECOBALYSE_DATA_DIR_COMMIT
 
 fi
 
 # We need to send the referer to python in order to properly redirect after login
 # so we need to patch the html files that don't have it
-if [[ -z "$(grep origin-when-cross-origin dist/index.html)" ]]; then
-  sed -i "s/<meta charset=\"utf-8\">/<meta charset=\"utf-8\"><meta name=\"referrer\" content=\"origin-when-cross-origin\" \/>/" dist/index.html
-fi
+$ROOT_DIR/bin/patch_files_for_versions_compat.py patch-cross-origin dist/index.html
 
 cd $ROOT_DIR
 

--- a/bin/build-specific-app-version.sh
+++ b/bin/build-specific-app-version.sh
@@ -151,6 +151,7 @@ INDEX_JS_FILE=$PUBLIC_GIT_CLONE_DIR"/index.js"
 # Also patch the local storage key to avoid messing things up between versions
 $ROOT_DIR/bin/patch_files_for_versions_compat.py elm-version $ELM_VERSION_FILE
 $ROOT_DIR/bin/patch_files_for_versions_compat.py local-storage-key $INDEX_JS_FILE $COMMIT_OR_TAG
+$ROOT_DIR/bin/patch_files_for_versions_compat.py version-selector $ROOT_DIR/packages/python/ecobalyse/ecobalyse/0001-feat-patch-homepage-link-and-inject-and-inject-versi.patch $PUBLIC_GIT_CLONE_DIR
 
 cd $PUBLIC_GIT_CLONE_DIR
 

--- a/bin/build-specific-app-version.sh
+++ b/bin/build-specific-app-version.sh
@@ -149,7 +149,8 @@ INDEX_JS_FILE=$PUBLIC_GIT_CLONE_DIR"/index.js"
 # Patch old versions of the app so that it gets the version file using relative path in Elm
 # Otherwise serving the app from /versions will not display the good version number
 # Also patch the local storage key to avoid messing things up between versions
-$ROOT_DIR/bin/patch_files_for_versions_compat.py --elm_version_file $ELM_VERSION_FILE --index_js_file $INDEX_JS_FILE $COMMIT_OR_TAG
+$ROOT_DIR/bin/patch_files_for_versions_compat.py elm-version $ELM_VERSION_FILE
+$ROOT_DIR/bin/patch_files_for_versions_compat.py local-storage-key $INDEX_JS_FILE $COMMIT_OR_TAG
 
 cd $PUBLIC_GIT_CLONE_DIR
 

--- a/bin/patch_files_for_versions_compat.py
+++ b/bin/patch_files_for_versions_compat.py
@@ -1,57 +1,89 @@
 #!/usr/bin/env python
-import argparse
 import logging
 import pathlib
+from enum import Enum
+
+import typer
 
 # Tell ruff to not delete the unused import by rexporting it using as
 # See https://docs.astral.sh/ruff/rules/unused-import/
 from ecobalyse import logging_config as logging_config
-from ecobalyse.patch_files import patch_index_js_file, patch_version_file
+from ecobalyse.patch_files import (
+    patch_elm_version_file,
+    patch_index_js_file,
+)
+from typing_extensions import Annotated
 
 logger = logging.getLogger(__name__)
 
-ELM_VERSION_FILE = "src/Request/Version.elm"
-INDEX_JS_FILE = "index.js"
+
+class LoggingLevels(str, Enum):
+    CRITICAL = "CRITICAL"
+    DEBUG = "DEBUG"
+    ERROR = "ERROR"
+    INFO = "INFO"
+    NOTSET = "NOTSET"
+    WARNING = "WARNING"
+
+
+app = typer.Typer(
+    help="Patch old versions of ecobalyse to be compatible with the new versionning system."
+)
+
+
+@app.callback()
+def main(
+    loglevel: Annotated[
+        LoggingLevels, typer.Option("--loglevel", "-l")
+    ] = LoggingLevels.INFO,
+):
+    logger.setLevel(loglevel.value)
+
+
+@app.command()
+def elm_version(
+    elm_version_file: Annotated[
+        pathlib.Path,
+        typer.Argument(
+            help="The full path to the Version.elm file.",
+            exists=True,
+            file_okay=True,
+            dir_okay=False,
+            writable=True,
+            readable=True,
+            resolve_path=True,
+        ),
+    ],
+):
+    """
+    Patch Version.elm file to remove the absolute call to /version.json
+    """
+    patch_elm_version_file(elm_version_file)
+
+
+@app.command()
+def local_storage_key(
+    index_js_file: Annotated[
+        pathlib.Path,
+        typer.Argument(
+            help="The full path to the index.js file.",
+            exists=True,
+            file_okay=True,
+            dir_okay=False,
+            writable=True,
+            readable=True,
+            resolve_path=True,
+        ),
+    ],
+    suffix: Annotated[
+        str, typer.Argument(help="The suffix to append to the storage key.")
+    ],
+):
+    """
+    Patch main index.js file to add the version to the local storage key
+    """
+    patch_index_js_file(index_js_file, suffix)
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(
-        description="Patch old versions of ecobalyse to be compatible with the new versionning system."
-    )
-
-    parser.add_argument(
-        "version",
-        type=str,
-        help="The version used to prepend to the local storage key.",
-    )
-    parser.add_argument(
-        "--elm_version_file",
-        type=pathlib.Path,
-        nargs="?",
-        help=f"The Version.elm file path. Default to '{ELM_VERSION_FILE}'.",
-        default=ELM_VERSION_FILE,
-    )
-
-    parser.add_argument(
-        "--index_js_file",
-        type=pathlib.Path,
-        nargs="?",
-        help=f"The JS index.js file path. Default to '{INDEX_JS_FILE}'.",
-        default=INDEX_JS_FILE,
-    )
-
-    parser.add_argument(
-        "--loglevel",
-        type=str.upper,
-        help="Override default logging level for current module.",
-        choices=logging.getLevelNamesMapping().keys(),
-    )
-
-    args = parser.parse_args()
-
-    logger.info(
-        f"Trying to patch '{args.elm_version_file}' and '{args.index_js_file}'."
-    )
-
-    patch_version_file(args.elm_version_file)
-    patch_index_js_file(args.index_js_file, args.version)
+    app()

--- a/bin/patch_files_for_versions_compat.py
+++ b/bin/patch_files_for_versions_compat.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+import argparse
+import logging
+import pathlib
+
+# Tell ruff to not delete the unused import by rexporting it using as
+# See https://docs.astral.sh/ruff/rules/unused-import/
+from ecobalyse import logging_config as logging_config
+from ecobalyse.patch_files import patch_index_js_file, patch_version_file
+
+logger = logging.getLogger(__name__)
+
+ELM_VERSION_FILE = "src/Request/Version.elm"
+INDEX_JS_FILE = "index.js"
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Patch old versions of ecobalyse to be compatible with the new versionning system."
+    )
+
+    parser.add_argument(
+        "version",
+        type=str,
+        help="The version used to prepend to the local storage key.",
+    )
+    parser.add_argument(
+        "--elm_version_file",
+        type=pathlib.Path,
+        nargs="?",
+        help=f"The Version.elm file path. Default to '{ELM_VERSION_FILE}'.",
+        default=ELM_VERSION_FILE,
+    )
+
+    parser.add_argument(
+        "--index_js_file",
+        type=pathlib.Path,
+        nargs="?",
+        help=f"The JS index.js file path. Default to '{INDEX_JS_FILE}'.",
+        default=INDEX_JS_FILE,
+    )
+
+    parser.add_argument(
+        "--loglevel",
+        type=str.upper,
+        help="Override default logging level for current module.",
+        choices=logging.getLevelNamesMapping().keys(),
+    )
+
+    args = parser.parse_args()
+
+    logger.info(
+        f"Trying to patch '{args.elm_version_file}' and '{args.index_js_file}'."
+    )
+
+    patch_version_file(args.elm_version_file)
+    patch_index_js_file(args.index_js_file, args.version)

--- a/bin/patch_files_for_versions_compat.py
+++ b/bin/patch_files_for_versions_compat.py
@@ -11,6 +11,7 @@ from ecobalyse import logging_config as logging_config
 from ecobalyse.patch_files import (
     patch_elm_version_file,
     patch_index_js_file,
+    patch_version_selector,
 )
 from typing_extensions import Annotated
 
@@ -83,6 +84,38 @@ def local_storage_key(
     Patch main index.js file to add the version to the local storage key
     """
     patch_index_js_file(index_js_file, suffix)
+
+
+@app.command()
+def version_selector(
+    patch_file: Annotated[
+        pathlib.Path,
+        typer.Argument(
+            help="The full path of the patch to apply.",
+            exists=True,
+            file_okay=True,
+            dir_okay=False,
+            writable=True,
+            readable=True,
+            resolve_path=True,
+        ),
+    ],
+    git_dir: Annotated[
+        pathlib.Path,
+        typer.Argument(
+            help="The full path of the git repo where to apply the patch.",
+            exists=True,
+            file_okay=False,
+            dir_okay=True,
+            readable=True,
+            resolve_path=True,
+        ),
+    ],
+):
+    """
+    Patch main index.html and Page.elm to add the version selector
+    """
+    patch_version_selector(patch_file, git_dir)
 
 
 if __name__ == "__main__":

--- a/bin/patch_files_for_versions_compat.py
+++ b/bin/patch_files_for_versions_compat.py
@@ -9,6 +9,8 @@ import typer
 # See https://docs.astral.sh/ruff/rules/unused-import/
 from ecobalyse import logging_config as logging_config
 from ecobalyse.patch_files import (
+    add_entry_to_version_file,
+    patch_cross_origin_index_html_file,
     patch_elm_version_file,
     patch_index_js_file,
     patch_version_selector,
@@ -116,6 +118,54 @@ def version_selector(
     Patch main index.html and Page.elm to add the version selector
     """
     patch_version_selector(patch_file, git_dir)
+
+
+@app.command()
+def add_entry_to_version(
+    version_file: Annotated[
+        pathlib.Path,
+        typer.Argument(
+            help="The full path of the version.json file.",
+            exists=True,
+            file_okay=True,
+            dir_okay=False,
+            writable=True,
+            readable=True,
+            resolve_path=True,
+        ),
+    ],
+    name: Annotated[
+        str, typer.Argument(help="The name of the entry to add to the json file.")
+    ],
+    value: Annotated[
+        str, typer.Argument(help="The value of the entry to add to the json file.")
+    ],
+):
+    """
+    Patch version.json with the new entry
+    """
+    add_entry_to_version_file(version_file, name, value)
+
+
+@app.command()
+def patch_cross_origin(
+    index_html_file: Annotated[
+        pathlib.Path,
+        typer.Argument(
+            help="The full path of the index.html file.",
+            exists=True,
+            file_okay=True,
+            dir_okay=False,
+            writable=True,
+            readable=True,
+            resolve_path=True,
+        ),
+    ],
+):
+    """
+    Patch version.json with the new entry
+    """
+    patch_cross_origin_index_html_file(index_html_file)
 
 
 if __name__ == "__main__":

--- a/packages/python/ecobalyse/ecobalyse/0001-feat-patch-homepage-link-and-inject-and-inject-versi.patch
+++ b/packages/python/ecobalyse/ecobalyse/0001-feat-patch-homepage-link-and-inject-and-inject-versi.patch
@@ -1,4 +1,4 @@
-From dbf27e32a1d3140fef8f7ce793803df0e60d08d7 Mon Sep 17 00:00:00 2001
+From c6a72c8c69322ecf47d9f6c54c1e079100edc46b Mon Sep 17 00:00:00 2001
 From: Nicolas Perriault <nicolas@perriault.net>
 Date: Mon, 19 Aug 2024 15:58:26 +0200
 Subject: [PATCH] feat: patch homepage link and inject and inject version
@@ -10,7 +10,7 @@ Subject: [PATCH] feat: patch homepage link and inject and inject version
  2 files changed, 30 insertions(+)
 
 diff --git a/index.html b/index.html
-index b3ad75e0..f040ddc0 100644
+index b3ad75e0..c596eb8e 100644
 --- a/index.html
 +++ b/index.html
 @@ -18,5 +18,34 @@
@@ -33,11 +33,11 @@ index b3ad75e0..f040ddc0 100644
 +          const option = document.createElement("option");
 +          option.textContent = version;
 +          if (location.pathname.includes("/versions/")) {
-+            option.selected = version === location.pathname.split("/").pop();
++            option.selected = version === location.pathname.split("/").filter(x => !!x).pop();
 +          }
 +          selector.append(option);
 +        }
-+        selector.addEventListener("input", (e) => location.href = `/versions/${e.target.value}`);
++        selector.addEventListener("input", (e) => location.href = `/versions/${e.target.value}/`);
 +        document.querySelector(".HeaderBrand").after(selector);
 +        document.querySelector(".HeaderAuthLink").classList.remove("d-none", "d-sm-block");
 +        document.querySelector(".HeaderAuthLink").classList.add("text-end", "flex-fill");

--- a/packages/python/ecobalyse/ecobalyse/0001-feat-patch-homepage-link-and-inject-and-inject-versi.patch
+++ b/packages/python/ecobalyse/ecobalyse/0001-feat-patch-homepage-link-and-inject-and-inject-versi.patch
@@ -1,0 +1,64 @@
+From dbf27e32a1d3140fef8f7ce793803df0e60d08d7 Mon Sep 17 00:00:00 2001
+From: Nicolas Perriault <nicolas@perriault.net>
+Date: Mon, 19 Aug 2024 15:58:26 +0200
+Subject: [PATCH] feat: patch homepage link and inject and inject version
+ selector.
+
+---
+ index.html         | 29 +++++++++++++++++++++++++++++
+ src/Views/Page.elm |  1 +
+ 2 files changed, 30 insertions(+)
+
+diff --git a/index.html b/index.html
+index b3ad75e0..f040ddc0 100644
+--- a/index.html
++++ b/index.html
+@@ -18,5 +18,34 @@
+   <noscript>
+     <img src="https://stats.beta.gouv.fr/matomo.php?idsite=57&amp;rec=1" style="border:0" alt="" />
+   </noscript>
++  <script>
++    window.addEventListener("DOMContentLoaded", async() => {
++      if (document.querySelector(".VersionSelector")) {
++        return;
++      }
++      try {
++        const res = await fetch("https://api.github.com/repos/MTES-MCT/ecobalyse/releases");
++        const json = await res.json();
++        const versions = json.map(({tag_name}) => tag_name);
++        const selector = document.createElement("select");
++        selector.classList.add("VersionSelector", "d-none", "d-sm-block", "form-select", "form-select-sm", "w-auto");
++        selector.setAttribute("style", "background-color:transparent;box-shadow:none;");
++        for (const version of versions) {
++          const option = document.createElement("option");
++          option.textContent = version;
++          if (location.pathname.includes("/versions/")) {
++            option.selected = version === location.pathname.split("/").pop();
++          }
++          selector.append(option);
++        }
++        selector.addEventListener("input", (e) => location.href = `/versions/${e.target.value}`);
++        document.querySelector(".HeaderBrand").after(selector);
++        document.querySelector(".HeaderAuthLink").classList.remove("d-none", "d-sm-block");
++        document.querySelector(".HeaderAuthLink").classList.add("text-end", "flex-fill");
++      } catch (e) {
++        console.error("Unable to build version selector menu", e);
++      }
++    });
++  </script>
+ </body>
+ </html>
+diff --git a/src/Views/Page.elm b/src/Views/Page.elm
+index b713f836..d43880b4 100644
+--- a/src/Views/Page.elm
++++ b/src/Views/Page.elm
+@@ -313,6 +313,7 @@ pageHeader config =
+                 -- https://dashlord.mte.incubateur.net/dashlord/url/ecobalyse-beta-gouv-fr/best-practices/#dsfr
+                 , class "fr-header__brand"
+                 , href "/"
++                , onClick (config.loadUrl "/")
+                 ]
+                 [ img [ class "HeaderLogo", alt "République Française", src "img/republique-francaise.svg" ] []
+                 , h1 [ class "HeaderTitle" ] [ text "Ecobalyse" ]
+--
+2.39.3 (Apple Git-146)

--- a/packages/python/ecobalyse/ecobalyse/patch_files.py
+++ b/packages/python/ecobalyse/ecobalyse/patch_files.py
@@ -13,23 +13,23 @@ logger = logging.getLogger(__name__)
 
 
 def patch_storage_key(index_js_string: str, version: str) -> Tuple[str, int]:
-    nb = index_js_string.count('storeKey = "store"')
+    nb_patched = index_js_string.count('storeKey = "store"')
     data = index_js_string
-    if nb >= 0:
+    if nb_patched >= 0:
         data = index_js_string.replace(
             'storeKey = "store"', f'storeKey = "store{version}"'
         )
 
-    return (data, nb)
+    return (data, nb_patched)
 
 
 def patch_version_string(elm_version_string: str) -> Tuple[str, int]:
-    nb = elm_version_string.count('"/version.json')
+    nb_patched = elm_version_string.count('"/version.json')
     data = elm_version_string
-    if nb >= 0:
+    if nb_patched >= 0:
         data = elm_version_string.replace('"/version.json', '"version.json')
 
-    return (data, nb)
+    return (data, nb_patched)
 
 
 def write_patched_data(nb_patched: int, data: str, dest_file: pathlib.Path) -> bool:
@@ -45,70 +45,70 @@ def write_patched_data(nb_patched: int, data: str, dest_file: pathlib.Path) -> b
 
 
 def patch_elm_version_file(elm_version_file: pathlib.Path):
-    (data, nb) = (None, 0)
+    (data, nb_patched) = (None, 0)
 
     with open(elm_version_file, "r") as file:
         data = file.read()
-        (data, nb) = patch_version_string(data)
+        (data, nb_patched) = patch_version_string(data)
 
-    write_patched_data(nb, data, elm_version_file)
+    write_patched_data(nb_patched, data, elm_version_file)
 
 
 def patch_index_js_file(index_js_file: pathlib.Path, version: str):
-    (data, nb) = (None, 0)
+    (data, nb_patched) = (None, 0)
 
     with open(index_js_file, "r") as file:
         data = file.read()
-        (data, nb) = patch_storage_key(data, version)
+        (data, nb_patched) = patch_storage_key(data, version)
 
-    write_patched_data(nb, data, index_js_file)
+    write_patched_data(nb_patched, data, index_js_file)
 
 
 def patch_version_json(json_content: dict, key: str, value: str):
-    (data, nb) = (json_content, 0)
+    (data, nb_patched) = (json_content, 0)
 
     if data.get(key) is None:
         data[key] = value
-        nb = 1
+        nb_patched = 1
         logger.info(f"Adding key '{key}' with value '{value}' to `version.json`.")
     else:
         logger.info(f"Key '{key}' already present in `version.json`, skipping.")
 
-    return (json.dumps(data), nb)
+    return (json.dumps(data), nb_patched)
 
 
 def add_entry_to_version_file(version_file: pathlib.Path, key: str, value: str):
-    (data, nb) = (None, 0)
+    (data, nb_patched) = (None, 0)
 
     with open(version_file, "r") as file:
         json_content = json.load(file)
-        (data, nb) = patch_version_json(json_content, key, value)
+        (data, nb_patched) = patch_version_json(json_content, key, value)
 
-    write_patched_data(nb, data, version_file)
+    write_patched_data(nb_patched, data, version_file)
 
 
 def patch_cross_origin(index_html_string: str):
     meta_charset = '<meta charset="utf-8">'
     meta_content = '<meta name="referrer" content="origin-when-cross-origin" />'
-    (data, nb) = (index_html_string, 0)
+    (data, nb_patched) = (index_html_string, 0)
     if (
         index_html_string.count(meta_charset) >= 0
         and index_html_string.count('content="origin-when-cross-origin"') == 0
     ):
         data = index_html_string.replace(meta_charset, meta_charset + meta_content)
-        nb = 1
+        nb_patched = 1
 
-    return (data, nb)
+    return (data, nb_patched)
 
 
 def patch_cross_origin_index_html_file(index_html_file: pathlib.Path):
-    (data, nb) = (None, 0)
+    (data, nb_patched) = (None, 0)
 
     with open(index_html_file, "r") as file:
         data = file.read()
-        (data, nb) = patch_cross_origin(data)
+        (data, nb_patched) = patch_cross_origin(data)
 
-    write_patched_data(nb, data, index_html_file)
+    write_patched_data(nb_patched, data, index_html_file)
 
 
 def patch_version_selector(patch_file: pathlib.Path, git_dir: pathlib.Path):

--- a/packages/python/ecobalyse/ecobalyse/patch_files.py
+++ b/packages/python/ecobalyse/ecobalyse/patch_files.py
@@ -1,0 +1,61 @@
+import logging
+import pathlib
+from typing import Tuple
+
+# Tell ruff to not delete the unused import by rexporting it using as
+# See https://docs.astral.sh/ruff/rules/unused-import/
+from ecobalyse import logging_config as logging_config
+
+logger = logging.getLogger(__name__)
+
+
+def patch_storage_key(index_js_string: str, version: str) -> Tuple[str, int]:
+    nb = index_js_string.count('storeKey = "store"')
+    data = None
+    if nb >= 0:
+        data = index_js_string.replace(
+            'storeKey = "store"', f'storeKey = "store{version}"'
+        )
+
+    return (data, nb)
+
+
+def patch_version_string(elm_version_string: str) -> Tuple[str, int]:
+    nb = elm_version_string.count('"/version.json')
+    data = None
+    if nb >= 0:
+        data = elm_version_string.replace('"/version.json', '"version.json')
+
+    return (data, nb)
+
+
+def write_patched_data(nb_patched: int, data: str, dest_file: pathlib.Path) -> bool:
+    if nb_patched == 1:
+        with open(dest_file, "w") as f:
+            f.write(data)
+            logger.info(f"Content patched successfully in `{dest_file}`.")
+            return True
+    else:
+        logger.info(f"No content to patch in `{dest_file}`, doing nothing.")
+
+    return False
+
+
+def patch_version_file(elm_version_file: pathlib.Path):
+    (data, nb) = (None, 0)
+
+    with open(elm_version_file, "r") as file:
+        data = file.read()
+        (data, nb) = patch_version_string(data)
+
+    write_patched_data(nb, data, elm_version_file)
+
+
+def patch_index_js_file(index_js_file: pathlib.Path, version: str):
+    (data, nb) = (None, 0)
+
+    with open(index_js_file, "r") as file:
+        data = file.read()
+        (data, nb) = patch_storage_key(data, version)
+
+    write_patched_data(nb, data, index_js_file)

--- a/packages/python/ecobalyse/ecobalyse/patch_files.py
+++ b/packages/python/ecobalyse/ecobalyse/patch_files.py
@@ -1,5 +1,7 @@
 import logging
+import os
 import pathlib
+import subprocess
 from typing import Tuple
 
 # Tell ruff to not delete the unused import by rexporting it using as
@@ -41,7 +43,7 @@ def write_patched_data(nb_patched: int, data: str, dest_file: pathlib.Path) -> b
     return False
 
 
-def patch_version_file(elm_version_file: pathlib.Path):
+def patch_elm_version_file(elm_version_file: pathlib.Path):
     (data, nb) = (None, 0)
 
     with open(elm_version_file, "r") as file:
@@ -59,3 +61,15 @@ def patch_index_js_file(index_js_file: pathlib.Path, version: str):
         (data, nb) = patch_storage_key(data, version)
 
     write_patched_data(nb, data, index_js_file)
+
+
+def patch_version_selector(patch_file: pathlib.Path, git_dir: pathlib.Path):
+    with open(os.path.join(git_dir, "index.html"), "r") as index_file:
+        data = index_file.read()
+        if data.count('selector.classList.add("VersionSelector"') > 0:
+            logger.info("Patch content already present in 'index.html', skipping.")
+        else:
+            logger.info(
+                f"Applying patch file `{patch_file}` to `{git_dir}` using `git apply`."
+            )
+            subprocess.run(["git", "apply", patch_file], check=True, cwd=git_dir)

--- a/packages/python/ecobalyse/ecobalyse/tests/test_patch_old_versions.py
+++ b/packages/python/ecobalyse/ecobalyse/tests/test_patch_old_versions.py
@@ -1,9 +1,14 @@
+import json
 import logging
+import os
 import tempfile
 
 from ecobalyse import logging_config as logging_config
 from ecobalyse.patch_files import (
+    patch_cross_origin,
     patch_storage_key,
+    patch_version_json,
+    patch_version_selector,
     patch_version_string,
     write_patched_data,
 )
@@ -17,6 +22,8 @@ const storeKey = "store";
 
 const app = Elm.Main.init({"""
 
+INDEX_HTML_CONTENT = """<!DOCTYPE html><html lang="fr"><head><meta charset="utf-8"><title>Ecobalyse</title><link rel="canonical" href="https://ecobalyse.beta.gouv.fr/"><meta name="viewport" content="width=device-width, initial-scale=1"><meta name="description" content="Accélerer la mise en place de l'affichage environnemental"><meta name="theme-color" content="#333333"><link rel="icon" type="image/svg" href="logo.42bf0895.svg"><link rel="preload" href="Marianne-Regular.e7aa0a9a.woff2" as="font" type="font/woff2" crossorigin><link rel="preload" href="Marianne-Bold.93333c67.woff2" as="font" type="font/woff2" crossorigin><link rel="stylesheet" href="index.cc2b0572.css"><link rel="stylesheet" href="index.0fa174c7.css"><script type="module" src="index.9ea8d260.js"></script></head><body> <noscript> <img src="https://stats.beta.gouv.fr/matomo.php?idsite=57&amp;rec=1" style="border:0" alt> </noscript> <script>window.addEventListener("DOMContentLoaded",async()=>{if(!document.querySelector(".VersionSelector"))try{let e=await fetch("https://api.github.com/repos/MTES-MCT/ecobalyse/releases"),t=(await e.json()).map(({tag_name:e})=>e),o=document.createElement("select");for(let e of(o.classList.add("VersionSelector","d-none","d-sm-block","form-select","form-select-sm","w-auto"),o.setAttribute("style","background-color:transparent;box-shadow:none;"),t)){let t=document.createElement("option");t.textContent=e,location.pathname.includes("/versions/")&&(t.selected=e===location.pathname.split("/").filter(e=>!!e).pop()),o.append(t)}o.addEventListener("input",e=>location.href=`/versions/${e.target.value}/`),document.querySelector(".HeaderBrand").after(o),document.querySelector(".HeaderAuthLink").classList.remove("d-none","d-sm-block"),document.querySelector(".HeaderAuthLink").classList.add("text-end","flex-fill")}catch(e){console.error("Unable to build version selector menu",e)}});</script> </body></html>"""
+
 
 def test_version_content_should_be_patched():
     (patched_content, nb) = patch_version_string(ELM_VERSION_CONTENT)
@@ -28,6 +35,78 @@ def test_index_js_content_should_be_patched():
     (patched_content, nb) = patch_storage_key(JS_INDEX_CONTENT, "testversion")
     assert "storetestversion" in patched_content
     assert nb == 1
+
+
+def test_version_json_patch():
+    json_content = {"hash": "somecommitsha"}
+    (patched_content, nb) = patch_version_json(json_content, "tag", "sometag")
+    json_content = json.loads(patched_content)
+
+    assert nb == 1
+    assert json_content == {"hash": "somecommitsha", "tag": "sometag"}
+
+    (patched_content, nb) = patch_version_json(json_content, "tag", "somenewtag")
+
+    # We should not replace an existing tag
+    assert nb == 0
+    assert json.loads(patched_content) == json_content
+
+    json_content = {"hash": "somecommitsha", "tag": None}
+    (patched_content, nb) = patch_version_json(json_content, "tag", "sometag")
+
+    # But we should overwrite a null value
+    assert nb == 1
+    assert json_content == {"hash": "somecommitsha", "tag": "sometag"}
+
+
+def test_patch_cross_origin():
+    (patched_content, nb) = patch_cross_origin(INDEX_HTML_CONTENT)
+    assert 'content="origin-when-cross-origin"' in patched_content
+    assert nb == 1
+
+    # We should not patch an already patched file
+    (patched_content, nb) = patch_cross_origin(patched_content)
+    assert nb == 0
+    assert 'content="origin-when-cross-origin"' in patched_content
+
+
+def test_patch_version_selector_should_patch_non_patched_file(mocker):
+    mock_run = mocker.patch("subprocess.run")
+
+    patch_file = tempfile.TemporaryFile()
+    git_dir = tempfile.TemporaryDirectory()
+
+    with open(os.path.join(git_dir.name, "index.html"), "w") as index_file:
+        index_file.write("")
+
+    patch_version_selector(patch_file.name, git_dir.name)
+
+    mock_run.assert_called_once_with(
+        ["git", "apply", patch_file.name], check=True, cwd=git_dir.name
+    )
+
+    with open(os.path.join(git_dir.name, "index.html"), "w") as index_file:
+        index_file.write('selector.classList.add("VersionSelector"')
+
+    patch_version_selector(patch_file.name, git_dir.name)
+
+    mock_run.assert_called_once_with(
+        ["git", "apply", patch_file.name], check=True, cwd=git_dir.name
+    )
+
+
+def test_patch_version_selector_should_not_patch_alreadx_patched_file(mocker):
+    mock_run = mocker.patch("subprocess.run")
+
+    patch_file = tempfile.TemporaryFile()
+    git_dir = tempfile.TemporaryDirectory()
+
+    with open(os.path.join(git_dir.name, "index.html"), "w") as index_file:
+        index_file.write('selector.classList.add("VersionSelector"')
+
+    patch_version_selector(patch_file.name, git_dir.name)
+
+    assert not mock_run.called
 
 
 def test_write_patched_data(caplog):

--- a/packages/python/ecobalyse/ecobalyse/tests/test_patch_old_versions.py
+++ b/packages/python/ecobalyse/ecobalyse/tests/test_patch_old_versions.py
@@ -1,0 +1,51 @@
+import logging
+import tempfile
+
+from ecobalyse import logging_config as logging_config
+from ecobalyse.patch_files import (
+    patch_storage_key,
+    patch_version_string,
+    write_patched_data,
+)
+
+ELM_VERSION_CONTENT = """loadVersion : (WebData VersionData -> msg) -> Cmd msg
+loadVersion event =
+    Http.get "/version.json" event versionDataDecoder"""
+
+JS_INDEX_CONTENT = """// The localStorage key to use to store serialized session data
+const storeKey = "store";
+
+const app = Elm.Main.init({"""
+
+
+def test_version_content_should_be_patched():
+    (patched_content, nb) = patch_version_string(ELM_VERSION_CONTENT)
+    assert '"version.json' in patched_content
+    assert nb == 1
+
+
+def test_index_js_content_should_be_patched():
+    (patched_content, nb) = patch_storage_key(JS_INDEX_CONTENT, "testversion")
+    assert "storetestversion" in patched_content
+    assert nb == 1
+
+
+def test_write_patched_data(caplog):
+    with caplog.at_level(logging.INFO):
+        dest_file = tempfile.TemporaryFile()
+        written = write_patched_data(1, ELM_VERSION_CONTENT, dest_file.name)
+
+        assert written
+        assert "successfully" in caplog.text
+
+        (patched_content, nb) = patch_version_string(ELM_VERSION_CONTENT)
+
+        # Try to write already patched content
+        written = write_patched_data(0, patched_content, dest_file.name)
+        assert not written
+        assert "doing nothing" in caplog.text
+
+        # Try to write unknown content
+        written = write_patched_data(0, "random content", dest_file.name)
+        assert not written
+        assert "doing nothing" in caplog.text


### PR DESCRIPTION
## :wrench: Problem

We are using a combination of bash and sed commands to patch the files and it's not reliable: it breaks on Mac OS X and it is not testable.

## :cake: Solution

Replace critical bash code with tested python code.

## :rotating_light:  Points to watch / comments

I've introduced [Typer](https://typer.tiangolo.com/) to manage the CLI program. It uses Python types to parse arguments and provides a lot of features out of the box. You can run the help command for example to see by yourself:

    pipenv run python ./bin/patch_files_for_versions_compat.py --help

## :desert_island: How to test

Be sure to run `pipenv install` first.

Building a specific version with `pipenv run ./bin/build-specific-app-version.sh v1.3.2 3531c73f23a1eb6f1fc6b9c256a5344742230fcf` for example should still work as expected.
