### PR TITLE
fix(ci): check for ecobalyse-private when extracting the branch name

### DIFF
--- a/packages/python/ecobalyse/ecobalyse/github.py
+++ b/packages/python/ecobalyse/ecobalyse/github.py
@@ -14,7 +14,7 @@ def extract_branch_name(content: str) -> str | None:
     # (it should be part of the body)
     # Branch names format: https://docs.github.com/en/get-started/using-git/dealing-with-special-characters-in-branch-and-tag-names#naming-branches-and-tags
     # The English alphabet (a to z and A to Z), Numbers (0 to 9), period (.), hyphen (-), underscore (_), forward slash (/)
-    result = re.search(r"ecobalyse_data: ([0-9a-zA-Z./_-]+)", content, re.M | re.I)
+    result = re.search(r"ecobalyse-private: ([0-9a-zA-Z./_-]+)", content, re.M | re.I)
     if result:
         return result.group(1)
 

--- a/packages/python/ecobalyse/ecobalyse/tests/test_data_branch.py
+++ b/packages/python/ecobalyse/ecobalyse/tests/test_data_branch.py
@@ -2,25 +2,27 @@ from ecobalyse.github import extract_branch_name
 
 
 def test_extract_data_branch_name(client):
-    branch_name = extract_branch_name("ecobalyse_data: test_branch_name")
+    branch_name = extract_branch_name("ecobalyse-private: test_branch_name")
     assert branch_name == "test_branch_name"
 
-    branch_name = extract_branch_name("nstnsnecobalyse_data: test_branch_name nstnstn")
+    branch_name = extract_branch_name(
+        "nstnsnecobalyse-private: test_branch_name nstnstn"
+    )
     assert branch_name == "test_branch_name"
 
     branch_name = extract_branch_name("""tnsrtntntsr
-    nstnsnecobalyse_data: test_branch_name nstnstn
+    nstnsnecobalyse-private: test_branch_name nstnstn
 
     eaiuiuea""")
     assert branch_name == "test_branch_name"
 
     branch_name = extract_branch_name(
-        "nstnsnecobalyse_data: test_branch_name/9./_- nstnstn"
+        "nstnsnecobalyse-private: test_branch_name/9./_- nstnstn"
     )
     assert branch_name == "test_branch_name/9./_-"
 
     # We should not include invalid characters in the match
     branch_name = extract_branch_name(
-        "nstnsnecobalyse_data: test_bran<ch_name/9./_- nstnstn"
+        "nstnsnecobalyse-private: test_bran<ch_name/9./_- nstnstn"
     )
     assert branch_name == "test_bran"


### PR DESCRIPTION
## :wrench: Problem

Currently, we are checking for `ecobalyse_data` in the content of a PR to synchronize withe the `ecobalyse-private` repo. For consistency, check for `ecobalyse-private`.

## :rotating_light:  Points to watch / comments

Github token was changed to my personal token to avoid 403 responses. We may need to use an app token at some point.
Tests have been moved to the package directory for consistency.

## :desert_island: How to test

Merge this PR in a PR requiring a different `ecobalyse-private` branch and check that everything is working as expected.