### PR TITLE
feat: add app version to openapi docs in the root endpoint.

### DIFF
--- a/server.js
+++ b/server.js
@@ -160,6 +160,7 @@ if (fs.existsSync(versionsDir)) {
 // API
 
 const openApiContents = yaml.load(fs.readFileSync("openapi.yaml"));
+openApiContents.version = require("./package.json").version;
 
 // Matomo
 const apiTracker = lib.setupTracker(openApiContents);


### PR DESCRIPTION
## :wrench: Problem

When using the API in production, you have no obvious way to be certain what's the precise app version you're using, as there's no version in the endpoint url nor in the result payloads.

## :cake: Solution

Expose the app version in the root endpoint, where the openapi docs reside.

## :desert_island: How to test

```
$ curl https://ecobalyse-pr726.osc-fr1.scalingo.io/api | jq .version
"2.1.1"
```