### PR TITLE
fix: ensure express app is properly monitored by Sentry.

### DIFF
--- a/lib/instrument.js
+++ b/lib/instrument.js
@@ -14,9 +14,8 @@ if (SENTRY_DSN) {
 
 function monitorExpressApp(app) {
   if (SENTRY_DSN) {
-    Sentry.setupExp;
+    Sentry.setupExpressErrorHandler(app);
   }
-  Sentry.setupExpressErrorHandler(app);
 }
 
 module.exports = {

--- a/lib/instrument.js
+++ b/lib/instrument.js
@@ -1,0 +1,24 @@
+const Sentry = require("@sentry/node");
+const { nodeProfilingIntegration } = require("@sentry/profiling-node");
+
+const { SENTRY_DSN } = process.env;
+
+if (SENTRY_DSN) {
+  Sentry.init({
+    dsn: SENTRY_DSN,
+    integrations: [nodeProfilingIntegration()],
+    tracesSampleRate: 1.0,
+    profilesSampleRate: 1.0,
+  });
+}
+
+function monitorExpressApp(app) {
+  if (SENTRY_DSN) {
+    Sentry.setupExp;
+  }
+  Sentry.setupExpressErrorHandler(app);
+}
+
+module.exports = {
+  monitorExpressApp,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@parcel/transformer-sass": "^2.12.0",
         "@sentry/browser": "^8.27.0",
         "@sentry/node": "^8.27.0",
+        "@sentry/profiling-node": "^8.28.0",
         "@sentry/tracing": "^7.114.0",
         "bootstrap": "^5.3.3",
         "cors": "^2.8.5",
@@ -3912,9 +3913,9 @@
       }
     },
     "node_modules/@sentry/node": {
-      "version": "8.27.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-8.27.0.tgz",
-      "integrity": "sha512-nE2VPSHOW/tzH/lB6CoBtYkmXqXncUuWMC56RLRiPyHEXDktZx8oFp364/3m117iKOjO0XHP57Kl5cdb90IM7g==",
+      "version": "8.28.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-8.28.0.tgz",
+      "integrity": "sha512-444hx0S7EAYDdq3g2U37qHFC/WFErgf8ZvXqhWfoCI4RweHHntdFbz3azexYnO61iUsmSAnFAX6htJtAG2zNdA==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
@@ -3941,10 +3942,10 @@
         "@opentelemetry/sdk-trace-base": "^1.25.1",
         "@opentelemetry/semantic-conventions": "^1.25.1",
         "@prisma/instrumentation": "5.18.0",
-        "@sentry/core": "8.27.0",
-        "@sentry/opentelemetry": "8.27.0",
-        "@sentry/types": "8.27.0",
-        "@sentry/utils": "8.27.0",
+        "@sentry/core": "8.28.0",
+        "@sentry/opentelemetry": "8.28.0",
+        "@sentry/types": "8.28.0",
+        "@sentry/utils": "8.28.0",
         "import-in-the-middle": "^1.11.0"
       },
       "engines": {
@@ -3954,15 +3955,49 @@
         "opentelemetry-instrumentation-fetch-node": "1.2.3"
       }
     },
