### PR TITLE
fix: broken comparator charts on desynced cache data.

### DIFF
--- a/src/Data/Food/Db.elm
+++ b/src/Data/Food/Db.elm
@@ -1,8 +1,6 @@
 module Data.Food.Db exposing
     ( Db
     , buildFromJson
-    , updateIngredientsFromNewProcesses
-    , updateWellKnownFromNewProcesses
     )
 
 import Data.Example as Example exposing (Example)
@@ -34,23 +32,3 @@ buildFromJson exampleProductsJson foodProcessesJson ingredientsJson =
                     (ingredientsJson |> Decode.decodeString (Ingredient.decodeIngredients processes) |> Result.mapError Decode.errorToString)
                     (WellKnown.load processes)
             )
-
-
-updateIngredientsFromNewProcesses : List Process -> List Ingredient -> List Ingredient
-updateIngredientsFromNewProcesses processes =
-    List.map
-        (\ingredient ->
-            Process.findById processes ingredient.default.id_
-                |> Result.map (\default -> { ingredient | default = default })
-                |> Result.withDefault ingredient
-        )
-
-
-updateWellKnownFromNewProcesses : List Process -> WellKnown -> WellKnown
-updateWellKnownFromNewProcesses processes =
-    WellKnown.map
-        (\({ id_ } as process) ->
-            processes
-                |> Process.findByIdentifier (Process.identifierFromString id_)
-                |> Result.withDefault process
-        )

--- a/src/Data/Food/WellKnown.elm
+++ b/src/Data/Food/WellKnown.elm
@@ -1,7 +1,6 @@
 module Data.Food.WellKnown exposing
     ( WellKnown
     , load
-    , map
     )
 
 import Data.Food.Process as Process exposing (Process)
@@ -35,16 +34,3 @@ load processes =
         |> resolve "tap-water"
         |> resolve "low-voltage-electricity"
         |> resolve "domestic-gas-heat"
-
-
-map : (Process -> Process) -> WellKnown -> WellKnown
-map update wellKnown =
-    { lorryTransport = update wellKnown.lorryTransport
-    , boatTransport = update wellKnown.boatTransport
-    , planeTransport = update wellKnown.planeTransport
-    , lorryCoolingTransport = update wellKnown.lorryCoolingTransport
-    , boatCoolingTransport = update wellKnown.boatCoolingTransport
-    , water = update wellKnown.water
-    , lowVoltageElectricity = update wellKnown.lowVoltageElectricity
-    , domesticGasHeat = update wellKnown.domesticGasHeat
-    }

--- a/src/Data/Session.elm
+++ b/src/Data/Session.elm
@@ -282,9 +282,9 @@ updateStore update session =
     { session | store = update session.store }
 
 
-authenticated : Session -> User -> RawJsonProcesses -> Session
-authenticated ({ store } as session) user rawJsonProcessesWithImpacts =
-    case StaticDb.db rawJsonProcessesWithImpacts of
+authenticated : User -> RawJsonProcesses -> Session -> Session
+authenticated user rawDetailedProcessesJson ({ store } as session) =
+    case StaticDb.db rawDetailedProcessesJson of
         Ok db ->
             { session | db = db, store = { store | auth = Authenticated user } }
 

--- a/src/Data/Textile/WellKnown.elm
+++ b/src/Data/Textile/WellKnown.elm
@@ -4,7 +4,6 @@ module Data.Textile.WellKnown exposing
     , getEnnoblingHeatProcess
     , getPrintingProcess
     , load
-    , map
     )
 
 import Data.Country exposing (Country)
@@ -145,35 +144,3 @@ load processes =
         |> find .heatEurope
         |> find .heatRoW
         |> find .weaving
