### PR TITLE
feat: add impacts per 100g for example objects.

### DIFF
--- a/src/Page/Explore.elm
+++ b/src/Page/Explore.elm
@@ -656,14 +656,12 @@ getObjectScore db =
 getObjectScorePer100g : Db -> Example ObjectQuery.Query -> Float
 getObjectScorePer100g db { query } =
     query
-        |> Debug.log "query"
         |> ObjectSimulator.compute db
         |> Result.map
             (\(ObjectSimulator.Results { impacts, mass }) ->
                 impacts
                     |> Impact.per100grams mass
                     |> Impact.getImpact Definition.Ecs
-                    |> Debug.log "ecs"
                     |> Unit.impactToFloat
             )
         |> Result.withDefault 0

--- a/src/Page/Explore/ObjectExamples.elm
+++ b/src/Page/Explore/ObjectExamples.elm
@@ -14,10 +14,10 @@ import Views.Icon as Icon
 
 
 table :
-    { maxScore : Float }
+    { maxScore : Float, maxPer100g : Float }
     -> { detailed : Bool, scope : Scope }
-    -> Table ( Example Query, { score : Float } ) String msg
-table { maxScore } { detailed, scope } =
+    -> Table ( Example Query, { score : Float, per100g : Float } ) String msg
+table { maxScore, maxPer100g } { detailed, scope } =
     { filename = "examples"
     , toId = Tuple.first >> .id >> Uuid.toString
     , toRoute = Tuple.first >> .id >> Just >> Dataset.ObjectExamples >> Route.Explore scope
@@ -36,6 +36,12 @@ table { maxScore } { detailed, scope } =
           , toCell =
                 \( _, { score } ) ->
                     Common.impactBarGraph detailed maxScore score
+          }
+        , { label = "Coût Environnemental/100g"
+          , toValue = Table.FloatValue (Tuple.second >> .per100g)
+          , toCell =
+                \( _, { per100g } ) ->
+                    Common.impactBarGraph detailed maxPer100g per100g
           }
         , { label = ""
           , toValue = Table.NoValue


### PR DESCRIPTION
## :wrench: Problem

Impacts per 100g, as we already have for Food and Textile, may be wanted for Objects in a near future.

## :cake: Solution

This patch implements just that.

## :rotating_light:  Points to watch/comments

[Discussion](https://mattermost.incubateur.net/fabnum-mte/pl/w6rpeucd67bemgee7jkfedofbe) is currently ongoing across POs to figure out if this is actually wanted or not.

## :desert_island: How to test

Check that the Object examples explorer page features impacts per 100g of product.