### PR TITLE
fix(api,food): nullable fields weren't nullable anymore.

### DIFF
--- a/src/Data/Common/DecodeUtils.elm
+++ b/src/Data/Common/DecodeUtils.elm
@@ -5,8 +5,9 @@ import Json.Decode.Extra as DE
 
 
 {-| A stricter Decode.maybe using Json.Decode.Extra's optionalField here because we want
-a failure when a Maybe decoded field value is invalid.
+a failure when a Maybe decoded field value is invalid, while we still want to treat `null`
+as an acepted value.
 -}
 strictOptional : String -> Decoder a -> Decoder (Maybe a -> b) -> Decoder b
 strictOptional field decoder =
-    DE.andMap (DE.optionalField field decoder)
+    DE.andMap (DE.optionalNullableField field decoder)

--- a/src/Data/Food/Query.elm
+++ b/src/Data/Food/Query.elm
@@ -96,7 +96,7 @@ buildApiQuery clientUrl query =
   -H "content-type: application/json" \\
   -d '%json%'
 """
-        |> String.replace "%apiUrl%" (clientUrl ++ "api/food/recipe")
+        |> String.replace "%apiUrl%" (clientUrl ++ "api/food")
         |> String.replace "%json%" (encode query |> Encode.encode 0)
 
 

--- a/src/Server.elm
+++ b/src/Server.elm
@@ -60,7 +60,7 @@ sendResponse httpStatus { jsResponseHandler, method, url } body =
 encodeStringError : String -> Encode.Value
 encodeStringError error =
     Encode.object
-        [ ( "error", error |> String.lines |> Encode.list Encode.string )
+        [ ( "error", error |> String.lines |> List.filter ((/=) "") |> Encode.list Encode.string )
         , ( "documentation", Encode.string apiDocUrl )
         ]
 
@@ -280,7 +280,7 @@ handleRequest db request =
             executeFoodQuery db (toFoodResults foodQuery) foodQuery
 
         Just (Route.FoodPostRecipe (Err error)) ->
-            Encode.string error
+            encodeStringError error
                 |> respondWith 400
 
         Just (Route.TextilePostSimulator (Ok textileQuery)) ->
@@ -288,7 +288,7 @@ handleRequest db request =
                 |> executeTextileQuery db toAllImpactsSimple
 
         Just (Route.TextilePostSimulator (Err error)) ->
-            Encode.string error
+            encodeStringError error
                 |> respondWith 400
 
         Just (Route.TextilePostSimulatorDetailed (Ok textileQuery)) ->
@@ -296,7 +296,7 @@ handleRequest db request =
                 |> executeTextileQuery db Simulator.encode
 
         Just (Route.TextilePostSimulatorDetailed (Err error)) ->
-            Encode.string error
+            encodeStringError error
                 |> respondWith 400
 
         Just (Route.TextilePostSimulatorSingle (Ok textileQuery) trigram) ->
@@ -304,7 +304,7 @@ handleRequest db request =
                 |> executeTextileQuery db (toSingleImpactSimple trigram)
 
         Just (Route.TextilePostSimulatorSingle (Err error) _) ->
-            Encode.string error
+            encodeStringError error
                 |> respondWith 400
 
         Nothing ->

--- a/tests/Data/Food/QueryTest.elm
+++ b/tests/Data/Food/QueryTest.elm
@@ -1,0 +1,29 @@
+module Data.Food.QueryTest exposing (..)
+
+import Data.Food.Query as Query
+import Expect
+import Json.Decode as Decode
+import Test exposing (..)
+import TestUtils exposing (asTest)
+
+
+suite : Test
+suite =
+    describe "Data.Food.Query"
+        [ "<invalid json>"
+            |> Decode.decodeString Query.decode
+            |> Expect.err
+            |> asTest "should fail on invalid JSON"
+        , """{"ingredients": [{"id":"mango","mass":500,"country":"BR"}],"transform":null,"packaging":[],"distribution":"ambient","preparation":[]}"""
+            |> Decode.decodeString Query.decode
+            |> Expect.ok
+            |> asTest "should decode a null transform"
+        , """{"ingredients": [{"id":"mango","mass":500,"country":"BR"}],"packaging":[],"distribution":"ambient","preparation":[]}"""
+            |> Decode.decodeString Query.decode
+            |> Expect.ok
+            |> asTest "should decode a missing transform"
+        , """{"ingredients": [{"id":"mango","mass":500,"country":"BR"}],"packaging":[],"distribution":"invalid","preparation":[]}"""
+            |> Decode.decodeString Query.decode
+            |> Expect.err
+            |> asTest "should fail an invalid distribution"
+        ]


### PR DESCRIPTION
## :wrench: Problem

Nullable fields weren't nullable anymore when parsing JSON queries in the Food API. See [card](https://www.notion.so/Erreur-API-sur-exemple-de-la-Mangue-fd77338b263b44728b9b5df95bed0373).

## :cake: Solution

This patch uses a more flexible utilitity from `Decode.Extra` to relax nullable value check. It also ensures always responding with errors encoded as JSON, for consistency.

## :desert_island: How to test

Unit tests have been added so we're probably safe here, but toying around with the API manually might be a good idea.

### Production

```bash
$ curl 'https://ecobalyse.beta.gouv.fr/api/food' \
  -H "accept: application/json" \
  -H "content-type: application/json" \
  -d '{"ingredients": [{"id": "milk","mass": 500,"country": "BR"}],"transform": null,"packaging": [],"distribution": "ambient","preparation":[]}'
Problem with the value at json.transform:

    null

Expecting an OBJECT with a field named `code`
```

### Patch version

A `null` transform is now accepted:

```bash
$ curl 'http://localhost:1234/api/food' \
  -H "accept: application/json" \
  -H "content-type: application/json" \
  -d '{"ingredients": [{"id": "milk","mass": 500,"country": "BR"}],"transform": null,"packaging": [],"distribution": "ambient","preparation":[]}'
{"webUrl":"https://ecobalyse.beta.gouv.fr/#/food/ecs/eyJpbmdyZWRpZW50cyI6W3siaWQiOiJtaWxrIiwibWFzcyI6NTAwLCJjb3VudHJ5IjoiQlIifV0sImRpc3RyaWJ1dGlvbiI6ImFtYmllbnQifQ==","results":{"total":{"acd":0,"cch":0,"etf":0,"etf-c":0,"fru":0,"fwe":0,"htc":0,"htc-c":0,"htn":0,"htn-c":0,"ior":0,"ldu":0,"mru":0,"ozd":0,"pco":0,"pma":0,"swe":0,"tre":0,"wtu":0,"ecs":88.24043055316605,"pef":78.16321668566478},"perKg":{"acd":0,"cch":0,"etf":0,"etf-c":0,"fru":0,"fwe":0,"htc":0,"htc-c":0,"htn":0,"htn-c":0,"ior":0,"ldu":0,"mru":0,"ozd":0,"pco":0,"pma":0,"swe":0,"tre":0,"wtu":0,"ecs":176.4808611063321,"pef":156.32643337132956},"scoring":{"all":176.4808611063321,"climate":0,"biodiversity":0,"health":0,"resources":0},"totalMass":0.5,"preparedMass":0.5,"recipe":{"total":{"acd":0,"cch":0,"etf":0,"etf-c":0,"fru":0,"fwe":0,"htc":0,"htc-c":0,"htn":0,"htn-c":0,"ior":0,"ldu":0,"mru":0,"ozd":0,"pco":0,"pma":0,"swe":0,"tre":0,"wtu":0,"ecs":79.83329037441166,"pef":69.32826980137915},"ingredientsTotal":{"acd":0,"cch":0,"etf":0,"etf-c":0,"fru":0,"fwe":0,"htc":0,"htc-c":0,"htn":0,"htn-c":0,"ior":0,"ldu":0,"mru":0,"ozd":0,"pco":0,"pma":0,"swe":0,"tre":0,"wtu":0,"ecs":62.11529284239579,"pef":50.43721172589145},"totalBonusImpact":{"cropDiversity":0,"hedges":-1.005370395,"livestockDensity":0.255,"microfibers":0,"outOfEuropeEOL":0,"permanentPasture":-0.6124999999999999,"plotSize":-1.26399895},"transform":{"acd":0,"cch":0,"etf":0,"etf-c":0,"fru":0,"fwe":0,"htc":0,"htc-c":0,"htn":0,"htn-c":0,"ior":0,"ldu":0,"mru":0,"ozd":0,"pco":0,"pma":0,"swe":0,"tre":0,"wtu":0,"ecs":0,"pef":0},"transports":{"air":0,"impacts":{"acd":0,"cch":0,"etf":0,"etf-c":0,"fru":0,"fwe":0,"htc":0,"htc-c":0,"htn":0,"htn-c":0,"ior":0,"ldu":0,"mru":0,"ozd":0,"pco":0,"pma":0,"swe":0,"tre":0,"wtu":0,"ecs":17.717997532015875,"pef":18.891058075487692},"road":0,"roadCooled":660,"sea":0,"seaCooled":8315}},"packaging":{"acd":0,"cch":0,"etf":0,"etf-c":0,"fru":0,"fwe":0,"htc":0,"htc-c":0,"htn":0,"htn-c":0,"ior":0,"ldu":0,"mru":0,"ozd":0,"pco":0,"pma":0,"swe":0,"tre":0,"wtu":0,"ecs":0,"pef":0},"preparation":{"acd":0,"cch":0,"etf":0,"etf-c":0,"fru":0,"fwe":0,"htc":0,"htc-c":0,"htn":0,"htn-c":0,"ior":0,"ldu":0,"mru":0,"ozd":0,"pco":0,"pma":0,"swe":0,"tre":0,"wtu":0,"ecs":0,"pef":0},"transports":{"air":0,"impacts":{"acd":0,"cch":0,"etf":0,"etf-c":0,"fru":0,"fwe":0,"htc":0,"htc-c":0,"htn":0,"htn-c":0,"ior":0,"ldu":0,"mru":0,"ozd":0,"pco":0,"pma":0,"swe":0,"tre":0,"wtu":0,"ecs":24.456621136766252,"pef":25.682404001519505},"road":0,"roadCooled":1260,"sea":0,"seaCooled":8315},"distribution":{"total":{"acd":0,"cch":0,"etf":0,"etf-c":0,"fru":0,"fwe":0,"htc":0,"htc-c":0,"htn":0,"htn-c":0,"ior":0,"ldu":0,"mru":0,"ozd":0,"pco":0,"pma":0,"swe":0,"tre":0,"wtu":0,"ecs":1.6685165740040186,"pef":2.043600958253823},"transports":{"air":0,"impacts":{"acd":0,"cch":0,"etf":0,"etf-c":0,"fru":0,"fwe":0,"htc":0,"htc-c":0,"htn":0,"htn-c":0,"ior":0,"ldu":0,"mru":0,"ozd":0,"pco":0,"pma":0,"swe":0,"tre":0,"wtu":0,"ecs":6.738623604750378,"pef":6.791345926031812},"road":0,"roadCooled":600,"sea":0,"seaCooled":0}}},"description":"TODO","query":{"ingredients":[{"id":"milk","mass":500,"country":"BR"}],"distribution":"ambient"}}
```

Decoding errors are now wrapped in JSON:

```bash
$ curl 'http://localhost:1234/api/food' \
  -H "accept: application/json" \
  -d '{"ingredients": [{"id": "milk","mass": 500,"country": "BR"}],"transform": null,"packaging": [],"distribution": "ambient","preparation":[]}'
{"error":["Problem with the given value:","","{}","","Expecting an OBJECT with a field named `ingredients`"],"documentation":"https://ecobalyse.beta.gouv.fr/#/api"}
```