### PR TITLE
fix: fix github CI python build setup.

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -53,9 +53,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ~/.local/share/virtualenvs
-        key: ${{ runner.os }}-${{ matrix.python-version }}-pipenv-${{ hashFiles('Pipfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-pipenv-
+        key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-pipenv-${{ hashFiles('Pipfile.lock') }}
 
     - name: Install Node dependencies
       run: npm ci --prefer-offline --no-audit


### PR DESCRIPTION
This is an attempt at fixing failing github action CI builds at the Python setup step.

https://github.com/actions/cache/blob/main/examples.md#python---pipenv