### PR TITLE
fix: create object encrypted file for versions

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -86,6 +86,7 @@ jobs:
           # files it was using on production
           npm run encrypt $ECOBALYSE_DATA_DIR/data/textile/processes_impacts.json dist/processes_impacts_textile.json.enc
           npm run encrypt $ECOBALYSE_DATA_DIR/data/food/processes_impacts.json dist/processes_impacts_food.json.enc
+          npm run encrypt $ECOBALYSE_DATA_DIR/data/object/processes_impacts.json dist/processes_impacts_object.json.enc
 
       - name: Generate dist archive
         if: steps.tag_creation.outputs.tag_created

--- a/bin/build-specific-app-version.sh
+++ b/bin/build-specific-app-version.sh
@@ -197,6 +197,7 @@ mkdir -p $VERSION_DIR
 
 npm run encrypt $PUBLIC_GIT_CLONE_DIR/public/data/textile/processes_impacts.json $PUBLIC_GIT_CLONE_DIR/dist/processes_impacts_textile.json.enc
 npm run encrypt $PUBLIC_GIT_CLONE_DIR/public/data/food/processes_impacts.json $PUBLIC_GIT_CLONE_DIR/dist/processes_impacts_food.json.enc
+npm run encrypt $PUBLIC_GIT_CLONE_DIR/public/data/object/processes_impacts.json $PUBLIC_GIT_CLONE_DIR/dist/processes_impacts_object.json.enc
 
 # Never ship detailed impacts
 rm -f -- $PUBLIC_GIT_CLONE_DIR/data/textile/processes_impacts.json


### PR DESCRIPTION
## :wrench: Problem

We have an error in production when logged-in and going from old version back to the `2.4.0` in the selector.

![image](https://github.com/user-attachments/assets/a63e8c10-f2a6-4905-a700-7cfcc630ade3)


## :cake: Solution

Add the encrypted file for objects when creating the version.


## :rotating_light:  Points to watch/comments

I’ve modified the already published version by adding the encrypted `processes_impacts_object.json.enc` manually and redeployed the production, so it should be working now. We don't need to land this patch ASAP, it can wait for the next release.

## :desert_island: How to test

We will only be able to test it in the next release.