### PR TITLE
ci: use builtin python action cache for pipenv

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -33,6 +33,7 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pipenv'
 
     - name: Cache node_modules
       id: cache-node_modules
@@ -48,12 +49,6 @@ jobs:
         path: ~/.elm
         key: elm-cache-${{ hashFiles('elm.json') }}
         restore-keys: elm-cache-
-
-    - name: Cache pipenv virtualenv
-      uses: actions/cache@v4
-      with:
-        path: ~/.local/share/virtualenvs
-        key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-pipenv-${{ hashFiles('Pipfile.lock') }}
 
     - name: Install Node dependencies
       run: npm ci --prefer-offline --no-audit

--- a/.github/workflows/score_history.yml
+++ b/.github/workflows/score_history.yml
@@ -37,6 +37,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pipenv'
+
 
       - name: Cache node_modules
         id: cache-node_modules
@@ -52,14 +54,6 @@ jobs:
           path: ~/.elm
           key: elm-cache-${{ hashFiles('elm.json') }}
           restore-keys: elm-cache-
-
-      - name: Cache pipenv virtualenv
-        uses: actions/cache@v4
-        with:
-          path: ~/.local/share/virtualenvs
-          key: ${{ runner.os }}-${{ matrix.python-version }}-pipenv-${{ hashFiles('Pipfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-pipenv-
 
       - name: Install Node dependencies
         run: npm ci --prefer-offline --no-audit


### PR DESCRIPTION
## :wrench: Problem

Python builds in Github actions seem to [fail randomly on Github Actions](https://github.com/MTES-MCT/ecobalyse/actions/runs/11256209104/job/31297541397).

![image](https://github.com/user-attachments/assets/d9e62f70-d724-440b-9c80-32dc5513639c)

## :cake: Solution

Try to use the now builtin [cache feature of the python github action](https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#caching-packages) to fix the problem.


## :desert_island: How to test

The CI should be green on this PR.