-
-
-map : (Process -> Process) -> WellKnown -> WellKnown
-map update wellKnown =
-    { airTransport = update wellKnown.airTransport
-    , bleaching = update wellKnown.bleaching
-    , seaTransport = update wellKnown.seaTransport
-    , roadTransport = update wellKnown.roadTransport
-    , trainTransport = update wellKnown.trainTransport
-    , distribution = update wellKnown.distribution
-    , dyeingYarn = update wellKnown.dyeingYarn
-    , dyeingFabric = update wellKnown.dyeingFabric
-    , dyeingArticle = update wellKnown.dyeingArticle
-    , dyeingSynthetic = update wellKnown.dyeingSynthetic
-    , dyeingCellulosic = update wellKnown.dyeingCellulosic
-    , printingPigment = update wellKnown.printingPigment
-    , printingSubstantive = update wellKnown.printingSubstantive
-    , printingPaste = update wellKnown.printingPaste
-    , printingDyes = update wellKnown.printingDyes
-    , finishing = update wellKnown.finishing
-    , passengerCar = update wellKnown.passengerCar
-    , endOfLife = update wellKnown.endOfLife
-    , fading = update wellKnown.fading
-    , heatEurope = update wellKnown.heatEurope
-    , heatRoW = update wellKnown.heatRoW
-    , knittingMix = update wellKnown.knittingMix
-    , knittingFullyFashioned = update wellKnown.knittingFullyFashioned
-    , knittingSeamless = update wellKnown.knittingSeamless
-    , knittingCircular = update wellKnown.knittingCircular
-    , knittingStraight = update wellKnown.knittingStraight
-    , weaving = update wellKnown.weaving
-    }

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -9,6 +9,7 @@ import Data.Impact as Impact
 import Data.Session as Session exposing (Session)
 import Data.Textile.Query as TextileQuery
 import Html
+import Http
 import Page.Api as Api
 import Page.Auth as Auth
 import Page.Changelog as Changelog
@@ -20,11 +21,13 @@ import Page.Stats as Stats
 import Page.Textile as TextileSimulator
 import Ports
 import RemoteData exposing (WebData)
+import Request.Auth
+import Request.Common
 import Request.Github
 import Request.Version exposing (VersionData)
 import Route
 import Static.Db as StaticDb exposing (Db)
-import Static.Json as StaticJson
+import Static.Json as StaticJson exposing (RawJsonProcesses)
 import Url exposing (Url)
 import Views.Page as Page
 
@@ -71,6 +74,7 @@ type Msg
     | ChangelogMsg Changelog.Msg
     | CloseMobileNavigation
     | CloseNotification Session.Notification
+    | DetailedProcessesReceived Url (Result Http.Error RawJsonProcesses)
     | EditorialMsg Editorial.Msg
     | ExploreMsg Explore.Msg
     | FoodBuilderMsg FoodBuilder.Msg
@@ -91,23 +95,40 @@ type Msg
 
 init : Flags -> Url -> Nav.Key -> ( Model, Cmd Msg )
 init flags url navKey =
-    setRoute url
-        ( { state =
-                case StaticDb.db StaticJson.rawJsonProcesses of
-                    Ok db ->
-                        Loaded (setupSession navKey flags db) LoadingPage
+    case StaticDb.db StaticJson.rawJsonProcesses of
+        Ok db ->
+            let
+                session =
+                    setupSession navKey flags db
+            in
+            setRoute url
+                ( { state = Loaded session LoadingPage
+                  , mobileNavigationOpened = False
+                  , navKey = navKey
+                  }
+                , Cmd.batch
+                    [ Ports.appStarted ()
+                    , Request.Version.loadVersion VersionReceived
+                    , Request.Github.getReleases ReleasesReceived
 
-                    Err err ->
-                        Errored err
-          , mobileNavigationOpened = False
-          , navKey = navKey
-          }
-        , Cmd.batch
-            [ Ports.appStarted ()
-            , Request.Version.loadVersion VersionReceived
-            , Request.Github.getReleases ReleasesReceived
-            ]
-        )
+                    -- FIXME: tester si localStorage auth pas null, et récupérer les processes détaillés
+                    , case session.store.auth of
+                        Session.Authenticated user ->
+                            Request.Auth.processes (DetailedProcessesReceived url) user.token
+
+                        Session.NotAuthenticated ->
+                            Cmd.none
+                    ]
+                )
+
+        Err err ->
+            setRoute url
+                ( { state = Errored err
+                  , mobileNavigationOpened = False
+                  , navKey = navKey
+                  }
+                , Cmd.none
+                )
 
 
 setupSession : Nav.Key -> Flags -> Db -> Session
@@ -116,13 +137,7 @@ setupSession navKey flags db =
         store =
             Session.deserializeStore flags.rawStore
     in
