### PR TITLE
fix: reset physical durablility in regulatory mode

### DIFF
--- a/src/Data/Textile/Query.elm
+++ b/src/Data/Textile/Query.elm
@@ -236,6 +236,7 @@ isAdvancedQuery query =
         , query.makingDeadStock /= Nothing
         , query.makingWaste /= Nothing
         , query.materials |> List.any (.spinning >> (/=) Nothing)
+        , query.physicalDurability /= Nothing
         , query.surfaceMass /= Nothing
         , not query.upcycled && List.length query.disabledSteps > 0
         , query.yarnSize /= Nothing
@@ -254,6 +255,7 @@ regulatory query =
         , makingDeadStock = Nothing
         , makingWaste = Nothing
         , materials = query.materials |> List.map (\m -> { m | spinning = Nothing })
+        , physicalDurability = Nothing
         , surfaceMass = Nothing
         , yarnSize = Nothing
     }


### PR DESCRIPTION
## :wrench: Problem

When switching from exploratory mode to regulatory mode, the physical durability is not reset.

[Notion card](https://www.notion.so/Correction-du-coeff-de-durabilit-227d9ba113354f4388de9a6e49cff9ff)

## :cake: Solution

Add `physicalDurability` to the advanced query check.


## :desert_island: How to test

- Go to the regulatory mode
- Choose "Pull coton chine fast fashion"
- Put the physical durability to 0.67
- Switch to regulatory tab and check that this popup appears
![image](https://github.com/user-attachments/assets/e7f1e381-3a44-4aa9-bfd1-06102f733c9b)
- Confirm
- On the regulatory tab,  the durability coefficient should be back to 0.92
![image](https://github.com/user-attachments/assets/cc96b916-140e-4a79-99fe-0f9072bb5c02)

