### PR TITLE
fix: stricter validation of POST json body passed to the textile API.

### DIFF
--- a/src/Data/Textile/Query.elm
+++ b/src/Data/Textile/Query.elm
@@ -110,33 +110,37 @@ buildApiQuery clientUrl query =
 
 decode : Decoder Query
 decode =
-    -- Note: We're using Json.Decode.Extra's optionalField here because we want
-    -- a failure when an optional decoded field value is invalid
+    let
+        -- Note: Using Json.Decode.Extra's optionalField here because we want
+        -- a failure when a Maybe decoded field value is invalid
+        strictOptional field decoder =
+            DE.andMap (DE.optionalField field decoder)
+    in
     Decode.succeed Query
-        |> DE.andMap (DE.optionalField "airTransportRatio" Split.decodeFloat)
-        |> DE.andMap (DE.optionalField "business" Economics.decodeBusiness)
-        |> DE.andMap (DE.optionalField "countryDyeing" Country.decodeCode)
-        |> DE.andMap (DE.optionalField "countryFabric" Country.decodeCode)
-        |> DE.andMap (DE.optionalField "countryMaking" Country.decodeCode)
-        |> DE.andMap (DE.optionalField "countrySpinning" Country.decodeCode)
+        |> strictOptional "airTransportRatio" Split.decodeFloat
+        |> strictOptional "business" Economics.decodeBusiness
+        |> strictOptional "countryDyeing" Country.decodeCode
+        |> strictOptional "countryFabric" Country.decodeCode
+        |> strictOptional "countryMaking" Country.decodeCode
+        |> strictOptional "countrySpinning" Country.decodeCode
         |> Pipe.optional "disabledSteps" (Decode.list Label.decodeFromCode) []
-        |> DE.andMap (DE.optionalField "dyeingMedium" DyeingMedium.decode)
-        |> DE.andMap (DE.optionalField "fabricProcess" Fabric.decode)
-        |> DE.andMap (DE.optionalField "fading" Decode.bool)
-        |> DE.andMap (DE.optionalField "makingComplexity" MakingComplexity.decode)
-        |> DE.andMap (DE.optionalField "makingDeadStock" Split.decodeFloat)
-        |> DE.andMap (DE.optionalField "makingWaste" Split.decodeFloat)
+        |> strictOptional "dyeingMedium" DyeingMedium.decode
+        |> strictOptional "fabricProcess" Fabric.decode
+        |> strictOptional "fading" Decode.bool
+        |> strictOptional "makingComplexity" MakingComplexity.decode
+        |> strictOptional "makingDeadStock" Split.decodeFloat
+        |> strictOptional "makingWaste" Split.decodeFloat
         |> Pipe.required "mass" (Decode.map Mass.kilograms Decode.float)
         |> Pipe.required "materials" (Decode.list decodeMaterialQuery)
-        |> DE.andMap (DE.optionalField "numberOfReferences" Decode.int)
-        |> DE.andMap (DE.optionalField "physicalDurability" Unit.decodePhysicalDurability)
-        |> DE.andMap (DE.optionalField "price" Economics.decodePrice)
-        |> DE.andMap (DE.optionalField "printing" Printing.decode)
+        |> strictOptional "numberOfReferences" Decode.int
+        |> strictOptional "physicalDurability" Unit.decodePhysicalDurability
+        |> strictOptional "price" Economics.decodePrice
+        |> strictOptional "printing" Printing.decode
         |> Pipe.required "product" (Decode.map Product.Id Decode.string)
-        |> DE.andMap (DE.optionalField "surfaceMass" Unit.decodeSurfaceMass)
-        |> DE.andMap (DE.optionalField "traceability" Decode.bool)
+        |> strictOptional "surfaceMass" Unit.decodeSurfaceMass
+        |> strictOptional "traceability" Decode.bool
         |> Pipe.optional "upcycled" Decode.bool False
-        |> DE.andMap (DE.optionalField "yarnSize" Unit.decodeYarnSize)
+        |> strictOptional "yarnSize" Unit.decodeYarnSize
 
 
 decodeMaterialQuery : Decoder MaterialQuery

