### PR TITLE
fix: encode physicalDurability parameter.

### DIFF
--- a/src/Data/Textile/Inputs.elm
+++ b/src/Data/Textile/Inputs.elm
@@ -257,6 +257,13 @@ stepsToStrings inputs =
                 else
                     ""
                )
+            ++ (case inputs.physicalDurability of
+                    Just physicalDurability ->
+                        ", durabilité physique " ++ String.fromFloat (Unit.physicalDurabilityToFloat physicalDurability)
+
+                    Nothing ->
+                        ""
+               )
       , Format.kgToString inputs.mass
       ]
     , ifStepEnabled Label.Material
@@ -500,6 +507,7 @@ encode inputs =
         , ( "mass", Encode.float (Mass.inKilograms inputs.mass) )
         , ( "materials", Encode.list encodeMaterialInput inputs.materials )
         , ( "numberOfReferences", inputs.numberOfReferences |> Maybe.map Encode.int |> Maybe.withDefault Encode.null )
+        , ( "physicalDurability", inputs.physicalDurability |> Maybe.map Unit.encodePhysicalDurability |> Maybe.withDefault Encode.null )
         , ( "price", inputs.price |> Maybe.map Economics.encodePrice |> Maybe.withDefault Encode.null )
         , ( "printing", inputs.printing |> Maybe.map Printing.encode |> Maybe.withDefault Encode.null )
         , ( "product", Product.encode inputs.product )

--- a/src/Data/Textile/Query.elm
+++ b/src/Data/Textile/Query.elm
@@ -170,6 +170,7 @@ encode query =
     , ( "mass", query.mass |> Mass.inKilograms |> Encode.float |> Just )
     , ( "materials", query.materials |> Encode.list encodeMaterialQuery |> Just )
     , ( "numberOfReferences", query.numberOfReferences |> Maybe.map Encode.int )
+    , ( "physicalDurability", query.physicalDurability |> Maybe.map Unit.encodePhysicalDurability )
     , ( "price", query.price |> Maybe.map Economics.encodePrice )
     , ( "printing", query.printing |> Maybe.map Printing.encode )
     , ( "product", query.product |> Product.idToString |> Encode.string |> Just )

--- a/src/Data/Unit.elm
+++ b/src/Data/Unit.elm
@@ -16,6 +16,7 @@ module Data.Unit exposing
     , decodeYarnSize
     , encodeImpact
     , encodeNonPhysicalDurability
+    , encodePhysicalDurability
     , encodePickPerMeter
     , encodeRatio
     , encodeSurfaceMass
@@ -189,6 +190,11 @@ decodePhysicalDurability =
                     Decode.succeed float
             )
         |> Decode.map physicalDurability
+
+
+encodePhysicalDurability : PhysicalDurability -> Encode.Value
+encodePhysicalDurability (PhysicalDurability float) =
+    Encode.float float
 
 
 encodeNonPhysicalDurability : NonPhysicalDurability -> Encode.Value


### PR DESCRIPTION
This patch fixes missing JSON encoding of this parameter and update inputs string representation to include it as well. It also fixes an issue where two saved simulations could be highlighted while only one was actually selected (because the string serialization was used to check the highlight status).