### PR TITLE
feat: add bookmarks for objects

### DIFF
--- a/src/Data/Bookmark.elm
+++ b/src/Data/Bookmark.elm
@@ -4,8 +4,10 @@ module Data.Bookmark exposing
     , decode
     , encode
     , findByFoodQuery
+    , findByObjectQuery
     , findByTextileQuery
     , isFood
+    , isObject
     , isTextile
     , sort
     , toId
@@ -14,6 +16,7 @@ module Data.Bookmark exposing
 
 import Data.Food.Query as FoodQuery
 import Data.Food.Recipe as Recipe
+import Data.Object.Query as ObjectQuery
 import Data.Scope as Scope exposing (Scope)
 import Data.Textile.Inputs as Inputs
 import Data.Textile.Query as TextileQuery
@@ -32,6 +35,7 @@ type alias Bookmark =
 
 type Query
     = Food FoodQuery.Query
+    | Object ObjectQuery.Query
     | Textile TextileQuery.Query
 
 
@@ -47,6 +51,7 @@ decodeQuery : Decoder Query
 decodeQuery =
     Decode.oneOf
         [ Decode.map Food FoodQuery.decode
+        , Decode.map Object ObjectQuery.decode
         , Decode.map Textile TextileQuery.decode
         ]
 
@@ -66,6 +71,9 @@ encodeQuery v =
         Food query ->
             FoodQuery.encode query
 
+        Object query ->
+            ObjectQuery.encode query
+
         Textile query ->
             TextileQuery.encode query
 
@@ -74,6 +82,16 @@ isFood : Bookmark -> Bool
 isFood { query } =
     case query of
         Food _ ->
+            True
+
+        _ ->
+            False
+
+
+isObject : Bookmark -> Bool
+isObject { query } =
+    case query of
+        Object _ ->
             True
 
         _ ->
@@ -101,6 +119,11 @@ findByFoodQuery foodQuery =
     findByQuery (Food foodQuery)
 
 
+findByObjectQuery : ObjectQuery.Query -> List Bookmark -> Maybe Bookmark
+findByObjectQuery objectQuery =
+    findByQuery (Object objectQuery)
+
+
 findByTextileQuery : TextileQuery.Query -> List Bookmark -> Maybe Bookmark
 findByTextileQuery textileQuery =
     findByQuery (Textile textileQuery)
@@ -111,6 +134,9 @@ scope bookmark =
     case bookmark.query of
         Food _ ->
             Scope.Food
+
+        Object _ ->
+            Scope.Object
 
         Textile _ ->
             Scope.Textile
@@ -134,6 +160,10 @@ toQueryDescription db bookmark =
                 |> Recipe.fromQuery db
                 |> Result.map Recipe.toString
                 |> Result.withDefault bookmark.name
+
+        Object objectQuery ->
+            objectQuery
+                |> ObjectQuery.toString
 
         Textile textileQuery ->
             textileQuery

--- a/src/Data/Object/Process.elm
+++ b/src/Data/Object/Process.elm
@@ -6,6 +6,7 @@ module Data.Object.Process exposing
     , encode
     , encodeId
     , findById
+    , idToString
     )
 
 import Data.Impact as Impact exposing (Impacts)

--- a/src/Data/Object/Query.elm
+++ b/src/Data/Object/Query.elm
@@ -5,11 +5,14 @@ module Data.Object.Query exposing
     , amount
     , amountToFloat
     , b64encode
+    , buildApiQuery
     , decode
     , default
     , defaultItem
+    , encode
     , parseBase64Query
     , removeItem
+    , toString
     , updateItem
     )
 
@@ -43,6 +46,17 @@ amount =
 amountToFloat : Amount -> Float
 amountToFloat (Amount float) =
     float
+
+
+buildApiQuery : String -> Query -> String
+buildApiQuery clientUrl query =
+    """curl -sS -X POST %apiUrl% \\
+  -H "accept: application/json" \\
+  -H "content-type: application/json" \\
+  -d '%json%'
+"""
+        |> String.replace "%apiUrl%" (clientUrl ++ "api/object/simulator")
+        |> String.replace "%json%" (encode query |> Encode.encode 0)
 
 
 decode : Decoder Query