--- a/src/Data/Unit.elm
+++ b/src/Data/Unit.elm
@@ -187,9 +187,8 @@ decodePhysicalDurability =
                         )
 
                 else
-                    Decode.succeed float
+                    Decode.succeed (physicalDurability float)
             )
-        |> Decode.map physicalDurability
 
 
 encodePhysicalDurability : PhysicalDurability -> Encode.Value

--- a/src/Server.elm
+++ b/src/Server.elm
@@ -280,28 +280,32 @@ handleRequest db request =
             executeFoodQuery db (toFoodResults foodQuery) foodQuery
 
         Just (Route.FoodPostRecipe (Err error)) ->
-            ( 400, Encode.string error )
+            Encode.string error
+                |> respondWith 400
 
         Just (Route.TextilePostSimulator (Ok textileQuery)) ->
             textileQuery
                 |> executeTextileQuery db toAllImpactsSimple
 
         Just (Route.TextilePostSimulator (Err error)) ->
-            ( 400, Encode.string error )
+            Encode.string error
+                |> respondWith 400
 
         Just (Route.TextilePostSimulatorDetailed (Ok textileQuery)) ->
             textileQuery
                 |> executeTextileQuery db Simulator.encode
 
         Just (Route.TextilePostSimulatorDetailed (Err error)) ->
-            ( 400, Encode.string error )
+            Encode.string error
+                |> respondWith 400
 
         Just (Route.TextilePostSimulatorSingle (Ok textileQuery) trigram) ->
             textileQuery
                 |> executeTextileQuery db (toSingleImpactSimple trigram)
 
         Just (Route.TextilePostSimulatorSingle (Err error) _) ->
-            ( 400, Encode.string error )
+            Encode.string error
+                |> respondWith 400
 
         Nothing ->
             encodeStringError "Endpoint doesn't exist"

--- a/src/Server.elm
+++ b/src/Server.elm
@@ -277,25 +277,25 @@ handleRequest db request =
                 |> respondWith 400
 
         -- POST routes
-        Just Route.FoodPostRecipe ->
-            request.body
+        Just (Route.FoodPostRecipe jsonBody) ->
+            jsonBody
                 |> handleDecodeBody BuilderQuery.decode
                     (\query ->
                         executeFoodQuery db (toFoodResults query) query
                     )
 
-        Just Route.TextilePostSimulator ->
-            request.body
+        Just (Route.TextilePostSimulator jsonBody) ->
+            jsonBody
                 |> handleDecodeBody TextileQuery.decode
                     (executeTextileQuery db toAllImpactsSimple)
 
-        Just Route.TextilePostSimulatorDetailed ->
-            request.body
+        Just (Route.TextilePostSimulatorDetailed jsonBody) ->
+            jsonBody
                 |> handleDecodeBody TextileQuery.decode
                     (executeTextileQuery db Simulator.encode)
 
-        Just (Route.TextilePostSimulatorSingle trigram) ->
-            request.body
+        Just (Route.TextilePostSimulatorSingle jsonBody trigram) ->
+            jsonBody
                 |> handleDecodeBody TextileQuery.decode
                     (executeTextileQuery db (toSingleImpactSimple trigram))
 

--- a/src/Server.elm
+++ b/src/Server.elm
@@ -284,20 +284,26 @@ handleRequest db request =
                         executeFoodQuery db (toFoodResults query) query
                     )
 
-        Just (Route.TextilePostSimulator jsonBody) ->
-            jsonBody
-                |> handleDecodeBody TextileQuery.decode
-                    (executeTextileQuery db toAllImpactsSimple)
+        Just (Route.TextilePostSimulator (Ok textileQuery)) ->
+            textileQuery
+                |> executeTextileQuery db toAllImpactsSimple
 
-        Just (Route.TextilePostSimulatorDetailed jsonBody) ->
-            jsonBody
-                |> handleDecodeBody TextileQuery.decode
-                    (executeTextileQuery db Simulator.encode)
+        Just (Route.TextilePostSimulator (Err error)) ->
+            ( 400, Encode.string error )
 
