### PR TITLE
chore: add tolerance to tests comparison

### DIFF
--- a/tests/Data/Food/RecipeTest.elm
+++ b/tests/Data/Food/RecipeTest.elm
@@ -24,7 +24,7 @@ expectImpactEqual expectedImpactUnit =
             Unit.impactToFloat expectedImpactUnit
     in
     Unit.impactToFloat
-        >> Expect.within (Expect.Relative 0.000000000000001) expectedImpact
+        >> Expect.within (Expect.Relative 0.000000000001) expectedImpact
 
 
 suite : Test

--- a/tests/Data/Food/RecipeTest.elm
+++ b/tests/Data/Food/RecipeTest.elm
@@ -24,7 +24,7 @@ expectImpactEqual expectedImpactUnit =
             Unit.impactToFloat expectedImpactUnit
     in
     Unit.impactToFloat
-        >> Expect.within (Expect.Relative 0.0000000000000001) expectedImpact
+        >> Expect.within (Expect.Relative 0.000000000000001) expectedImpact
 
 
 suite : Test

--- a/tests/server.spec.js
+++ b/tests/server.spec.js
@@ -554,11 +554,11 @@ describe("API", () => {
 
           // Add tolerance check for impacts
           Object.entries(impacts).forEach(([key, value]) => {
-            expect(response.body.results.total[key]).toBeCloseTo(value, 6);
+            expect(response.body.results.total[key]).toBeCloseTo(value, 12);
           });
 
           Object.entries(scoring).forEach(([key, value]) => {
-            expect(response.body.results.scoring[key]).toBeCloseTo(value, 6);
+            expect(response.body.results.scoring[key]).toBeCloseTo(value, 12);
           });
         });
       }

--- a/tests/server.spec.js
+++ b/tests/server.spec.js
@@ -551,8 +551,15 @@ describe("API", () => {
             scoring: response.status === 200 ? response.body.results.scoring : {},
           });
           expectStatus(response, 200);
-          expect(response.body.results.total).toEqual(impacts);
-          expect(response.body.results.scoring).toEqual(scoring);
+
+          // Add tolerance check for impacts
+          Object.entries(impacts).forEach(([key, value]) => {
+            expect(response.body.results.total[key]).toBeCloseTo(value, 6);
+          });
+
+          Object.entries(scoring).forEach(([key, value]) => {
+            expect(response.body.results.scoring[key]).toBeCloseTo(value, 6);
+          });
         });
       }
     });


### PR DESCRIPTION
## :wrench: Problem

We have differences in results between local computer and server-ci. Maybe because of processor architecture (arm64 vs x86).
As a results tests are failing either in local or on server-ci
![image](https://github.com/user-attachments/assets/81b2c57d-a48b-43f8-a73c-30f75b5916a3)


## :cake: Solution

As a temporary fix, allow more tolerance in tests floating points comparison. Going from 1e-16 toleranc to 1e-12 seems reasonable and fix my tests.


## :desert_island: How to test
