### PR TITLE
chore: filter sentry errors by env

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -11,6 +11,6 @@ ENABLE_FOOD_SECTION=True
 MATOMO_HOST=stats.beta.gouv.fr
 MATOMO_SITE_ID=57
 MATOMO_TOKEN=xxx
-NODE_ENV=production
+NODE_ENV=development
 SCALINGO_POSTGRESQL_URL=please-change-this
 SENTRY_DSN=please-change-this

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Les variables d'environnement suivantes doivent être définies :
 - `MATOMO_HOST`: le domaine de l'instance Matomo permettant le suivi d'audience du produit (typiquement `stats.beta.gouv.fr`).
 - `MATOMO_SITE_ID`: l'identifiant du site Ecobalyse sur l'instance Matomo permettant le suivi d'audience du produit.
 - `MATOMO_TOKEN`: le token Matomo permettant le suivi d'audience du produit.
-- `NODE_ENV`: l'environnement d'exécution nodejs (par défaut, `production`)
+- `NODE_ENV`: l'environnement d'exécution nodejs (par défaut, `development`)
 - `SCALINGO_POSTGRESQL_URL` : l'uri pour accéder à Postgresl (définie automatiquement par Scalingo). Si non défini sqlite3 est utilisé.
 - `SENTRY_DSN`: le DSN [Sentry](https://sentry.io) à utiliser pour les rapports d'erreur.
 

--- a/bin/build-specific-app-version.sh
+++ b/bin/build-specific-app-version.sh
@@ -158,7 +158,7 @@ cd $PUBLIC_GIT_CLONE_DIR
 # Installing node stuff
 # We need to specify dev as the env to avoid errors with needed dev packages at build time like
 # old husky prerequesite
-NODE_ENV=dev npm ci
+NODE_ENV=development npm ci
 
 # We want a production build
 export NODE_ENV=production

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ if (process.env.SENTRY_DSN) {
       // Most often due to DOM-aggressive browser extensions
       /_VirtualDom_applyPatch/,
     ],
-    environment: process.env.IS_REVIEW_APP ? "review-app" : NODE_ENV || "development",
+    environment: process.env.IS_REVIEW_APP ? "review-app" : process.env.NODE_ENV || "development",
   });
 }
 
@@ -67,6 +67,15 @@ app.ports.appStarted.subscribe(() => {
   _paq.push(["disableCookies"]);
   _paq.push(["setSiteId", process.env.MATOMO_SITE_ID]);
   loadScript(u + "matomo.js");
+
+  var footer = document.getElementsByClassName("Footer");
+  footer[0].addEventListener(
+    "click",
+    function (e) {
+      throw new Error("Sentry Test");
+    },
+    false,
+  );
 });
 
 app.ports.loadRapidoc.subscribe((rapidocScriptUrl) => {

--- a/index.js
+++ b/index.js
@@ -11,11 +11,14 @@ if (process.env.SENTRY_DSN) {
     allowUrls: [
       /^https:\/\/ecobalyse\.beta\.gouv\.fr/,
       /^https:\/\/staging-ecobalyse\.incubateur\.net/,
+      // Review apps
+      /^https:\/\/ecobalyse-pr.*\.osc-fr1\.scalingo\.io/,
     ],
     ignoreErrors: [
       // Most often due to DOM-aggressive browser extensions
       /_VirtualDom_applyPatch/,
     ],
+    environment: process.env.IS_REVIEW_APP ? "review-app" : NODE_ENV || "development",
   });
 }
 