-        Just (Route.TextilePostSimulatorSingle jsonBody trigram) ->
-            jsonBody
-                |> handleDecodeBody TextileQuery.decode
-                    (executeTextileQuery db (toSingleImpactSimple trigram))
+        Just (Route.TextilePostSimulatorDetailed (Ok textileQuery)) ->
+            textileQuery
+                |> executeTextileQuery db Simulator.encode
+
+        Just (Route.TextilePostSimulatorDetailed (Err error)) ->
+            ( 400, Encode.string error )
+
+        Just (Route.TextilePostSimulatorSingle (Ok textileQuery) trigram) ->
+            textileQuery
+                |> executeTextileQuery db (toSingleImpactSimple trigram)
+
+        Just (Route.TextilePostSimulatorSingle (Err error) _) ->
+            ( 400, Encode.string error )
 
         Nothing ->
             encodeStringError "Endpoint doesn't exist"

--- a/src/Server/Query.elm
+++ b/src/Server/Query.elm
@@ -15,7 +15,6 @@ import Data.Food.Query as BuilderQuery
 import Data.Food.Retail as Retail exposing (Distribution)
 import Data.Scope as Scope exposing (Scope)
 import Data.Split as Split exposing (Split)
-import Data.Textile.Db as Textile
 import Data.Textile.DyeingMedium as DyeingMedium exposing (DyeingMedium)
 import Data.Textile.Economics as Economics
 import Data.Textile.Fabric as Fabric exposing (Fabric)
@@ -33,6 +32,7 @@ import Mass exposing (Mass)
 import Quantity
 import Regex
 import Result.Extra as RE
+import Static.Db exposing (Db)
 import Url.Parser.Query as Query exposing (Parser)
 
 
@@ -63,8 +63,8 @@ succeed =
     always >> Query.custom ""
 
 
-parseFoodQuery : List Country -> Food.Db -> Parser (Result Errors BuilderQuery.Query)
-parseFoodQuery countries food =
+parseFoodQuery : Db -> Parser (Result Errors BuilderQuery.Query)
+parseFoodQuery { countries, food } =
     succeed (Ok BuilderQuery.Query)
         |> apply (distributionParser "distribution")
         |> apply (ingredientListParser "ingredients" countries food)
@@ -281,9 +281,8 @@ validatePhysicalDurability string =
                         )
 
                 else
-                    Ok durability
+                    Ok (Unit.PhysicalDurability durability)
             )
-        |> Result.map Unit.PhysicalDurability
 
 
 maybeTransformParser : String -> List FoodProcess.Process -> Parser (ParseResult (Maybe BuilderQuery.ProcessQuery))
@@ -384,8 +383,8 @@ parseTransform_ transforms string =
             Err <| "Format de procédé de transformation invalide : " ++ string ++ "."
 
 
-parseTextileQuery : List Country -> Textile.Db -> Parser (Result Errors TextileQuery.Query)
-parseTextileQuery countries textile =
+parseTextileQuery : Db -> Parser (Result Errors TextileQuery.Query)
+parseTextileQuery { countries, textile } =
     succeed (Ok TextileQuery.Query)
         |> apply (maybeSplitParser "airTransportRatio")
         |> apply (maybeBusiness "business")
@@ -884,7 +883,6 @@ encodeErrors : Errors -> Encode.Value
 encodeErrors errors =
     Encode.object
         [ ( "errors"
-          , errors
-                |> Encode.dict identity Encode.string
+          , errors |> Encode.dict identity Encode.string
           )
         ]

--- a/src/Server/Route.elm
+++ b/src/Server/Route.elm
@@ -40,7 +40,7 @@ type Route
     | FoodGetTransformList
       --   POST
       --     Food recipe builder (POST, JSON body)
-    | FoodPostRecipe Encode.Value
+    | FoodPostRecipe (Result String BuilderQuery.Query)
       --
       -- Textile Routes
       --   GET
@@ -77,7 +77,7 @@ parser foodDb textile countries body =
         , Parser.map FoodGetRecipe (s "GET" </> s "food" <?> Query.parseFoodQuery countries foodDb)
 
         -- POST
-        , Parser.map (FoodPostRecipe body) (s "POST" </> s "food")
+        , Parser.map (FoodPostRecipe (decodeFoodQueryBody body)) (s "POST" </> s "food")
 
         -- Textile
         -- GET
