### PR TITLE
fix: add github token to worklows

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -80,6 +80,7 @@ jobs:
       if: ${{ github.event_name == 'pull_request' }}
       env:
         LAST_COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+        GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         eval `ssh-agent -s`
         # Private ssh key used by this Github action to clone the private repo

--- a/.github/workflows/score_history.yml
+++ b/.github/workflows/score_history.yml
@@ -85,6 +85,8 @@ jobs:
           git clone git@github.com:MTES-MCT/ecobalyse-private.git
 
       - name: Checkout specific ecobalyse-private branch
+        env:
+          GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           eval `ssh-agent -s`
           # Private ssh key used by this Github action to clone the private repo


### PR DESCRIPTION
## :wrench: Problem

We may face rate limiting issues with the github API when running workflows because we are not using any Github token.

## :cake: Solution

Use the automatically generated token in github actions to call the public API.

## :desert_island: How to test

The Github worklows should still be green.
