### PR TITLE
chore: render food api docs conditionally from env.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Les variables d'environnement suivantes doivent être définies :
 - `EMAIL_HOST` : le host SMTP pour envoyer les mail liés à l'authentification
 - `EMAIL_HOST_USER`: l'utilisateur du compte SMTP
 - `EMAIL_HOST_PASSWORD` : le mot de passe du compte SMTP pour envoyer les mail liés à l'authentification
+- `ENABLE_FOOD_SECTION` : affichage ou non de la section expérimentale dédiée à l'alimentaire (valeur `True` ou `False`, par défault `False`)
 - `MATOMO_HOST`: le domaine de l'instance Matomo permettant le suivi d'audience du produit (typiquement `stats.beta.gouv.fr`).
 - `MATOMO_SITE_ID`: l'identifiant du site Ecobalyse sur l'instance Matomo permettant le suivi d'audience du produit.
 - `MATOMO_TOKEN`: le token Matomo permettant le suivi d'audience du produit.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -295,160 +295,160 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/InvalidParametersError"
-  # /food/countries:
-  #   get:
-  #     tags:
-  #       - Alimentaire
-  #     summary: Liste des pays utilisables pour les simulations alimentairess.
-  #     responses:
-  #       200:
-  #         description: Opération réussie
-  #         content:
-  #           application/json:
-  #             schema:
-  #               $ref: "#/components/schemas/CountryListResponse"
-  # /food/ingredients:
-  #   get:
-  #     tags:
-  #       - Alimentaire
-  #     summary: Liste des ingrédients disponibles pour élaborer une recette
-  #     responses:
-  #       200:
-  #         description: Opération réussie
-  #         content:
-  #           application/json:
-  #             schema:
-  #               $ref: "#/components/schemas/IngredientListResponse"
-  # /food/transforms:
-  #   get:
-  #     tags:
-  #       - Alimentaire
-  #     summary: Liste des procédés de transformation alimentaire
-  #     responses:
-  #       200:
-  #         description: Opération réussie
-  #         content:
-  #           application/json:
-  #             schema:
-  #               $ref: "#/components/schemas/TransformListResponse"
-  # /food/packagings:
-  #   get:
-  #     tags:
-  #       - Alimentaire
-  #     summary: Liste des emballages disponibles pour conditionner une recette
-  #     responses:
-  #       200:
-  #         description: Opération réussie
-  #         content:
-  #           application/json:
-  #             schema:
-  #               $ref: "#/components/schemas/PackagingListResponse"
-  # /food:
-  #   get:
-  #     tags:
-  #       - Alimentaire
-  #     summary: Calcul des impacts environnementaux d'une recette alimentaire
-  #     parameters:
-  #       - $ref: "#/components/parameters/ingredientsParam"
-  #       - $ref: "#/components/parameters/transformParam"
-  #       - $ref: "#/components/parameters/packagingParam"
-  #       - $ref: "#/components/parameters/distributionParam"
-  #       - $ref: "#/components/parameters/preparationParam"
-  #     responses:
-  #       200:
-  #         description: Opération réussie
-  #         content:
-  #           application/json:
-  #             schema:
-  #               $ref: "#/components/schemas/RecipeResultsResponse"
-  #       400:
-  #         description: Paramètres invalides
-  #         content:
-  #           application/json:
-  #             schema:
-  #               $ref: "#/components/schemas/InvalidParametersError"
-  #   post:
-  #     tags:
-  #       - Alimentaire
-  #     summary: Calcul des impacts environnementaux d'une recette alimentaire
-  #     requestBody:
-  #       description: Requête modélisant les éléments de la recette à évaluer
-  #       required: true
-  #       content:
-  #         application/json:
-  #           schema:
-  #             $ref: "#/components/schemas/FoodQuery"
-  #           examples:
-  #             CarrotCake:
-  #               summary: "Carrot cake conventionnel"
-  #               value:
-  #                 ingredients:
-  #                 - id: egg
-  #                   mass: 120
-  #                 - id: wheat
-  #                   mass: 140
-  #                 - id: milk
-  #                   mass: 60
-  #                 - id: carrot
-  #                   mass: 225
-  #                 transform:
-  #                   code: AGRIBALU000000003103966
-  #                   mass: 545
-  #                 packaging:
-  #                 - code: AGRIBALU000000003104019
-  #                   mass: 105
-  #                 distribution: ambient
-  #                 preparation:
-  #                 - refrigeration
-  #             SpanishOrganicCarrotCake:
-  #               summary: "Carrot cake bio, origine Espagne"
-  #               value:
-  #                 ingredients:
-  #                 - id: egg-organic
-  #                   mass: 120
-  #                   country: ES
-  #                 - id: wheat-organic
-  #                   mass: 140
-  #                   country: ES
-  #                 - id: milk-organic
-  #                   mass: 60
-  #                   country: ES
-  #                 - id: carrot-organic
-  #                   mass: 225
-  #                   country: ES
-  #                 transform:
-  #                   code: AGRIBALU000000003103966
-  #                   mass: 545
-  #                 packaging:
-  #                 - code: AGRIBALU000000003104019
-  #                   mass: 105
-  #                 distribution: ambient
-  #                 preparation:
-  #                 - refrigeration
-  #             BrazilianMango:
-  #               summary: "Mangue du Brésil"
-  #               value:
-  #                 ingredients:
-  #                 - id: mango
-  #                   mass: 500
-  #                   country: BR
-  #                 transform: null
-  #                 packaging: []
-  #                 distribution: ambient
-  #                 preparation: []
-  #     responses:
-  #       200:
-  #         description: Opération réussie
-  #         content:
-  #           application/json:
-  #             schema:
-  #               $ref: "#/components/schemas/RecipeResultsResponse"
-  #       400:
-  #         description: Paramètres invalides
-  #         content:
-  #           application/json:
-  #             schema:
-  #               $ref: "#/components/schemas/InvalidParametersError"
+  /food/countries:
+    get:
+      tags:
+        - Alimentaire
+      summary: Liste des pays utilisables pour les simulations alimentairess.
+      responses:
+        200:
+          description: Opération réussie
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CountryListResponse"
+  /food/ingredients:
+    get:
+      tags:
+        - Alimentaire
+      summary: Liste des ingrédients disponibles pour élaborer une recette
+      responses:
+        200:
+          description: Opération réussie
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IngredientListResponse"
+  /food/transforms:
+    get:
+      tags:
+        - Alimentaire
+      summary: Liste des procédés de transformation alimentaire
+      responses:
+        200:
+          description: Opération réussie
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TransformListResponse"
+  /food/packagings:
+    get:
+      tags:
+        - Alimentaire
+      summary: Liste des emballages disponibles pour conditionner une recette
+      responses:
+        200:
+          description: Opération réussie
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PackagingListResponse"
+  /food:
+    get:
+      tags:
+        - Alimentaire
+      summary: Calcul des impacts environnementaux d'une recette alimentaire
+      parameters:
+        - $ref: "#/components/parameters/ingredientsParam"
+        - $ref: "#/components/parameters/transformParam"
+        - $ref: "#/components/parameters/packagingParam"
+        - $ref: "#/components/parameters/distributionParam"
+        - $ref: "#/components/parameters/preparationParam"
+      responses:
+        200:
+          description: Opération réussie
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RecipeResultsResponse"
+        400:
+          description: Paramètres invalides
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InvalidParametersError"
+    post:
+      tags:
+        - Alimentaire
+      summary: Calcul des impacts environnementaux d'une recette alimentaire
+      requestBody:
+        description: Requête modélisant les éléments de la recette à évaluer
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/FoodQuery"
+            examples:
+              CarrotCake:
+                summary: "Carrot cake conventionnel"
+                value:
+                  ingredients:
+                  - id: egg
+                    mass: 120
+                  - id: wheat
+                    mass: 140
+                  - id: milk
+                    mass: 60
+                  - id: carrot
+                    mass: 225
+                  transform:
+                    code: AGRIBALU000000003103966
+                    mass: 545
+                  packaging:
+                  - code: AGRIBALU000000003104019
+                    mass: 105
+                  distribution: ambient
+                  preparation:
+                  - refrigeration
+              SpanishOrganicCarrotCake:
+                summary: "Carrot cake bio, origine Espagne"
+                value:
+                  ingredients:
+                  - id: egg-organic
+                    mass: 120
+                    country: ES
+                  - id: wheat-organic
+                    mass: 140
+                    country: ES
+                  - id: milk-organic
+                    mass: 60
+                    country: ES
+                  - id: carrot-organic
+                    mass: 225
+                    country: ES
+                  transform:
+                    code: AGRIBALU000000003103966
+                    mass: 545
+                  packaging:
+                  - code: AGRIBALU000000003104019
+                    mass: 105
+                  distribution: ambient
+                  preparation:
+                  - refrigeration
+              BrazilianMango:
+                summary: "Mangue du Brésil"
+                value:
+                  ingredients:
+                  - id: mango
+                    mass: 500
+                    country: BR
+                  transform: null
+                  packaging: []
+                  distribution: ambient
+                  preparation: []
+      responses:
+        200:
+          description: Opération réussie
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RecipeResultsResponse"
+        400:
+          description: Paramètres invalides
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/InvalidParametersError"
 components:
   securitySchemes:
     token:


### PR DESCRIPTION
## :wrench: Problem

While we introduced the `ENABLE_FOOD_SECTION` env var to hide or show the Food section, associated menus and links, we hide the API docs for Food completely and there's no current way to access these API docs. 

## :cake: Solution

This patch checks for the value of the `ENABLE_FOOD_SECTION` var and filter the openapi docs appropriately.

## :desert_island: How to test

Check that the API docs for food are available for this review app.