@@ -94,6 +94,12 @@ parser foodDb textile countries body =
         , Parser.map (TextilePostSimulatorDetailed (decodeTextileQueryBody body)) (s "POST" </> s "textile" </> s "simulator" </> s "detailed")
         , Parser.map (TextilePostSimulatorSingle (decodeTextileQueryBody body)) (s "POST" </> s "textile" </> s "simulator" </> Impact.parseTrigram)
         ]
+
+
+decodeFoodQueryBody : Encode.Value -> Result String BuilderQuery.Query
+decodeFoodQueryBody body =
+    Decode.decodeValue BuilderQuery.decode body
+        |> Result.mapError Decode.errorToString
 
 
 decodeTextileQueryBody : Encode.Value -> Result String TextileQuery.Query

--- a/src/Server/Route.elm
+++ b/src/Server/Route.elm
@@ -68,29 +68,38 @@ parser db body =
     Parser.oneOf
         [ -- Food
           -- GET
-          Parser.map FoodGetCountryList (s "GET" </> s "food" </> s "countries")
-        , Parser.map FoodGetIngredientList (s "GET" </> s "food" </> s "ingredients")
-        , Parser.map FoodGetTransformList (s "GET" </> s "food" </> s "transforms")
-        , Parser.map FoodGetPackagingList (s "GET" </> s "food" </> s "packagings")
-        , Parser.map FoodGetRecipe (s "GET" </> s "food" <?> Query.parseFoodQuery db)
-
-        -- POST
-        , Parser.map (FoodPostRecipe (decodeFoodQueryBody body)) (s "POST" </> s "food")
+          (s "GET" </> s "food" </> s "countries")
+            |> Parser.map FoodGetCountryList
+        , (s "GET" </> s "food" </> s "ingredients")
+            |> Parser.map FoodGetIngredientList
+        , (s "GET" </> s "food" </> s "transforms")
+            |> Parser.map FoodGetTransformList
+        , (s "GET" </> s "food" </> s "packagings")
+            |> Parser.map FoodGetPackagingList
+        , (s "GET" </> s "food" <?> Query.parseFoodQuery db)
+            |> Parser.map FoodGetRecipe
+        , (s "POST" </> s "food")
+            |> Parser.map (FoodPostRecipe (decodeFoodQueryBody body))
 
         -- Textile
-        -- GET
-        , Parser.map TextileGetCountryList (s "GET" </> s "textile" </> s "countries")
-        , Parser.map TextileGetMaterialList (s "GET" </> s "textile" </> s "materials")
-        , Parser.map TextileGetProductList (s "GET" </> s "textile" </> s "products")
-        , Parser.map TextileGetSimulator (s "GET" </> s "textile" </> s "simulator" <?> Query.parseTextileQuery db)
-        , Parser.map TextileGetSimulatorDetailed (s "GET" </> s "textile" </> s "simulator" </> s "detailed" <?> Query.parseTextileQuery db)
-        , Parser.map TextileGetSimulatorSingle (s "GET" </> s "textile" </> s "simulator" </> Impact.parseTrigram <?> Query.parseTextileQuery db)
-
-        -- POST
-        -- FIXME: we should parse the body to ensure it's an actual query
-        , Parser.map (TextilePostSimulator (decodeTextileQueryBody db body)) (s "POST" </> s "textile" </> s "simulator")
-        , Parser.map (TextilePostSimulatorDetailed (decodeTextileQueryBody db body)) (s "POST" </> s "textile" </> s "simulator" </> s "detailed")
-        , Parser.map (TextilePostSimulatorSingle (decodeTextileQueryBody db body)) (s "POST" </> s "textile" </> s "simulator" </> Impact.parseTrigram)
+        , (s "GET" </> s "textile" </> s "countries")
+            |> Parser.map TextileGetCountryList
+        , (s "GET" </> s "textile" </> s "materials")
+            |> Parser.map TextileGetMaterialList
+        , (s "GET" </> s "textile" </> s "products")
+            |> Parser.map TextileGetProductList
+        , (s "GET" </> s "textile" </> s "simulator" <?> Query.parseTextileQuery db)
+            |> Parser.map TextileGetSimulator
+        , (s "GET" </> s "textile" </> s "simulator" </> s "detailed" <?> Query.parseTextileQuery db)
+            |> Parser.map TextileGetSimulatorDetailed
+        , (s "GET" </> s "textile" </> s "simulator" </> Impact.parseTrigram <?> Query.parseTextileQuery db)
+            |> Parser.map TextileGetSimulatorSingle
+        , (s "POST" </> s "textile" </> s "simulator")
+            |> Parser.map (TextilePostSimulator (decodeTextileQueryBody db body))
+        , (s "POST" </> s "textile" </> s "simulator" </> s "detailed")
+            |> Parser.map (TextilePostSimulatorDetailed (decodeTextileQueryBody db body))
+        , (s "POST" </> s "textile" </> s "simulator" </> Impact.parseTrigram)
+            |> Parser.map (TextilePostSimulatorSingle (decodeTextileQueryBody db body))
         ]
 
 

