### PR TITLE
feat: display score without durability

### DIFF
--- a/src/Data/Textile/Simulator.elm
+++ b/src/Data/Textile/Simulator.elm
@@ -3,6 +3,7 @@ module Data.Textile.Simulator exposing
     , compute
     , encode
     , getTotalImpactsWithoutComplements
+    , getTotalImpactsWithoutDurability
     , stepMaterialImpacts
     , toStepsImpacts
     )
@@ -10,7 +11,7 @@ module Data.Textile.Simulator exposing
 import Array
 import Data.Country as Country
 import Data.Env as Env
-import Data.Impact as Impact exposing (Impacts)
+import Data.Impact as Impact exposing (ComplementsImpacts, Impacts)
 import Data.Impact.Definition as Definition
 import Data.Split as Split
 import Data.Textile.Economics as Economics
@@ -749,6 +750,19 @@ getTotalImpactsWithoutComplements { durability, lifeCycle } =
         |> Array.toList
         |> Impact.sumImpacts
         |> Impact.divideBy (Unit.floatDurabilityFromHolistic durability)
+
+
+getTotalImpactsWithoutDurability : Simulator -> Impacts
+getTotalImpactsWithoutDurability { lifeCycle } =
+    let
+        complementsImpactsWithoutDurability =
+            lifeCycle
+                |> Array.filter .enabled
+                |> LifeCycle.sumComplementsImpacts
+    in
+    lifeCycle
+        |> LifeCycle.computeFinalImpacts
+        |> Impact.impactsWithComplements complementsImpactsWithoutDurability
 
 
 updateLifeCycle : (LifeCycle -> LifeCycle) -> Simulator -> Simulator

--- a/src/Data/Textile/Simulator.elm
+++ b/src/Data/Textile/Simulator.elm
@@ -56,6 +56,7 @@ encode v =
         , ( "daysOfWear", v.daysOfWear |> Duration.inDays |> round |> Encode.int )
         , ( "durability", v.durability |> Unit.floatDurabilityFromHolistic |> Encode.float )
         , ( "impacts", Impact.encode v.impacts )
+        , ( "impactsWithoutDurability", Impact.encode (getTotalImpactsWithoutDurability v.lifeCycle) )
         , ( "inputs", Inputs.encode v.inputs )
         , ( "lifeCycle", LifeCycle.encode v.lifeCycle )
         , ( "transport", Transport.encode v.transport )
@@ -752,8 +753,8 @@ getTotalImpactsWithoutComplements { durability, lifeCycle } =
         |> Impact.divideBy (Unit.floatDurabilityFromHolistic durability)
 
 
-getTotalImpactsWithoutDurability : Simulator -> Impacts
-getTotalImpactsWithoutDurability { lifeCycle } =
+getTotalImpactsWithoutDurability : LifeCycle -> Impacts
+getTotalImpactsWithoutDurability lifeCycle =
     let
         complementsImpactsWithoutDurability =
             lifeCycle

--- a/src/Data/Textile/Simulator.elm
+++ b/src/Data/Textile/Simulator.elm
@@ -11,7 +11,7 @@ module Data.Textile.Simulator exposing
 import Array
 import Data.Country as Country
 import Data.Env as Env
-import Data.Impact as Impact exposing (ComplementsImpacts, Impacts)
+import Data.Impact as Impact exposing (Impacts)
 import Data.Impact.Definition as Definition
 import Data.Split as Split
 import Data.Textile.Economics as Economics

--- a/src/Page/Api.elm
+++ b/src/Page/Api.elm
@@ -55,7 +55,12 @@ getApiServerUrl { clientUrl } =
 
 changelog : List News
 changelog =
