### PR TITLE
chore: fix npm error when make_export_food

### DIFF
--- a/data/Makefile
+++ b/data/Makefile
@@ -47,7 +47,7 @@ compare_food:
 	@$(call DOCKER,python3 export.py compare)
 
 format:
-	npm run format:json
+	npm run fix:all
 
 python:
 	echo Running Python inside the container...
@@ -94,4 +94,3 @@ clean_image:
 	docker image rm $(NAME)
 
 clean: clean_data clean_image
-

--- a/data/docker/entrypoint.sh
+++ b/data/docker/entrypoint.sh
@@ -8,6 +8,11 @@ if [ $ECOBALYSE_ID -ne $JOVYAN_ID ]; then
     usermod -u $ECOBALYSE_ID jovyan
 fi
 
-chown -R 1000:100 "/home/jovyan/.npm"
+# Ensure .npm directory is owned by jovyan
+mkdir -p /home/jovyan/.npm
+chown -R jovyan:100 "/home/jovyan/.npm"
 
-gosu jovyan "$@"
+# Clear npm cache
+su jovyan -c "npm cache clean --force"
+
+exec gosu jovyan "$@"


### PR DESCRIPTION
Bug : 
![image](https://github.com/user-attachments/assets/75098475-311d-4bf6-b88c-769e30f4dc90)

Fix :
- The previous  chown command in the Dockerfile is setting ownership to user ID 1000, but the error message suggests the container is running as user ID 1001. -> use the actual jovyan user ID in the container
- clear the npm cache before running any npm commands