--- a/index.js
+++ b/index.js
@@ -67,15 +67,6 @@ app.ports.appStarted.subscribe(() => {
   _paq.push(["disableCookies"]);
   _paq.push(["setSiteId", process.env.MATOMO_SITE_ID]);
   loadScript(u + "matomo.js");
-
-  var footer = document.getElementsByClassName("Footer");
-  footer[0].addEventListener(
-    "click",
-    function (e) {
-      throw new Error("Sentry Test");
-    },
-    false,
-  );
 });
 
 app.ports.loadRapidoc.subscribe((rapidocScriptUrl) => {

--- a/index.js
+++ b/index.js
@@ -6,6 +6,8 @@ import Charts from "./lib/charts";
 if (process.env.SENTRY_DSN) {
   Sentry.init({
     dsn: process.env.SENTRY_DSN,
+    integrations: [Sentry.browserTracingIntegration()],
+    tracesSampleRate: 0,
     allowUrls: [
       /^https:\/\/ecobalyse\.beta\.gouv\.fr/,
       /^https:\/\/staging-ecobalyse\.incubateur\.net/,

--- a/index.js
+++ b/index.js
@@ -6,8 +6,6 @@ import Charts from "./lib/charts";
 if (process.env.SENTRY_DSN) {
   Sentry.init({
     dsn: process.env.SENTRY_DSN,
-    integrations: [Sentry.browserTracingIntegration()],
-    tracesSampleRate: 0,
     allowUrls: [
       /^https:\/\/ecobalyse\.beta\.gouv\.fr/,
       /^https:\/\/staging-ecobalyse\.incubateur\.net/,

--- a/lib/instrument.js
+++ b/lib/instrument.js
@@ -11,6 +11,7 @@ if (shouldInitSentry) {
     integrations: [nodeProfilingIntegration()],
     tracesSampleRate: 1.0,
     profilesSampleRate: 1.0,
+    // IS_REVIEW_APP is set by `scalingo.json` only on review apps
     environment: IS_REVIEW_APP ? "review-app" : NODE_ENV,
   });
 }

--- a/lib/instrument.js
+++ b/lib/instrument.js
@@ -1,7 +1,7 @@
 const Sentry = require("@sentry/node");
 const { nodeProfilingIntegration } = require("@sentry/profiling-node");
 
-const { SENTRY_DSN } = process.env;
+const { SENTRY_DSN, IS_REVIEW_APP, NODE_ENV } = process.env;
 
 if (SENTRY_DSN) {
   Sentry.init({
@@ -9,6 +9,7 @@ if (SENTRY_DSN) {
     integrations: [nodeProfilingIntegration()],
     tracesSampleRate: 1.0,
     profilesSampleRate: 1.0,
+    environment: IS_REVIEW_APP ? "review-app" : NODE_ENV || "development",
   });
 }
 

--- a/lib/instrument.js
+++ b/lib/instrument.js
@@ -3,18 +3,20 @@ const { nodeProfilingIntegration } = require("@sentry/profiling-node");
 
 const { SENTRY_DSN, IS_REVIEW_APP, NODE_ENV } = process.env;
 
-if (SENTRY_DSN) {
+const shouldInitSentry = SENTRY_DSN && NODE_ENV === "production";
+
+if (shouldInitSentry) {
   Sentry.init({
     dsn: SENTRY_DSN,
     integrations: [nodeProfilingIntegration()],
     tracesSampleRate: 1.0,
     profilesSampleRate: 1.0,
-    environment: IS_REVIEW_APP ? "review-app" : NODE_ENV || "development",
+    environment: IS_REVIEW_APP ? "review-app" : NODE_ENV,
   });
 }
 
 function monitorExpressApp(app) {
-  if (SENTRY_DSN) {
+  if (shouldInitSentry) {
     Sentry.setupExpressErrorHandler(app);
   }
 }

--- a/scalingo.json
+++ b/scalingo.json
@@ -1,0 +1,7 @@
+{
+  "env": {
+    "IS_REVIEW_APP": {
+      "value": "true"
+    }
+  }
+}


### PR DESCRIPTION
## :wrench: Problem

Production and review app errors are mix and matched in Sentry.

[Notion card](https://www.notion.so/Ne-loguer-les-v-nements-Sentry-qu-en-production-43f188ca8a624f08b6b7c7fd8e31254d)

## :cake: Solution

Use a different environment in Sentry for production and review-apps errors.

## :rotating_light:  Points to watch / comments

I've introduced a new file `scalingo.json` used to configure review apps https://doc.scalingo.com/platform/app/review-apps#run-a-task-after-each-deployment-of-a-review-app

I have CORS issue with the envelope call on the review-app without knowing why. Could be a server config/version issue cf. https://github.com/getsentry/sentry/issues/24637

## :desert_island: How to test

Clicking on the footer should throw an error (the code will be removed before merging).