### PR TITLE
fix: don't hide version information on staging

### DIFF
--- a/src/Views/Page.elm
+++ b/src/Views/Page.elm
@@ -91,12 +91,14 @@ frame ({ activePage } as config) ( title, content ) =
     }
 
 
+isStaging : Session -> Bool
+isStaging session =
+    String.contains "ecobalyse-pr" session.clientUrl || String.contains "staging-ecobalyse" session.clientUrl
+
+
 stagingAlert : Config msg -> Html msg
 stagingAlert { session, loadUrl } =
-    if
-        String.contains "ecobalyse-pr" session.clientUrl
-            || String.contains "staging-ecobalyse" session.clientUrl
-    then
+    if isStaging session then
         div [ class "StagingAlert d-block d-sm-flex justify-content-center align-items-center mt-3" ]
             [ text "Vous êtes sur un environnement de recette. "
             , button
@@ -203,7 +205,16 @@ pageFooter session =
                     a [ class "text-decoration-none", href <| "mailto:" ++ email ]
                         [ text label ]
     in
-    footer [ class "Footer" ]
+    footer
+        (class "Footer"
+            :: -- Add bottom padding to avoid StagingAlert to hide the version details
+               (if isStaging session then
+                    [ class "pb-5" ]
+
+                else
+                    []
+               )
+        )
         [ div [ class "FooterNavigation" ]
             [ Container.centered []
                 [ div [ class "row" ]


### PR DESCRIPTION
## :wrench: Problem

When there is a PR deployed on Scalingo, a yellow banner is displayed at the bottom of the website to inform that we are on a staging env.

![Screenshot 2024-09-30 at 11-30-59 Accueil Ecobalyse](https://github.com/user-attachments/assets/870feed6-a4dc-47bc-afc6-1b99ffc2741d)

This banner hides the version number and/or the commit we're looking at.

## :cake: Solution

Add a padding bottom to the footer when we are on a staging env.

## :desert_island: How to test

The review app of this PR should not hide the version number when scrolling at the bottom of the page.
![Screenshot 2024-09-30 at 11-34-28 Accueil Ecobalyse](https://github.com/user-attachments/assets/bd82c3a1-261d-4711-be83-7216625b5a77)