-    "node_modules/@sentry/opentelemetry": {
-      "version": "8.27.0",
-      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-8.27.0.tgz",
-      "integrity": "sha512-FRz7ApnyZYDFmi2CWUhKBux2N/0WswRLHwHDZ31FYCajujw7vQKucgdsxDW2RIRPWDwcMxHY1kvt6EzM1hIsxQ==",
+    "node_modules/@sentry/node/node_modules/@sentry/core": {
+      "version": "8.28.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.28.0.tgz",
+      "integrity": "sha512-+If9uubvpZpvaQQw4HLiKPhrSS9/KcoA/AcdQkNm+5CVwAoOmDPtyYfkPBgfo2hLZnZQqR1bwkz/PrNoOm+gqA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "8.27.0",
-        "@sentry/types": "8.27.0",
-        "@sentry/utils": "8.27.0"
+        "@sentry/types": "8.28.0",
+        "@sentry/utils": "8.28.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@sentry/types": {
+      "version": "8.28.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.28.0.tgz",
+      "integrity": "sha512-hOfqfd92/AzBrEdMgmmV1VfOXJbIfleFTnerRl0mg/+CcNgP/6+Fdonp354TD56ouWNF2WkOM6sEKSXMWp6SEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@sentry/utils": {
+      "version": "8.28.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.28.0.tgz",
+      "integrity": "sha512-smhk7PJpvDMQ2DB5p2qn9UeoUHdU41IgjMmS2xklZpa8tjzBTxDeWpGvrX2fuH67D9bAJuLC/XyZjJCHLoEW5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/types": "8.28.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/opentelemetry": {
+      "version": "8.28.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-8.28.0.tgz",
+      "integrity": "sha512-xClK/fa2Y9AMoaV6f7sWfoHAz56actn2RN3UuYAfxlgmNEfZEa0tc78x4XygCT+2b83QbUb+qf1q4+1ft+HEsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "8.28.0",
+        "@sentry/types": "8.28.0",
+        "@sentry/utils": "8.28.0"
       },
       "engines": {
         "node": ">=14.18"
@@ -3973,6 +4008,104 @@
         "@opentelemetry/instrumentation": "^0.52.1",
         "@opentelemetry/sdk-trace-base": "^1.25.1",
         "@opentelemetry/semantic-conventions": "^1.25.1"
+      }
+    },
+    "node_modules/@sentry/opentelemetry/node_modules/@sentry/core": {
+      "version": "8.28.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.28.0.tgz",
+      "integrity": "sha512-+If9uubvpZpvaQQw4HLiKPhrSS9/KcoA/AcdQkNm+5CVwAoOmDPtyYfkPBgfo2hLZnZQqR1bwkz/PrNoOm+gqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/types": "8.28.0",
+        "@sentry/utils": "8.28.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/opentelemetry/node_modules/@sentry/types": {
+      "version": "8.28.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.28.0.tgz",
+      "integrity": "sha512-hOfqfd92/AzBrEdMgmmV1VfOXJbIfleFTnerRl0mg/+CcNgP/6+Fdonp354TD56ouWNF2WkOM6sEKSXMWp6SEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/opentelemetry/node_modules/@sentry/utils": {
+      "version": "8.28.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.28.0.tgz",
+      "integrity": "sha512-smhk7PJpvDMQ2DB5p2qn9UeoUHdU41IgjMmS2xklZpa8tjzBTxDeWpGvrX2fuH67D9bAJuLC/XyZjJCHLoEW5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/types": "8.28.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/profiling-node": {
+      "version": "8.28.0",
+      "resolved": "https://registry.npmjs.org/@sentry/profiling-node/-/profiling-node-8.28.0.tgz",
+      "integrity": "sha512-VJFj0XxodeRm+mRJlLYMEmn6HKnYkEm07Zb2mdhG979bQwt2VRoPd+Cv4M6irEfmFoRD1OAR9HX0/p9ClcWzXg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "8.28.0",
+        "@sentry/node": "8.28.0",
+        "@sentry/types": "8.28.0",
+        "@sentry/utils": "8.28.0",
+        "detect-libc": "^2.0.2",
+        "node-abi": "^3.61.0"
+      },
+      "bin": {
+        "sentry-prune-profiler-binaries": "scripts/prune-profiler-binaries.js"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/profiling-node/node_modules/@sentry/core": {
+      "version": "8.28.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.28.0.tgz",
+      "integrity": "sha512-+If9uubvpZpvaQQw4HLiKPhrSS9/KcoA/AcdQkNm+5CVwAoOmDPtyYfkPBgfo2hLZnZQqR1bwkz/PrNoOm+gqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/types": "8.28.0",
+        "@sentry/utils": "8.28.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/profiling-node/node_modules/@sentry/types": {
+      "version": "8.28.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.28.0.tgz",
+      "integrity": "sha512-hOfqfd92/AzBrEdMgmmV1VfOXJbIfleFTnerRl0mg/+CcNgP/6+Fdonp354TD56ouWNF2WkOM6sEKSXMWp6SEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/profiling-node/node_modules/@sentry/utils": {
+      "version": "8.28.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.28.0.tgz",
+      "integrity": "sha512-smhk7PJpvDMQ2DB5p2qn9UeoUHdU41IgjMmS2xklZpa8tjzBTxDeWpGvrX2fuH67D9bAJuLC/XyZjJCHLoEW5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/types": "8.28.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/profiling-node/node_modules/detect-libc": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@sentry/tracing": {
@@ -5064,9 +5197,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001596",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001596.tgz",
-      "integrity": "sha512-zpkZ+kEr6We7w63ORkoJ2pOfBwBkY/bJrG/UZ90qNb45Isblu8wzDgevEOrRL1r9dWayHjYiiyCMEXPn4DweGQ==",
+      "version": "1.0.30001657",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001657.tgz",
+      "integrity": "sha512-DPbJAlP8/BAXy3IgiWmZKItubb3TYGP0WscQQlVGIfT4s/YlFYVuJgyOsQNP7rJRChx/qdMeLJQJP0Sgg2yjNA==",
       "funding": [
         {
           "type": "opencollective",
@@ -5080,7 +5213,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/caseless": {
       "version": "0.12.0",
@@ -8796,6 +8930,18 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+    },
+    "node_modules/node-abi": {
+      "version": "3.67.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.67.0.tgz",
+      "integrity": "sha512-bLn/fU/ALVBE9wj+p4Y21ZJWYFjUXLXPi/IewyLZkx3ApxKDNBWCKdReeKOtD8dWpOdDCeMyLh6ZewzcLsG2Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/node-addon-api": {
       "version": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@parcel/transformer-sass": "^2.12.0",
     "@sentry/browser": "^8.27.0",
     "@sentry/node": "^8.27.0",
+    "@sentry/profiling-node": "^8.28.0",
     "@sentry/tracing": "^7.114.0",
     "bootstrap": "^5.3.3",
     "cors": "^2.8.5",

--- a/server.js
+++ b/server.js
@@ -1,15 +1,16 @@
 require("dotenv").config();
 const fs = require("fs");
 const path = require("path");
-const express = require("express");
 const bodyParser = require("body-parser");
 const cors = require("cors");
 const yaml = require("js-yaml");
 const helmet = require("helmet");
-const Sentry = require("@sentry/node");
 const { Elm } = require("./server-app");
 const lib = require("./lib");
 const { decrypt } = require("./lib/crypto");
+const Sentry = require("@sentry/node");
+Sentry.init({ dsn: process.env.SENTRY_DSN, tracesSampleRate: 0.1 });
+const express = require("express");
 
 const rateLimit = require("express-rate-limit");
 const app = express(); // web app
@@ -48,7 +49,6 @@ try {
 
 // Sentry
 if (SENTRY_DSN) {
-  Sentry.init({ dsn: SENTRY_DSN, tracesSampleRate: 0.1 });
   Sentry.setupExpressErrorHandler(app);
 }
 

--- a/server.js
+++ b/server.js
@@ -1,4 +1,5 @@
 require("dotenv").config();
+const { monitorExpressApp } = require("./lib/instrument");
 const fs = require("fs");
 const path = require("path");
 const bodyParser = require("body-parser");
@@ -8,8 +9,6 @@ const helmet = require("helmet");
 const { Elm } = require("./server-app");
 const lib = require("./lib");
 const { decrypt } = require("./lib/crypto");
-const Sentry = require("@sentry/node");
-Sentry.init({ dsn: process.env.SENTRY_DSN, tracesSampleRate: 0.1 });
 const express = require("express");
 
 const rateLimit = require("express-rate-limit");
@@ -22,8 +21,7 @@ const djangoPort = 8002;
 const version = express(); // version app
 
 // Env vars
-const { ECOBALYSE_DATA_DIR, MATOMO_HOST, MATOMO_SITE_ID, MATOMO_TOKEN, NODE_ENV, SENTRY_DSN } =
-  process.env;
+const { ECOBALYSE_DATA_DIR, MATOMO_HOST, MATOMO_SITE_ID, MATOMO_TOKEN, NODE_ENV } = process.env;
 
 var rateLimiter = rateLimit({
   windowMs: 1000, // 1 second
@@ -47,10 +45,8 @@ try {
   process.exit(1);
 }
 
-// Sentry
-if (SENTRY_DSN) {
-  Sentry.setupExpressErrorHandler(app);
-}
+// Sentry monitoring
+monitorExpressApp(app);
 
 // Web
 


### PR DESCRIPTION
We have `[server] [Sentry] express is not instrumented. This is likely because you required/imported express before calling Sentry.init()` log errors which is fixed by this patch — which follows the [official integration guide](https://docs.sentry.io/platforms/javascript/guides/express/).