### PR TITLE
fix(ui): Hide unreleased entry in production version selector.

### DIFF
--- a/src/Request/Version.elm
+++ b/src/Request/Version.elm
@@ -1,6 +1,7 @@
 module Request.Version exposing
     ( Version(..)
     , VersionData
+    , getTag
     , is
     , loadVersion
     , pollVersion
@@ -64,6 +65,16 @@ is release version =
 
         _ ->
             False
+
+
+getTag : Version -> Maybe String
+getTag version =
+    case version of
+        Version { tag } ->
+            tag
+
+        _ ->
+            Nothing
 
 
 loadVersion : (WebData VersionData -> msg) -> Cmd msg

--- a/src/Views/Page.elm
+++ b/src/Views/Page.elm
@@ -324,8 +324,14 @@ pageHeader { session, activePage, openMobileNavigation, loadUrl, switchVersion }
             , session.releases
                 |> RemoteData.map
                     (\releases ->
-                        Github.unreleased
-                            :: releases
+                        (case Version.getTag session.currentVersion of
+                            Just _ ->
+                                releases
+
+                            Nothing ->
+                                -- If we're not on a tag, add an "unreleased" entry to reflect that
+                                Github.unreleased :: releases
+                        )
                             |> List.map
                                 (\release ->
                                     option [ selected <| Version.is release session.currentVersion ]


### PR DESCRIPTION
This patch removes the `Unreleased` version selector entry when the app is a tagged release.