@@ -104,6 +118,23 @@ updateItem newItem query =
                             item
                     )
     }
+
+
+toString : Query -> String
+toString query =
+    query.items
+        |> List.map
+            (\i ->
+                (i.amount
+                    |> amountToFloat
+                    |> String.fromFloat
+                )
+                    ++ " "
+                    ++ (i.processId
+                            |> Process.idToString
+                       )
+            )
+        |> String.join " - "
 
 
 

--- a/src/Data/Object/Simulator.elm
+++ b/src/Data/Object/Simulator.elm
@@ -5,20 +5,20 @@ module Data.Object.Simulator exposing
     )
 
 import Data.Impact as Impact exposing (Impacts)
-import Data.Object.Db exposing (Db)
 import Data.Object.Process as Process exposing (Process)
 import Data.Object.Query as Query exposing (Item, Query)
 import Quantity
 import Result.Extra as RE
+import Static.Db exposing (Db)
 
 
 availableProcesses : Db -> Query -> List Process
-availableProcesses db query =
+availableProcesses { object } query =
     let
         usedIds =
             List.map .processId query.items
     in
-    db.processes
+    object.processes
         |> List.filter (\{ id } -> not (List.member id usedIds))
 
 
@@ -31,9 +31,9 @@ compute db query =
 
 
 computeItemImpacts : Db -> Item -> Result String Impacts
-computeItemImpacts db { amount, processId } =
+computeItemImpacts { object } { amount, processId } =
     processId
-        |> Process.findById db.processes
+        |> Process.findById object.processes
         |> Result.map
             (.impacts
                 >> Impact.mapImpacts (\_ -> Quantity.multiplyBy (Query.amountToFloat amount))

--- a/src/Page/Object.elm
+++ b/src/Page/Object.elm
@@ -149,7 +149,7 @@ findExistingBookmarkName { store } query =
     store.bookmarks
         |> Bookmark.findByObjectQuery query
         |> Maybe.map .name
-        |> Maybe.withDefault (query |> Query.toString)
+        |> Maybe.withDefault (Query.toString query)
 
 
 updateQuery : Query -> ( Model, Session, Cmd Msg ) -> ( Model, Session, Cmd Msg )

--- a/src/Views/Bookmark.elm
+++ b/src/Views/Bookmark.elm
@@ -3,6 +3,7 @@ module Views.Bookmark exposing (ActiveTab(..), view)
 import Data.Bookmark as Bookmark exposing (Bookmark)
 import Data.Food.Query as FoodQuery
 import Data.Impact.Definition exposing (Definition)
+import Data.Object.Query as ObjectQuery
 import Data.Scope as Scope exposing (Scope)
 import Data.Session exposing (Session)
 import Data.Textile.Query as TextileQuery
@@ -84,11 +85,11 @@ shareTabView { copyToClipBoard, impact, scope, session } =
                         |> Route.toString
                         |> (++) session.clientUrl
                       -- FIXME: make this a maybe
-                    , session.queries.textile
-                        |> TextileQuery.buildApiQuery session.clientUrl
+                    , session.queries.object
+                        |> ObjectQuery.buildApiQuery session.clientUrl
                       -- FIXME: make this a maybe
-                    , session.queries.textile
-                        |> TextileQuery.encode
+                    , session.queries.object
+                        |> ObjectQuery.encode
                         |> Encode.encode 2
                     )
 
@@ -248,6 +249,10 @@ bookmarkView cfg ({ name, query } as bookmark) =
                     Just foodQuery
                         |> Route.FoodBuilder cfg.impact.trigram
 
+                Bookmark.Object objectQuery ->
+                    Just objectQuery
+                        |> Route.ObjectSimulator cfg.impact.trigram
+
                 Bookmark.Textile textileQuery ->
                     Just textileQuery
                         |> Route.TextileSimulator cfg.impact.trigram