-    [ { date = "5 septembre 2024"
+    [ { date = "29 octobre 2024"
+      , level = "minor"
+      , domains = [ "Textile" ]
+      , md = "Ajout du champ `impactsWithoutDurability` dans la réponse des calculs détaillés. Ce champ a le même format que le champ `impacts` mais contient les scores avant application du coefficient de durabilité."
+      }
+    , { date = "5 septembre 2024"
       , level = "minor"
       , domains = [ "Textile" ]
       , md = "Ajout du champ `physicalDurability` qui permet de préciser la durabilité physique d'un vêtement."

--- a/src/Page/Food.elm
+++ b/src/Page/Food.elm
@@ -1407,6 +1407,7 @@ sidebarView session model results =
         , customScoreInfo = Nothing
         , productMass = results.preparedMass
         , totalImpacts = results.total
+        , totalImpactsWithoutDurability = Nothing
 
         -- Impacts tabs
         , impactTabsConfig =

--- a/src/Page/Object.elm
+++ b/src/Page/Object.elm
@@ -402,6 +402,7 @@ simulatorView session model =
                 , customScoreInfo = Nothing
                 , productMass = Simulator.extractMass model.results
                 , totalImpacts = Simulator.extractImpacts model.results
+                , totalImpactsWithoutDurability = Nothing
 
                 -- Impacts tabs
                 , impactTabsConfig =

--- a/src/Page/Textile.elm
+++ b/src/Page/Textile.elm
@@ -1121,6 +1121,7 @@ simulatorView session model ({ inputs, impacts } as simulator) =
                         )
                 , productMass = inputs.mass
                 , totalImpacts = impacts
+                , totalImpactsWithoutDurability = Just <| Simulator.getTotalImpactsWithoutDurability simulator
 
                 -- Impacts tabs
                 , impactTabsConfig =

--- a/src/Page/Textile.elm
+++ b/src/Page/Textile.elm
@@ -1121,7 +1121,7 @@ simulatorView session model ({ inputs, impacts } as simulator) =
                         )
                 , productMass = inputs.mass
                 , totalImpacts = impacts
-                , totalImpactsWithoutDurability = Just <| Simulator.getTotalImpactsWithoutDurability simulator
+                , totalImpactsWithoutDurability = Just <| Simulator.getTotalImpactsWithoutDurability simulator.lifeCycle
 
                 -- Impacts tabs
                 , impactTabsConfig =

--- a/src/Views/Score.elm
+++ b/src/Views/Score.elm
@@ -13,14 +13,20 @@ type alias Config msg =
     , impactDefinition : Definition
     , mass : Mass
     , score : Impacts
+    , scoreWithoutDurability : Maybe Impacts
     }
 
 
 view : Config msg -> Html msg
-view { customInfo, impactDefinition, mass, score } =
+view { customInfo, impactDefinition, mass, score, scoreWithoutDurability } =
     div [ class "card bg-secondary shadow-sm" ]
         [ div [ class "card-body text-center text-nowrap text-white" ]
             [ div [ class "display-3 lh-1" ] [ Format.formatImpact impactDefinition score ]
+            , div []
+                [ scoreWithoutDurability
+                    |> Maybe.map (\s -> span [] [ Format.formatImpact impactDefinition s, text " hors durabilité" ])
+                    |> Maybe.withDefault (text "")
+                ]
             , small [] [ text "Pour ", Format.kg mass ]
             ]
         , case customInfo of

--- a/src/Views/Sidebar.elm
+++ b/src/Views/Sidebar.elm
@@ -30,6 +30,7 @@ type alias Config msg =
     , switchBookmarkTab : BookmarkView.ActiveTab -> msg
     , switchImpact : Result String Trigram -> msg
     , totalImpacts : Impacts
+    , totalImpactsWithoutDurability : Maybe Impacts
     , updateBookmarkName : String -> msg
     }
 
@@ -58,6 +59,7 @@ view config =
             , impactDefinition = config.selectedImpact
             , mass = config.productMass
             , score = config.totalImpacts
+            , scoreWithoutDurability = config.totalImpactsWithoutDurability
             }
         , case config.impactTabsConfig of
             Just impactTabsConfig ->

--- a/tests/server.spec.js
+++ b/tests/server.spec.js
@@ -320,6 +320,14 @@ describe("API", () => {
         expectStatus(response, 200);
         expect(response.body.lifeCycle).toHaveLength(8);
       });
+
+      it("should expose impacts without durability", async () => {
+        const response = await makeRequest("/api/textile/simulator/detailed", successQuery);
+
+        expectStatus(response, 200);
+        expect(response.body.impacts.ecs).toBeCloseTo(1619.93, 1);
+        expect(response.body.impactsWithoutDurability.ecs).toBeCloseTo(1085.35, 1);
+      });
     });
 
     describe("End to end textile simulations", () => {


### PR DESCRIPTION
## :wrench: Problem

Summing the scores of each step doesn't match the score displayed in the sidebar. Ineed, the main score displayed in the sidebar takes into account the durability (=totalImpacts score/durability) but the scores displayed for each step doesn't take into account the durability.

This is confusing.

[Notion card ](https://www.notion.so/Ajouter-le-score-hors-durabilit-ebd0fec910fa408491fec616923edca3)

## :cake: Solution

Display, below the actual score, the score without the durability taken into account.

## :desert_island: How to test

- Go on the textile tab
- Choose "T-shirt coton (150g) - Majorant par défaut"
- Check that 2 scores are displayed in the sidebar, "1 854 Pts" and "1 242 Pts hors durabilité"

![Screenshot 2024-10-28 at 11-33-50 Simulateur Ecobalyse](https://github.com/user-attachments/assets/7adf7668-087e-43bb-adee-2f619d8ec525)

- Check that 1242 is the sum of all the impacts scores of each step: 486+1.96+48.40+3.25+43.64+1.63+396+1.63+38.10+65.07+1.18+114+41.73=1242.59

![Screenshot 2024-10-28 at 11-34-01 Simulateur Ecobalyse](https://github.com/user-attachments/assets/1266e1f3-db54-41e7-b4ca-4f284bbbb723)

