### PR TITLE
fix: improve object simulator.

### DIFF
--- a/public/data/object/examples.json
+++ b/public/data/object/examples.json
@@ -1,5 +1,13 @@
 [
   {
+    "id": "0d08a9ff-5683-4d3d-a7b8-dce74f37cd3b",
+    "name": "Produit vide",
+    "category": "",
+    "query": {
+      "processes": []
+    }
+  },
+  {
     "id": "7d78d30e-7c35-451f-b8ab-e590f39ed0e8",
     "name": "Chaise",
     "category": "",

--- a/public/data/object/processes.json
+++ b/public/data/object/processes.json
@@ -35,7 +35,6 @@
     "id": "3295b2a5-328a-4c00-b046-e2ddeb0da823",
     "name": "Plastic frame (PP)",
     "display_name": "Composant en plastique (PP)",
-    "density": 900,
     "unit": "kg",
     "impacts": {
       "acd": 0,

--- a/src/Data/Bookmark.elm
+++ b/src/Data/Bookmark.elm
@@ -163,7 +163,8 @@ toQueryDescription db bookmark =
 
         Object objectQuery ->
             objectQuery
-                |> ObjectQuery.toString
+                |> ObjectQuery.toString db.object.processes
+                |> Result.withDefault "N/A"
 
         Textile textileQuery ->
             textileQuery

--- a/src/Data/Object/Process.elm
+++ b/src/Data/Object/Process.elm
@@ -6,7 +6,6 @@ module Data.Object.Process exposing
     , encode
     , encodeId
     , findById
-    , idToString
     )
 
 import Data.Impact as Impact exposing (Impacts)

--- a/src/Data/Object/Process.elm
+++ b/src/Data/Object/Process.elm
@@ -35,7 +35,7 @@ decodeProcess : Decoder Impact.Impacts -> Decoder Process
 decodeProcess impactsDecoder =
     Decode.succeed Process
         |> Pipe.required "comment" Decode.string
-        |> Pipe.required "density" Decode.float
+        |> Pipe.optional "density" Decode.float 1
         |> Pipe.required "display_name" Decode.string
         |> Pipe.required "id" decodeId
         |> Pipe.required "impacts" impactsDecoder

--- a/src/Data/Object/Query.elm
+++ b/src/Data/Object/Query.elm
@@ -20,6 +20,7 @@ import Base64
 import Data.Object.Process as Process exposing (Process)
 import Json.Decode as Decode exposing (Decoder)
 import Json.Encode as Encode
+import Result.Extra as RE
 import Url.Parser as Parser exposing (Parser)
 
 
@@ -120,21 +121,23 @@ updateItem newItem query =
     }
 
 
-toString : Query -> String
-toString query =
-    query.items
-        |> List.map
-            (\i ->
-                (i.amount
-                    |> amountToFloat
-                    |> String.fromFloat
-                )
-                    ++ " "
-                    ++ (i.processId
-                            |> Process.idToString
-                       )
+toString : List Process -> Query -> Result String String
+toString processes =
+    .items
+        >> List.map
+            (\item ->
+                item.processId
+                    |> Process.findById processes
+                    |> Result.map
+                        (\process ->
+                            String.fromFloat (amountToFloat item.amount)
+                                ++ process.unit
+                                ++ " "
+                                ++ process.displayName
+                        )
             )
-        |> String.join " - "
+        >> RE.combine
+        >> Result.map (String.join ", ")
 
 
 

--- a/src/Data/Object/Simulator.elm
+++ b/src/Data/Object/Simulator.elm
@@ -2,9 +2,9 @@ module Data.Object.Simulator exposing
     ( Results(..)
     , availableProcesses
     , compute
-    , computeItemResults
     , emptyResults
     , extractImpacts
+    , extractItems
     , extractMass
     )
 
@@ -41,7 +41,7 @@ compute db query =
         |> List.map (computeItemResults db)
         |> RE.combine
         |> Result.map
-            (List.foldl
+            (List.foldr
                 (\(Results { impacts, mass }) (Results acc) ->
                     Results
                         { acc
@@ -89,6 +89,11 @@ emptyResults =
 extractImpacts : Results -> Impacts
 extractImpacts (Results { impacts }) =
     impacts
+
+
+extractItems : Results -> List Results
+extractItems (Results { items }) =
+    items
 
 
 extractMass : Results -> Mass

--- a/src/Data/Object/Simulator.elm
+++ b/src/Data/Object/Simulator.elm
@@ -7,9 +7,11 @@ module Data.Object.Simulator exposing
     , extractImpacts
     , extractItems
     , extractMass
+    , toStepsImpacts
     )
 
-import Data.Impact as Impact exposing (Impacts)
+import Data.Impact as Impact exposing (Impacts, noStepsImpacts)
+import Data.Impact.Definition as Definition
 import Data.Object.Process as Process exposing (Process)
 import Data.Object.Query as Query exposing (Item, Query)
 import Mass exposing (Mass)
@@ -108,3 +110,14 @@ extractItems (Results { items }) =
 extractMass : Results -> Mass
 extractMass (Results { mass }) =
     mass
+
+
+toStepsImpacts : Definition.Trigram -> Results -> Impact.StepsImpacts
+toStepsImpacts trigram results =
+    { noStepsImpacts
+      -- FIXME: for now, as we only have materials, assign everything to the material step
+        | materials =
+            extractImpacts results
+                |> Impact.getImpact trigram
+                |> Just
+    }

--- a/src/Data/Object/Simulator.elm
+++ b/src/Data/Object/Simulator.elm
@@ -3,6 +3,7 @@ module Data.Object.Simulator exposing
     , availableProcesses
     , compute
     , emptyResults
+    , expandItems
     , extractImpacts
     , extractItems
     , extractMass
@@ -84,6 +85,14 @@ emptyResults =
         , items = []
         , mass = Quantity.zero
         }
+
+
+expandItems : Db -> Query -> Result String (List ( Query.Amount, Process ))
+expandItems db =
+    .items
+        >> List.map (\{ amount, processId } -> ( amount, processId ))
+        >> List.map (RE.combineMapSecond (Process.findById db.object.processes))
+        >> RE.combine
 
 
 extractImpacts : Results -> Impacts

--- a/src/Data/Object/Simulator.elm
+++ b/src/Data/Object/Simulator.elm
@@ -2,7 +2,7 @@ module Data.Object.Simulator exposing
     ( Results(..)
     , availableProcesses
     , compute
-    , computeItemImpacts
+    , computeItemResults
     , emptyResults
     , extractImpacts
     , extractMass
@@ -38,7 +38,7 @@ availableProcesses { object } query =
 compute : Db -> Query -> Result String Results
 compute db query =
     query.items
-        |> List.map (computeItemImpacts db)
+        |> List.map (computeItemResults db)
         |> RE.combine
         |> Result.map
             (List.foldl
@@ -54,8 +54,8 @@ compute db query =
             )
 
 
-computeItemImpacts : Db -> Item -> Result String Results
-computeItemImpacts { object } { amount, processId } =
+computeItemResults : Db -> Item -> Result String Results
+computeItemResults { object } { amount, processId } =
     processId
         |> Process.findById object.processes
         |> Result.map

--- a/src/Page/Object.elm
+++ b/src/Page/Object.elm
@@ -27,7 +27,6 @@ import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (..)
 import Ports
-import Result.Extra as RE
 import Route
 import Static.Db exposing (Db)
 import Task
@@ -458,19 +457,23 @@ itemListView db selectedImpact results query =
         [ h2 [ class "h5 mb-0" ] [ text "Éléments" ] ]
     , div [ class "table-responsive" ]
         [ table [ class "table mb-0" ]
-            [ tbody []
+            [ thead []
+                [ tr [ class "fs-7 text-muted" ]
+                    [ th [] [ text "Quantité" ]
+                    , th [] [ text "Procédé" ]
+                    , th [] [ text "Masse" ]
+                    , th [] [ text "Impact" ]
+                    , th [] []
+                    ]
+                ]
+            , tbody []
                 (if List.isEmpty query.items then
                     [ tr [] [ td [] [ text "Aucun élément." ] ] ]
 
                  else
-                    case
-                        query.items
-                            |> List.map (\{ amount, processId } -> ( amount, processId ))
-                            |> List.map (RE.combineMapSecond (Process.findById db.object.processes))
-                            |> RE.combine
-                    of
+                    case Simulator.expandItems db query of
                         Err error ->
-                            [ tr [] [ td [] [ text error ] ] ]
+                            [ tr [] [ td [ class "text-danger" ] [ text "Error: ", text error ] ] ]
 
                         Ok items ->
                             Simulator.extractItems results
@@ -485,7 +488,7 @@ itemListView db selectedImpact results query =
 itemView : Definition -> ( Query.Amount, Process ) -> Results -> Html Msg
 itemView selectedImpact ( amount, process ) itemResults =
     tr []
-        [ td [ class "input-group", style "width" "200px" ]
+        [ td [ class "input-group text-nowrap", style "min-width" "180px" ]
             [ input
                 [ type_ "number"
                 , class "form-control text-end"
@@ -510,7 +513,8 @@ itemView selectedImpact ( amount, process ) itemResults =
                                 NoOp
                 ]
                 []
-            , span [ class "input-group-text" ] [ text process.unit ]
+            , span [ class "input-group-text justify-content-center fs-8", style "width" "38px" ]
+                [ text process.unit ]
             ]
         , td [ class "align-middle text-truncate w-100" ]
             [ text process.displayName ]

--- a/src/Page/Object.elm
+++ b/src/Page/Object.elm
@@ -387,9 +387,13 @@ simulatorView session model =
 
                 -- Score
                 , customScoreInfo = Nothing
-                , productMass = Quantity.zero
+                , productMass =
+                    Simulator.compute session.db session.queries.object
+                        |> Result.map Simulator.extractMass
+                        |> Result.withDefault Quantity.zero
                 , totalImpacts =
                     Simulator.compute session.db session.queries.object
+                        |> Result.map Simulator.extractImpacts
                         |> Result.withDefault Impact.empty
 
                 -- Impacts tabs
@@ -398,7 +402,7 @@ simulatorView session model =
                         |> ImpactTabs.createConfig session model.impact model.activeImpactsTab (always NoOp)
                         |> ImpactTabs.forObject
                             (Simulator.compute session.db session.queries.object
-                                |> Result.withDefault Impact.empty
+                                |> Result.withDefault Simulator.emptyResults
                             )
                         |> Just
 
@@ -518,7 +522,7 @@ itemImpactView : Db -> Definition -> Query.Item -> Html Msg
 itemImpactView db selectedImpact item =
     item
         |> Simulator.computeItemImpacts db
-        |> Result.map (Format.formatImpact selectedImpact)
+        |> Result.map (Simulator.extractImpacts >> Format.formatImpact selectedImpact)
         |> Result.withDefault (text "N/A")
 
 

--- a/src/Page/Object.elm
+++ b/src/Page/Object.elm
@@ -469,8 +469,10 @@ itemListView db selectedImpact query =
                     [ text error ]
 
                 Ok items ->
-                    List.map (itemView db selectedImpact) items ++ [ addItemButton db query ]
+                    items
+                        |> List.map (itemView db selectedImpact)
         )
+    , addItemButton db query
     ]
 
 

--- a/src/Page/Object.elm
+++ b/src/Page/Object.elm
@@ -171,7 +171,8 @@ suggestBookmarkName { db, store } query =
             name
 
         _ ->
-            Query.toString query
+            Query.toString db.object.processes query
+                |> Result.withDefault "N/A"
 
 
 updateQuery : Query -> ( Model, Session, Cmd Msg ) -> ( Model, Session, Cmd Msg )

--- a/src/Page/Object.elm
+++ b/src/Page/Object.elm
@@ -177,7 +177,7 @@ suggestBookmarkName { db, store } query =
 
 updateQuery : Query -> ( Model, Session, Cmd Msg ) -> ( Model, Session, Cmd Msg )
 updateQuery query ( model, session, commands ) =
-    ( { model | initialQuery = query }
+    ( { model | initialQuery = query, bookmarkName = query |> suggestBookmarkName session }
     , session |> Session.updateObjectQuery query
     , commands
     )
@@ -346,12 +346,7 @@ selectExample autocompleteState ( model, session, _ ) =
             Autocomplete.selectedValue autocompleteState
                 |> Maybe.withDefault Query.default
     in
-    update session
-        (SetModal NoModal)
-        { model
-            | initialQuery = exampleQuery
-            , bookmarkName = exampleQuery |> suggestBookmarkName session
-        }
+    update session (SetModal NoModal) { model | initialQuery = exampleQuery }
         |> updateQuery exampleQuery
 
 

--- a/src/Page/Object.elm
+++ b/src/Page/Object.elm
@@ -461,6 +461,7 @@ itemListView db selectedImpact results query =
                 [ tr [ class "fs-7 text-muted" ]
                     [ th [] [ text "Quantité" ]
                     , th [] [ text "Procédé" ]
+                    , th [] [ text "Densité" ]
                     , th [] [ text "Masse" ]
                     , th [] [ text "Impact" ]
                     , th [] []
@@ -518,6 +519,13 @@ itemView selectedImpact ( amount, process ) itemResults =
             ]
         , td [ class "align-middle text-truncate w-100" ]
             [ text process.displayName ]
+        , td [ class "align-middle text-end" ]
+            [ if process.unit /= "kg" then
+                process.density |> Format.formatRichFloat 0 ("kg/" ++ process.unit)
+
+              else
+                text ""
+            ]
         , td [ class "text-end align-middle text-nowrap" ]
             [ Format.kg <| Simulator.extractMass itemResults ]
         , td [ class "text-end align-middle text-nowrap" ]

--- a/src/Views/Comparator.elm
+++ b/src/Views/Comparator.elm
@@ -126,12 +126,14 @@ addToComparison session label query =
             objectQuery
                 |> ObjectSimulator.compute session.db
                 |> Result.map
-                    (\impacts ->
-                        { complementsImpact = Impact.noComplementsImpacts
-                        , impacts = impacts
-                        , label = label
-                        , stepsImpacts = Impact.noStepsImpacts
-                        }
+                    (ObjectSimulator.extractImpacts
+                        >> (\impacts ->
+                                { complementsImpact = Impact.noComplementsImpacts
+                                , impacts = impacts
+                                , label = label
+                                , stepsImpacts = Impact.noStepsImpacts
+                                }
+                           )
                     )
 
         Bookmark.Textile textileQuery ->

--- a/src/Views/Comparator.elm
+++ b/src/Views/Comparator.elm
@@ -126,14 +126,14 @@ addToComparison session label query =
             objectQuery
                 |> ObjectSimulator.compute session.db
                 |> Result.map
-                    (ObjectSimulator.extractImpacts
-                        >> (\impacts ->
-                                { complementsImpact = Impact.noComplementsImpacts
-                                , impacts = impacts
-                                , label = label
-                                , stepsImpacts = Impact.noStepsImpacts
-                                }
-                           )
+                    (\results ->
+                        { complementsImpact = Impact.noComplementsImpacts
+                        , impacts = ObjectSimulator.extractImpacts results
+                        , label = label
+                        , stepsImpacts =
+                            results
+                                |> ObjectSimulator.toStepsImpacts Definition.Ecs
+                        }
                     )
 
         Bookmark.Textile textileQuery ->

--- a/src/Views/ImpactTabs.elm
+++ b/src/Views/ImpactTabs.elm
@@ -3,6 +3,7 @@ module Views.ImpactTabs exposing
     , Tab(..)
     , createConfig
     , forFood
+    , forObject
     , forTextile
     , view
     )
@@ -185,6 +186,24 @@ forFood results config =
         , scoring = results.scoring
         , stepsImpacts = Recipe.toStepsImpacts config.impactDefinition.trigram results
         , total = results.total
+    }
+
+
+forObject : Impacts -> Config msg -> Config msg
+forObject impacts config =
+    { config
+        | stepsImpacts =
+            { distribution = Nothing
+            , endOfLife = Nothing
+            , materials =
+                impacts
+                    |> Impact.getImpact config.impactDefinition.trigram
+                    |> Just
+            , packaging = Nothing
+            , transform = Nothing
+            , transports = Nothing
+            , usage = Nothing
+            }
     }
 
 

--- a/src/Views/ImpactTabs.elm
+++ b/src/Views/ImpactTabs.elm
@@ -11,9 +11,10 @@ module Views.ImpactTabs exposing
 import Data.Food.Recipe as Recipe
 import Data.Impact as Impact exposing (Impacts)
 import Data.Impact.Definition as Definition exposing (Definition, Definitions)
+import Data.Object.Simulator as ObjectSimulator
 import Data.Scoring as Scoring exposing (Scoring)
 import Data.Session as Session exposing (Session)
-import Data.Textile.Simulator as Simulator exposing (Simulator)
+import Data.Textile.Simulator as TextileSimulator exposing (Simulator)
 import Data.Unit as Unit
 import Html exposing (..)
 import Html.Attributes exposing (..)
@@ -189,14 +190,14 @@ forFood results config =
     }
 
 
-forObject : Impacts -> Config msg -> Config msg
-forObject impacts config =
+forObject : ObjectSimulator.Results -> Config msg -> Config msg
+forObject results config =
     { config
         | stepsImpacts =
             { distribution = Nothing
             , endOfLife = Nothing
             , materials =
-                impacts
+                ObjectSimulator.extractImpacts results
                     |> Impact.getImpact config.impactDefinition.trigram
                     |> Just
             , packaging = Nothing
@@ -211,7 +212,7 @@ forTextile : Definitions -> Simulator -> Config msg -> Config msg
 forTextile definitions simulator config =
     let
         totalImpactsWithoutComplements =
-            Simulator.getTotalImpactsWithoutComplements simulator
+            TextileSimulator.getTotalImpactsWithoutComplements simulator
     in
     { config
         | complementsImpact = simulator.complementsImpacts
@@ -220,6 +221,6 @@ forTextile definitions simulator config =
                 |> Scoring.compute definitions (Impact.getTotalComplementsImpacts simulator.complementsImpacts)
         , stepsImpacts =
             simulator
-                |> Simulator.toStepsImpacts config.impactDefinition.trigram
+                |> TextileSimulator.toStepsImpacts config.impactDefinition.trigram
         , total = totalImpactsWithoutComplements
     }

--- a/tests/Data/Object/SimulatorTest.elm
+++ b/tests/Data/Object/SimulatorTest.elm
@@ -15,7 +15,10 @@ import TestUtils exposing (asTest, suiteWithDb)
 getEcsImpact : Db -> Query -> Result String Float
 getEcsImpact db =
     Simulator.compute db
-        >> Result.map (Impact.getImpact Definition.Ecs >> Unit.impactToFloat)
+        >> Result.map
+            (Simulator.extractImpacts
+                >> (Impact.getImpact Definition.Ecs >> Unit.impactToFloat)
+            )
 
 
 suite : Test


### PR DESCRIPTION
## :wrench: Problems

- The simulator doesn't show masses (total and per-item)
- The "add item" button is missing when the product items list is empty.
- When selecting an existing example or bookmark, we'd like to fill its name in the new bookmark text input. 
- We'd also like a more meaningful query string representation than what we currently have.
- We want to render the steps impact distribution chart in the sidebar.

## :cake: Solution

Implement aforementioned tasks.

## :desert_island: How to test

- Check that the simulator renders total and per-item masses
- Check that we always have an "add item" button rendered.
- Check that an existing bookmark or example name is filled in the bookmark input text.
- Check that suggested bookmark names are more convenient than what we have now.
- Check that the step impacts distribution chart is rendered properly.