@@ -286,8 +291,7 @@ queryFromScope session scope =
             Bookmark.Food session.queries.food
 
         Scope.Object ->
-            -- FIXME: object bookmarks
-            Bookmark.Textile session.queries.textile
+            Bookmark.Object session.queries.object
 
         Scope.Textile ->
             Bookmark.Textile session.queries.textile
@@ -302,8 +306,7 @@ scopedBookmarks session scope =
                     Bookmark.isFood
 
                 Scope.Object ->
-                    -- FIXME: object bookmarks
-                    always False
+                    Bookmark.isObject
 
                 Scope.Textile ->
                     Bookmark.isTextile

--- a/src/Views/Comparator.elm
+++ b/src/Views/Comparator.elm
@@ -126,9 +126,9 @@ addToComparison session label query =
             objectQuery
                 |> ObjectSimulator.compute session.db
                 |> Result.map
-                    (\_ ->
+                    (\impacts ->
                         { complementsImpact = Impact.noComplementsImpacts
-                        , impacts = Impact.empty
+                        , impacts = impacts
                         , label = label
                         , stepsImpacts = Impact.noStepsImpacts
                         }

--- a/src/Views/Comparator.elm
+++ b/src/Views/Comparator.elm
@@ -7,8 +7,9 @@ import Data.Bookmark as Bookmark exposing (Bookmark)
 import Data.Food.Recipe as Recipe
 import Data.Impact as Impact
 import Data.Impact.Definition as Definition exposing (Definition, Definitions)
+import Data.Object.Simulator as ObjectSimulator
 import Data.Session as Session exposing (Session)
-import Data.Textile.Simulator as Simulator
+import Data.Textile.Simulator as TextileSimulator
 import Data.Unit as Unit
 import Dict
 import Html exposing (..)
@@ -121,9 +122,21 @@ addToComparison session label query =
                         }
                     )
 
+        Bookmark.Object objectQuery ->
+            objectQuery
+                |> ObjectSimulator.compute session.db
+                |> Result.map
+                    (\_ ->
+                        { complementsImpact = Impact.noComplementsImpacts
+                        , impacts = Impact.empty
+                        , label = label
+                        , stepsImpacts = Impact.noStepsImpacts
+                        }
+                    )
+
         Bookmark.Textile textileQuery ->
             textileQuery
-                |> Simulator.compute session.db
+                |> TextileSimulator.compute session.db
                 |> Result.map
                     (\simulator ->
                         { complementsImpact = simulator.complementsImpacts
@@ -131,7 +144,7 @@ addToComparison session label query =
                         , label = label
                         , stepsImpacts =
                             simulator
-                                |> Simulator.toStepsImpacts Definition.Ecs
+                                |> TextileSimulator.toStepsImpacts Definition.Ecs
                         }
                     )
 

--- a/tests/Data/Object/SimulatorTest.elm
+++ b/tests/Data/Object/SimulatorTest.elm
@@ -14,7 +14,7 @@ import TestUtils exposing (asTest, suiteWithDb)
 
 getEcsImpact : Db -> Query -> Result String Float
 getEcsImpact db =
-    Simulator.compute db.object
+    Simulator.compute db
         >> Result.map (Impact.getImpact Definition.Ecs >> Unit.impactToFloat)
 
 


### PR DESCRIPTION
## :wrench: Problem

The first version of the object interface doesn't manage bookmarks.

## :cake: Solution

Implement the bookmark mechanism already available for the food and textile sections.

## :rotating_light:  Points to watch/comments

The `toString` on the `Query` object to find a default name for the bookmark may be questionnable.

## :desert_island: How to test

Go on the review app https://ecobalyse-pr781.osc-fr1.scalingo.io/#/object/simulator and try to save/load simulations for the object interface using the bottom right tab.

![Screenshot 2024-10-01 at 14-41-57 Simulateur Ecobalyse](https://github.com/user-attachments/assets/313ffcd4-ada5-41f8-bbe6-ddb553e7dde1)
