### PR TITLE
fix(api): handle ingredient plane transport in food POST api.

### DIFF
--- a/src/Data/Food/Ingredient.elm
+++ b/src/Data/Food/Ingredient.elm
@@ -69,6 +69,9 @@ byPlaneAllowed planeTransport ingredient =
         ( ByPlane, PlaneNotApplicable ) ->
             Err "Impossible de spécifier un acheminement par avion pour cet ingrédient, son origine par défaut ne le permet pas."
 
+        -- Note: PlaneNotApplicable is used for conveying both the absence of air transport AND impossible plane transport;
+        --       here we treat it as the equivalent of a `Nothing` where the ingredient default origin would suggest a
+        --       transport by air (eg. Non-EU Mango)
         ( PlaneNotApplicable, ByPlane ) ->
             Ok ByPlane
 

--- a/src/Data/Food/Ingredient.elm
+++ b/src/Data/Food/Ingredient.elm
@@ -65,11 +65,15 @@ type TransportCooling
 
 byPlaneAllowed : PlaneTransport -> Ingredient -> Result String PlaneTransport
 byPlaneAllowed planeTransport ingredient =
-    if byPlaneByDefault ingredient == PlaneNotApplicable && planeTransport /= PlaneNotApplicable then
-        Err byPlaneErrorMessage
+    case ( planeTransport, byPlaneByDefault ingredient ) of
+        ( ByPlane, PlaneNotApplicable ) ->
+            Err "Impossible de spécifier un acheminement par avion pour cet ingrédient, son origine par défaut ne le permet pas."
 
-    else
-        Ok planeTransport
+        ( PlaneNotApplicable, ByPlane ) ->
+            Ok ByPlane
+
+        _ ->
+            Ok planeTransport
 
 
 byPlaneByDefault : Ingredient -> PlaneTransport
@@ -79,11 +83,6 @@ byPlaneByDefault ingredient =
 
     else
         PlaneNotApplicable
-
-
-byPlaneErrorMessage : String
-byPlaneErrorMessage =
-    "Impossible de spécifier un acheminement par avion pour cet ingrédient, son origine par défaut ne le permet pas."
 
 
 decodeId : Decode.Decoder Id

--- a/src/Data/Food/Query.elm
+++ b/src/Data/Food/Query.elm
@@ -91,7 +91,7 @@ addPackaging packaging query =
 
 buildApiQuery : String -> Query -> String
 buildApiQuery clientUrl query =
-    """curl -X POST %apiUrl% \\
+    """curl -sS -X POST %apiUrl% \\
   -H "accept: application/json" \\
   -H "content-type: application/json" \\
   -d '%json%'
@@ -127,15 +127,7 @@ decodePlaneTransport =
                             Ingredient.PlaneNotApplicable
                 )
         )
-        |> Decode.map
-            (\maybe ->
-                case maybe of
-                    Just planeTransport ->
-                        planeTransport
-
-                    Nothing ->
-                        Ingredient.PlaneNotApplicable
-            )
+        |> Decode.map (Maybe.withDefault Ingredient.PlaneNotApplicable)
 
 
 decodeMassInGrams : Decoder Mass

--- a/src/Data/Textile/Query.elm
+++ b/src/Data/Textile/Query.elm
@@ -99,7 +99,7 @@ addMaterial material query =
 
 buildApiQuery : String -> Query -> String
 buildApiQuery clientUrl query =
-    """curl -X POST %apiUrl% \\
+    """curl -sS -X POST %apiUrl% \\
   -H "accept: application/json" \\
   -H "content-type: application/json" \\
   -d '%json%'


### PR DESCRIPTION
## :wrench: Problem

The food API wasn't properly handling the `byPlane` ingredient parameter in `POST`, see [Notion card](https://www.notion.so/Inconsistance-UI-API-sur-mango-non-ue-9da4a84239b741efafd8c6620622c466).

## :cake: Solution

The patch fixes the issue.

## :rotating_light:  Points to watch/comments

There's a lot of tech debt in the way we parse the food query, but this would be HUGE work to properly refactor and should probably be assessed and prioritized better at a more appropriate time, so… this patch basically just patches and fixes the issue in the *least* dirty way.

## :desert_island: How to test

The test suite still passes, which is good. To test the patch works, ask for the Non-EU Mango to the patched food API (I'm running it againt the local branch and server):

```
curl -sS -X POST "http://localhost:1234/api/food" \
 -H "accept: application/json"\
 -H "content-type: application/json"\
 -d '{"ingredients":[{"id":"mango-non-eu","mass":1000}]}' | jq .results.total.ecs
 1090.6833471290029
```