### PR TITLE
debug python venv error

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,23 +31,29 @@ jobs:
         pip install pipenv
         pipenv --version
 
-    - name: Debug virtual environment
+    - name: Check Pipfile and Pipfile.lock
       run: |
-        pipenv --venv
-        pipenv run which python
-        pipenv run python --version
+        cat Pipfile
+        echo "---"
+        cat Pipfile.lock
+
+    - name: Check project structure
+      run: |
+        pwd
+        ls -R
 
     - name: Install dependencies
-      run: pipenv install -d
-
-    - name: Run tests
-      run: pipenv run python -m pytest
+      run: |
+        pipenv --python 3.12
+        pipenv install -d -v
 
     - name: Debug environment
-      if: failure()
+      if: always()
       run: |
         env
         pipenv --where
-        pipenv --venv
-        ls -la $(pipenv --venv)
-        ls -la $(pipenv --venv)/bin
+        pipenv --venv || echo "No virtualenv found"
+        pipenv graph
+
+    - name: Run tests
+      run: pipenv run python -m pytest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,53 @@
+name: Python application
+
+on:
+  push:
+    branches: [debug-python-venv]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.12'
+
+    - name: Verify Python installation
+      run: |
+        python --version
+        which python
+        pip --version
+
+    - name: List system Python versions
+      run: ls /usr/bin/python*
+
+    - name: Verify pip and pipenv
+      run: |
+        pip install --upgrade pip
+        pip install pipenv
+        pipenv --version
+
+    - name: Debug virtual environment
+      run: |
+        pipenv --venv
+        pipenv run which python
+        pipenv run python --version
+
+    - name: Install dependencies
+      run: pipenv install -d
+
+    - name: Run tests
+      run: pipenv run python -m pytest
+
+    - name: Debug environment
+      if: failure()
+      run: |
+        env
+        pipenv --where
+        pipenv --venv
+        ls -la $(pipenv --venv)
+        ls -la $(pipenv --venv)/bin


### PR DESCRIPTION
````
##[debug]Evaluating condition for step: 'Install Python dependencies'
##[debug]Evaluating: success()
##[debug]Evaluating success:
##[debug]=> true
##[debug]Result: true
##[debug]Starting: Install Python dependencies
##[debug]Loading inputs
##[debug]Loading env
Run pip install pipenv && pipenv install -d
##[debug]/usr/bin/bash -e /home/runner/work/_temp/60b4d518-25f4-452b-9c89-6c080c52c702.sh
Collecting pipenv
  Downloading pipenv-2024.0.2-py3-none-any.whl.metadata (19 kB)
Collecting certifi (from pipenv)
  Downloading certifi-2024.8.30-py3-none-any.whl.metadata (2.2 kB)
Collecting setuptools>=67 (from pipenv)
  Downloading setuptools-75.1.0-py3-none-any.whl.metadata (6.9 kB)
Collecting virtualenv>=20.24.2 (from pipenv)
  Downloading virtualenv-20.26.5-py3-none-any.whl.metadata (4.5 kB)
Collecting distlib<1,>=0.3.7 (from virtualenv>=20.24.2->pipenv)
  Downloading distlib-0.3.8-py2.py3-none-any.whl.metadata (5.1 kB)
Collecting filelock<4,>=3.12.2 (from virtualenv>=20.24.2->pipenv)
  Downloading filelock-3.16.1-py3-none-any.whl.metadata (2.9 kB)
Collecting platformdirs<5,>=3.9.1 (from virtualenv>=20.24.2->pipenv)
  Downloading platformdirs-4.3.6-py3-none-any.whl.metadata (11 kB)
