### PR TITLE
feat: allow downloading explorer data as CSV.

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -1,8 +1,6 @@
 {
     "type": "application",
-    "source-directories": [
-        "src"
-    ],
+    "source-directories": ["src"],
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {

--- a/elm.json
+++ b/elm.json
@@ -1,6 +1,8 @@
 {
     "type": "application",
-    "source-directories": ["src"],
+    "source-directories": [
+        "src"
+    ],
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
@@ -8,6 +10,7 @@
             "NoRedInk/elm-sortable-table": "1.0.0",
             "NoRedInk/elm-uuid": "2.0.0",
             "chain-partners/elm-bignum": "1.0.1",
+            "commonmind/elm-csv-encode": "1.2.0",
             "cuducos/elm-format-number": "8.1.4",
             "dillonkearns/elm-markdown": "7.0.1",
             "elm/browser": "1.0.2",

--- a/src/Page/Explore/Countries.elm
+++ b/src/Page/Explore/Countries.elm
@@ -19,7 +19,8 @@ import Views.Link as Link
 
 table : Transport.Distances -> List Country.Country -> { detailed : Bool, scope : Scope } -> Table Country String msg
 table distances countries { detailed, scope } =
-    { toId = .code >> Country.codeToString
+    { filename = "countries"
+    , toId = .code >> Country.codeToString
     , toRoute = .code >> Just >> Dataset.Countries >> Route.Explore scope
     , legend = []
     , columns =

--- a/src/Page/Explore/FoodExamples.elm
+++ b/src/Page/Explore/FoodExamples.elm
@@ -18,7 +18,8 @@ table :
     -> { detailed : Bool, scope : Scope }
     -> Table ( Example Query, { score : Float, per100g : Float } ) String msg
 table { maxScore, maxPer100g } { detailed, scope } =
-    { toId = Tuple.first >> .id >> Uuid.toString
+    { filename = "examples"
+    , toId = Tuple.first >> .id >> Uuid.toString
     , toRoute = Tuple.first >> .id >> Just >> Dataset.FoodExamples >> Route.Explore scope
     , legend = []
     , columns =

--- a/src/Page/Explore/FoodIngredients.elm
+++ b/src/Page/Explore/FoodIngredients.elm
@@ -22,7 +22,8 @@ import Views.Link as Link
 
 table : FoodDb.Db -> { detailed : Bool, scope : Scope } -> Table Ingredient String msg
 table _ { detailed, scope } =
-    { toId = .id >> Ingredient.idToString
+    { filename = "ingredients"
+    , toId = .id >> Ingredient.idToString
     , toRoute = .id >> Just >> Dataset.FoodIngredients >> Route.Explore scope
     , legend = []
     , columns =

--- a/src/Page/Explore/FoodProcesses.elm
+++ b/src/Page/Explore/FoodProcesses.elm
@@ -11,7 +11,8 @@ import Route
 
 table : FoodDb.Db -> { detailed : Bool, scope : Scope } -> Table FoodProcess.Process String msg
 table _ { detailed, scope } =
-    { toId = .identifier >> FoodProcess.identifierToString
+    { filename = "processes"
+    , toId = .identifier >> FoodProcess.identifierToString
     , toRoute = .identifier >> Just >> Dataset.FoodProcesses >> Route.Explore scope
     , legend = []
     , columns =

--- a/src/Page/Explore/Impacts.elm
+++ b/src/Page/Explore/Impacts.elm
@@ -14,7 +14,8 @@ import Views.Markdown as Markdown
 
 table : { detailed : Bool, scope : Scope } -> Table Definition String msg
 table { detailed, scope } =
-    { toId = .trigram >> Definition.toString
+    { filename = "impacts"
+    , toId = .trigram >> Definition.toString
     , toRoute = .trigram >> Just >> Dataset.Impacts >> Route.Explore scope
     , legend = []
     , columns =

--- a/src/Page/Explore/Table.elm
+++ b/src/Page/Explore/Table.elm
@@ -126,11 +126,12 @@ viewList routeToMsg defaultConfig tableState scope createTable items =
                 }
 
         csv =
-            toCSV table items
-                |> EncodeCsv.toString
-
-        b64csv =
-            Base64.encode csv
+            { filename = "ecobalyse-" ++ Scope.toString scope ++ "-" ++ filename ++ ".csv"
+            , content =
+                items
+                    |> toCSV table
+                    |> EncodeCsv.toString
+            }
     in
     div [ class "DatasetTable table-responsive" ]
         [ SortableTable.view config tableState items
@@ -138,8 +139,8 @@ viewList routeToMsg defaultConfig tableState scope createTable items =
         , div [ class "text-end pt-3" ]
             [ a
                 [ class "btn btn-secondary"
-                , href <| "data:text/csv;base64," ++ b64csv
-                , download <| "ecobalyse-" ++ Scope.toString scope ++ "-" ++ filename ++ ".csv"
+                , href <| "data:text/csv;base64," ++ Base64.encode csv.content
+                , download csv.filename
                 ]
                 [ text "Télécharger ces données au format CSV" ]
             ]

--- a/src/Page/Explore/TextileExamples.elm
+++ b/src/Page/Explore/TextileExamples.elm
@@ -18,7 +18,8 @@ table :
     -> { detailed : Bool, scope : Scope }
     -> Table ( Example Query, { score : Float, per100g : Float } ) String msg
 table { maxScore, maxPer100g } { detailed, scope } =
-    { toId = Tuple.first >> .id >> Uuid.toString
+    { filename = "examples"
+    , toId = Tuple.first >> .id >> Uuid.toString
     , toRoute = Tuple.first >> .id >> Just >> Dataset.TextileExamples >> Route.Explore scope
     , legend = []
     , columns =

--- a/src/Page/Explore/TextileMaterials.elm
+++ b/src/Page/Explore/TextileMaterials.elm
@@ -25,7 +25,8 @@ recycledToString maybeMaterialID =
 
 table : Db -> { detailed : Bool, scope : Scope } -> Table Material String msg
 table db { detailed, scope } =
-    { toId = .id >> Material.idToString
+    { filename = "materials"
+    , toId = .id >> Material.idToString
     , toRoute = .id >> Just >> Dataset.TextileMaterials >> Route.Explore scope
     , legend = []
     , columns =

--- a/src/Page/Explore/TextileProcesses.elm
+++ b/src/Page/Explore/TextileProcesses.elm
@@ -11,7 +11,8 @@ import Route
 
 table : { detailed : Bool, scope : Scope } -> Table Process String msg
 table { detailed, scope } =
-    { toId = .uuid >> Process.uuidToString
+    { filename = "processes"
+    , toId = .uuid >> Process.uuidToString
     , toRoute = .uuid >> Just >> Dataset.TextileProcesses >> Route.Explore scope
     , legend = []
     , columns =

--- a/src/Page/Explore/TextileProducts.elm
+++ b/src/Page/Explore/TextileProducts.elm
@@ -35,7 +35,8 @@ withTitle str =
 
 table : Db -> { detailed : Bool, scope : Scope } -> Table Product String msg
 table db { detailed, scope } =
-    { toId = .id >> Product.idToString
+    { filename = "products"
+    , toId = .id >> Product.idToString
     , toRoute = .id >> Just >> Dataset.TextileProducts >> Route.Explore scope
     , legend =
         [ ul [ class "list-unstyled text-muted p-2 m-0" ]


### PR DESCRIPTION
## :wrench: Problem

[user story](https://www.notion.so/Permettre-de-t-l-charger-en-csv-excel-les-donn-es-de-l-explorateur-a459d3be30cc44cb8977788073768df0)

Users want to be able to download the explorer data as CSV, so they can inspect and use them in their favorite software like Excel or Numbers.

## :cake: Solution

This patch adds a button to download explorer data as CSV on every tab, at the bottom right of the data table, for food and textile data.

## :desert_island: How to test

Click on the download buttons and open the CSV file in your preffered CSV viewer.

![image](https://github.com/user-attachments/assets/7659adb0-f2fb-4989-8d34-ba8ecfb7fee0)

![image](https://github.com/user-attachments/assets/62d8fc32-78a0-4d23-b796-3fb2388b0a92)
