### PR TITLE
refactor: Removed duplicate identifier column in the food explorer

### DIFF
--- a/src/Page/Explore/FoodProcesses.elm
+++ b/src/Page/Explore/FoodProcesses.elm
@@ -43,10 +43,6 @@ table _ { detailed, scope } =
           , toValue = Table.StringValue <| .source
           , toCell = .source >> text
           }
-        , { label = "Identifiant source"
-          , toValue = Table.StringValue <| .identifier >> FoodProcess.identifierToString
-          , toCell = \process -> code [] [ text (FoodProcess.identifierToString process.identifier) ]
-          }
         , { label = "Unité"
           , toValue = Table.StringValue <| .unit
           , toCell = .unit >> text


### PR DESCRIPTION
The `source identifier` column is a duplicate of the `identifier` and can be removed