Downloading pipenv-2024.0.2-py3-none-any.whl (3.3 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 3.3/3.3 MB 97.9 MB/s eta 0:00:00
Downloading setuptools-75.1.0-py3-none-any.whl (1.2 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━��━━━ 1.2/1.2 MB 137.7 MB/s eta 0:00:00
Downloading virtualenv-20.26.5-py3-none-any.whl (6.0 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 6.0/6.0 MB 196.3 MB/s eta 0:00:00
Downloading certifi-2024.8.30-py3-none-any.whl (167 kB)
Downloading distlib-0.3.8-py2.py3-none-any.whl (468 kB)
Downloading filelock-3.16.1-py3-none-any.whl (16 kB)
Downloading platformdirs-4.3.6-py3-none-any.whl (18 kB)
Installing collected packages: distlib, setuptools, platformdirs, filelock, certifi, virtualenv, pipenv
Successfully installed certifi-2024.8.30 distlib-0.3.8 filelock-3.16.1 pipenv-2024.0.2 platformdirs-4.3.6 setuptools-75.1.0 virtualenv-20.26.5
To activate this project's virtualenv, run pipenv shell.
Alternatively, run a command inside the virtualenv with pipenv run.
To activate this project's virtualenv, run pipenv shell.
Alternatively, run a command inside the virtualenv with pipenv run.
Installing dependencies from Pipfile.lock (adbbe8)...
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.12.6/x64/bin/pipenv", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "/opt/hostedtoolcache/Python/3.12.6/x64/lib/python3.12/site-packages/pipenv/vendor/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.6/x64/lib/python3.12/site-packages/pipenv/cli/options.py", line 52, in main
    return super().main(*args, **kwargs, windows_expand_args=False)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.6/x64/lib/python3.12/site-packages/pipenv/vendor/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.6/x64/lib/python3.12/site-packages/pipenv/vendor/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.6/x64/lib/python3.12/site-packages/pipenv/vendor/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.6/x64/lib/python3.12/site-packages/pipenv/vendor/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.6/x64/lib/python3.12/site-packages/pipenv/vendor/click/decorators.py", line 92, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.6/x64/lib/python3.12/site-packages/pipenv/vendor/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.6/x64/lib/python3.12/site-packages/pipenv/cli/command.py", line 207, in install
    do_install(
  File "/opt/hostedtoolcache/Python/3.12.6/x64/lib/python3.12/site-packages/pipenv/routines/install.py", line 234, in do_install
    raise e
  File "/opt/hostedtoolcache/Python/3.12.6/x64/lib/python3.12/site-packages/pipenv/routines/install.py", line 220, in do_install
    do_install_dependencies(
  File "/opt/hostedtoolcache/Python/3.12.6/x64/lib/python3.12/site-packages/pipenv/routines/install.py", line 413, in do_install_dependencies
    batch_install(
  File "/opt/hostedtoolcache/Python/3.12.6/x64/lib/python3.12/site-packages/pipenv/routines/install.py", line 481, in batch_install
    if not project.environment.is_satisfied(dep)
           ^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.6/x64/lib/python3.12/site-packages/pipenv/project.py", line 511, in environment
    self._environment = self.get_environment(allow_global=allow_global)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.6/x64/lib/python3.12/site-packages/pipenv/project.py", line 497, in get_environment
    environment = Environment(
                  ^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.6/x64/lib/python3.12/site-packages/pipenv/environment.py", line 79, in __init__
    self._base_paths = self.get_paths()
                       ^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.6/x64/lib/python3.12/site-packages/pipenv/environment.py", line 334, in get_paths
    c = subprocess_run(command)
        ^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.6/x64/lib/python3.12/site-packages/pipenv/utils/processes.py", line 72, in subprocess_run
    return subprocess.run(
           ^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.6/x64/lib/python3.12/subprocess.py", line 548, in run
    with Popen(*popenargs, **kwargs) as process:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.6/x64/lib/python3.12/subprocess.py", line 1026, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/opt/hostedtoolcache/Python/3.12.6/x64/lib/python3.12/subprocess.py", line 1955, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: '/home/runner/.local/share/virtualenvs/ecobalyse-04uuYkHe/bin/python'
Error: Process completed with exit code 1.
##[debug]Finishing: Install Python dependencies
````