-    { db =
-        case store.auth of
-            Session.Authenticated _ textileProcesses foodProcesses ->
-                db |> StaticDb.updateProcesses foodProcesses textileProcesses
-
-            Session.NotAuthenticated ->
-                db
+    { db = db
     , clientUrl = flags.clientUrl
     , enableFoodSection = flags.enableFoodSection
     , navKey = navKey
@@ -262,6 +277,21 @@ update rawMsg ({ state } as model) =
                 ( ChangelogMsg changelogMsg, ChangelogPage changelogModel ) ->
                     Changelog.update session changelogMsg changelogModel
                         |> toPage ChangelogPage ChangelogMsg
+
+                ( DetailedProcessesReceived url (Ok rawDetailedProcessesJson), currentPage ) ->
+                    -- When detailed processes are received, rebuild the entire static db using them
+                    case StaticDb.db rawDetailedProcessesJson of
+                        Ok detailedDb ->
+                            { model | state = currentPage |> Loaded { session | db = detailedDb } }
+                                |> update (UrlChanged url)
+
+                        Err error ->
+                            ( { model | state = Errored error }, Cmd.none )
+
+                ( DetailedProcessesReceived _ (Err httpError), _ ) ->
+                    ( { model | state = Errored (Request.Common.errorToString httpError) }
+                    , Cmd.none
+                    )
 
                 ( EditorialMsg editorialMsg, EditorialPage editorialModel ) ->
                     Editorial.update session editorialMsg editorialModel

--- a/src/Page/Auth.elm
+++ b/src/Page/Auth.elm
@@ -95,9 +95,9 @@ update session msg model =
                 |> AuthRequest.register TokenEmailSent
             )
 
-        Authenticated user (Ok newProcessesJson) ->
+        Authenticated user (Ok rawDetailedProcessesJson) ->
             ( model
-            , Session.authenticated session user newProcessesJson
+            , session |> Session.authenticated user rawDetailedProcessesJson
             , Cmd.none
             )
 

--- a/src/Static/Db.elm
+++ b/src/Static/Db.elm
@@ -2,16 +2,13 @@ module Static.Db exposing
     ( Db
     , db
     , decodeRawJsonProcesses
-    , updateProcesses
     )
 
 import Data.Common.Db as Common
 import Data.Country exposing (Country)
 import Data.Food.Db as FoodDb
-import Data.Food.Process as FoodProcess
 import Data.Impact.Definition exposing (Definitions)
 import Data.Textile.Db as TextileDb
-import Data.Textile.Process as TextileProcess
 import Data.Transport exposing (Distances)
 import Json.Decode as Decode exposing (Decoder)
 import Json.Decode.Pipeline as JDP
@@ -62,40 +59,3 @@ countries textileDb =
 distances : Result String Distances
 distances =
     Common.transportsFromJson StaticJson.transportsJson
-
-
-updateProcesses : List FoodProcess.Process -> List TextileProcess.Process -> Db -> Db
-updateProcesses foodProcesses textileProcesses ({ textile, food } as db_) =
-    { db_
-        | countries = db_.countries |> updateCountriesFromNewProcesses textileProcesses
-        , textile =
-            { textile
-                | processes = textileProcesses
-                , materials = TextileDb.updateMaterialsFromNewProcesses textileProcesses textile.materials
-                , products = TextileDb.updateProductsFromNewProcesses textileProcesses textile.products
-                , wellKnown = TextileDb.updateWellKnownFromNewProcesses textileProcesses textile.wellKnown
-            }
-        , food =
-            { food
-                | processes = foodProcesses
-                , ingredients = FoodDb.updateIngredientsFromNewProcesses foodProcesses db_.food.ingredients
-                , wellKnown = FoodDb.updateWellKnownFromNewProcesses foodProcesses food.wellKnown
-            }
-    }
-
-
-updateCountriesFromNewProcesses : List TextileProcess.Process -> List Country -> List Country
-updateCountriesFromNewProcesses processList =
-    List.map
-        (\country ->
-            Result.map2
-                (\electricityProcess heatProcess ->
-                    { country
-                        | electricityProcess = electricityProcess
-                        , heatProcess = heatProcess
-                    }
-                )
-                (TextileProcess.findByUuid country.electricityProcess.uuid processList)
-                (TextileProcess.findByUuid country.heatProcess.uuid processList)
-                |> Result.withDefault country
-        )


### PR DESCRIPTION
## :wrench: Problem

Sometimes when processes data are updated server side, the locally cached client data are desynced, which triggers weird issues — most notably in the comparator with missing chart segments, those corresponding to missing data or linked objects.

## :cake: Solution

This patch removes all use of the processes data cached in localStorage, and loads detailed data on client app start when authenticated. That way, we're always sure to start the client app with the latest available data from the server.

## :desert_island: How to test

Very hard to simulate data changed from the server while a locally cached previous version of it lives in memory. I suspect you'll have to trust me on this one.
