### PR TITLE
chore: add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## :wrench: Problem
+
+> _Describe the problem you're trying to solve, the reason why you are creating this pull request. Provide a link to the Notion card if any._
+
+## :cake: Solution
+
+> _Explain the solution that this PR implements to solve the problem above._
+
+
+## :rotating_light:  Points to watch/comments
+
+> _If there is anything unusual or some clarifications needed for the reviewer to better understand the PR, discuss it here._
+
+## :desert_island: How to test
+
+> _What someone else than you should do to validate that the solution you implemented is working as expected. Don't hesitate to be too verbose and to explain in details, using bullet points for example, the steps to follow to test the expected behavior._


### PR DESCRIPTION
## :wrench: Problem

PRs descriptions have different formats depending on the author of the PR and don't always provide context and/or how to test.

## :cake: Solution

Setup a PR template so that every PR created starts with the same structure.

## :desert_island: How to test

We can't test it before merging it into `master`. Once merged into `master`, the template should be the default content of a new PR description.
