### PR TITLE
chore: remove unneeded python package

### DIFF
--- a/data/docker/entrypoint.sh
+++ b/data/docker/entrypoint.sh
@@ -2,16 +2,12 @@
 
 ECOBALYSE_ID=$(ls -lnd /home/jovyan/ecobalyse|awk '{print $3}')
 JOVYAN_ID=$(id -u jovyan)
+export PYTHONPATH=/home/jovyan/ecobalyse/data
 
 if [ $ECOBALYSE_ID -ne $JOVYAN_ID ]; then
     usermod -u $ECOBALYSE_ID jovyan
 fi
 
-pushd /home/jovyan/${ECOBALYSE:=ecobalyse}/data
-gosu jovyan pip install -e .
-popd
-
-ldconfig
 chown -R 1000:100 "/home/jovyan/.npm"
 
 gosu jovyan "$@"

--- a/data/setup.py
+++ b/data/setup.py
@@ -1,7 +1,0 @@
-from setuptools import setup
-
-setup(
-    name="ecobalyse_data",
-    version="1.0",
-    packages=["food", "common", "textile", "food.ecosystemic_services"],
-)


### PR DESCRIPTION
no need for a setup.py as it's not distributed as a package. We just need to import it.
It allows faster and offline docker entrypoint where we don't install the local package