--- a/tests/Server/RouteTest.elm
+++ b/tests/Server/RouteTest.elm
@@ -233,7 +233,33 @@ textileEndpoints db =
                     }
                 )
             |> expectTextileSingleErrorContains "physicalDurability"
-            |> asTest "should reject invalid POST body"
+            |> asTest "should reject invalid physicalDurability"
+        , "/textile/simulator"
+            |> testEndpoint db
+                "POST"
+                (Query.encode
+                    { tShirtCotonFrance
+                        | countrySpinning = Just (Country.Code "invalid")
+                    }
+                )
+            |> expectTextileSingleErrorContains "materials"
+            |> asTest "should reject invalid spinning country"
+        , "/textile/simulator"
+            |> testEndpoint db
+                "POST"
+                (Query.encode
+                    { tShirtCotonFrance
+                        | materials =
+                            [ { country = Just (Country.Code "invalid")
+                              , id = Material.Id "ei-coton"
+                              , share = Split.full
+                              , spinning = Nothing
+                              }
+                            ]
+                    }
+                )
+            |> expectTextileSingleErrorContains "materials"
+            |> asTest "should reject invalid materials country"
         ]
     , describe "materials param checks"
         [ let

--- a/tests/Server/RouteTest.elm
+++ b/tests/Server/RouteTest.elm
@@ -75,11 +75,11 @@ foodEndpoints db =
     , describe "POST endpoints"
         [ "/food"
             |> testEndpoint db "POST" (FoodQuery.encode FoodQuery.empty)
-            |> Expect.equal (Just Route.FoodPostRecipe)
+            |> Expect.equal (Just (Route.FoodPostRecipe (FoodQuery.encode FoodQuery.empty)))
             |> asTest "should map the POST /food endpoint"
         , "/food"
             |> testEndpoint db "POST" Encode.null
-            |> Expect.equal (Just Route.FoodPostRecipe)
+            |> Expect.equal (Just (Route.FoodPostRecipe Encode.null))
             |> asTest "should map the POST /food endpoint whatever the request body is"
         ]
     , describe "validation"
@@ -216,11 +216,11 @@ textileEndpoints db =
     , describe "POST endpoints"
         [ "/textile/simulator"
             |> testEndpoint db "POST" (Query.encode tShirtCotonFrance)
-            |> Expect.equal (Just Route.TextilePostSimulator)
+            |> Expect.equal (Just (Route.TextilePostSimulator (Query.encode tShirtCotonFrance)))
             |> asTest "should map the POST /textile/simulator endpoint"
         , "/textile/simulator"
             |> testEndpoint db "POST" Encode.null
-            |> Expect.equal (Just Route.TextilePostSimulator)
+            |> Expect.equal (Just (Route.TextilePostSimulator Encode.null))
             |> asTest "should map the POST /textile/simulator endpoint whatever the request body is"
         ]
     , describe "materials param checks"

--- a/tests/Server/RouteTest.elm
+++ b/tests/Server/RouteTest.elm
@@ -76,11 +76,11 @@ foodEndpoints db =
     , describe "POST endpoints"
         [ "/food"
             |> testEndpoint db "POST" (FoodQuery.encode FoodQuery.empty)
-            |> Expect.equal (Just (Route.FoodPostRecipe (FoodQuery.encode FoodQuery.empty)))
+            |> Expect.equal (Just (Route.FoodPostRecipe (Ok FoodQuery.empty)))
             |> asTest "should map the POST /food endpoint"
         , "/food"
             |> testEndpoint db "POST" Encode.null
-            |> Expect.equal (Just (Route.FoodPostRecipe Encode.null))
+            |> Expect.equal (Just (Route.FoodPostRecipe (Err "Problem with the given value:\n\nnull\n\nExpecting an OBJECT with a field named `ingredients`")))
             |> asTest "should map the POST /food endpoint whatever the request body is"
         ]
     , describe "validation"

--- a/tests/Server/RouteTest.elm
+++ b/tests/Server/RouteTest.elm
@@ -242,7 +242,7 @@ textileEndpoints db =
                         | countrySpinning = Just (Country.Code "invalid")
                     }
                 )
-            |> expectTextileSingleErrorContains "materials"
+            |> Expect.equal (Just (Route.TextilePostSimulator (Err "Code pays invalide: invalid.")))
             |> asTest "should reject invalid spinning country"
         , "/textile/simulator"
             |> testEndpoint db
@@ -258,7 +258,7 @@ textileEndpoints db =
                             ]
                     }
                 )
-            |> expectTextileSingleErrorContains "materials"
+            |> Expect.equal (Just (Route.TextilePostSimulator (Err "Code pays invalide: invalid.")))
             |> asTest "should reject invalid materials country"
         ]
     , describe "materials param checks"

--- a/tests/server.spec.js
+++ b/tests/server.spec.js
@@ -614,7 +614,7 @@ async function expectListResponseContains(path, object) {
 
 function expectStatus(response, expectedCode, type = "application/json") {
   if (response.status === 400 && expectedCode != 400) {
-    expect(response.body).not.toHaveProperty("errors", "");
+    expect(response.body).toHaveProperty("errors", "");
   }
   expect(response.type).toBe(type);
   expect(response.statusCode).toBe(expectedCode);

--- a/tests/server.spec.js
+++ b/tests/server.spec.js
@@ -296,11 +296,6 @@ describe("API", () => {
             airTransportRatio: 0.5,
             durability: 1.2,
             reparability: 1.2,
-            makingWaste: null,
-            makingComplexity: null,
-            yarnSize: null,
-            surfaceMass: null,
-            knittingProcess: null,
             disabledSteps: ["use"],
           });
           expectStatus(response, 200);
@@ -619,7 +614,7 @@ async function expectListResponseContains(path, object) {
 
 function expectStatus(response, expectedCode, type = "application/json") {
   if (response.status === 400 && expectedCode != 400) {
-    expect(response.body).toHaveProperty("errors", "");
+    expect(response.body).not.toHaveProperty("errors", "");
   }
   expect(response.type).toBe(type);
   expect(response.statusCode).toBe(expectedCode);


### PR DESCRIPTION
~~Funnily enough, while we were thinking there wasn't any validation applied to some input POST parameters in the API, it was in fact our unit test env which was unable to execute these tests, because it didn't have access to the native JSON body to execute the correct assertions. Validation was working in e2e tests just fine… I should probably have spotted that earlier.~~

Edit: There actually wasn't any validation performed on some optional parameters passed as a JSON  body to POST requests, because we were using the infamous `Json.Decode.maybe` decoder which fallbacks to returning `Nothing` instead of a failure in case the decoded value is invalid. This patch leverages [Json.Decode.Extra.optionalField](https://package.elm-lang.org/packages/elm-community/json-extra/latest/Json-Decode-Extra#optionalField) instead:

> If a field is missing, succeed with Nothing. If it is present, decode it as normal and wrap successes in a Just.
>
> When decoding with [maybe](http://package.elm-lang.org/packages/elm-lang/core/latest/Json-Decode#maybe), if a field is present but malformed, you get a success and Nothing. optionalField gives you a failed decoding in that case, so you know you received malformed data.

