### PR TITLE
feat: add components to objects

### DIFF
--- a/public/data/object/examples.json
+++ b/public/data/object/examples.json
@@ -1,11 +1,11 @@
 [
   {
     "id": "0d08a9ff-5683-4d3d-a7b8-dce74f37cd3b",
-    "name": "Objet par défaut",
+    "name": "Objet vide",
     "scope": "object",
     "category": "",
     "query": {
-      "items": [{ "name": "Composant par défaut", "processes": [], "quantity": 0 }]
+      "items": []
     }
   },
   {

--- a/public/data/object/examples.json
+++ b/public/data/object/examples.json
@@ -5,7 +5,7 @@
     "scope": "object",
     "category": "",
     "query": {
-      "processes": []
+      "items": [{ "name": "Composant par défaut", "processes": [], "quantity": 0 }]
     }
   },
   {
@@ -14,7 +14,7 @@
     "scope": "veli",
     "category": "",
     "query": {
-      "processes": []
+      "items": [{ "name": "Composant par défaut", "processes": [], "quantity": 0 }]
     }
   },
   {
@@ -23,14 +23,38 @@
     "scope": "object",
     "category": "",
     "query": {
-      "processes": [
+      "items": [
         {
-          "process_id": "07e9e916-e02b-45e2-a298-2b5084de6242",
-          "amount": 0.00088
+          "name": "Pied 70 cm (plein bois)",
+          "processes": [
+            {
+              "process_id": "07e9e916-e02b-45e2-a298-2b5084de6242",
+              "amount": 0.00022
+            }
+          ],
+          "quantity": 4
         },
         {
-          "process_id": "3295b2a5-328a-4c00-b046-e2ddeb0da823",
-          "amount": 1.645313
+          "name": "Dossier plastique (PP)",
+          "processes": [
+            {
+              "process_id": "3295b2a5-328a-4c00-b046-e2ddeb0da823",
+              "amount": 0.734063
+            }
+          ],
+
+          "quantity": 1
+        },
+        {
+          "name": "Assise plastique (PP)",
+          "processes": [
+            {
+              "process_id": "3295b2a5-328a-4c00-b046-e2ddeb0da823",
+              "amount": 0.91125
+            }
+          ],
+
+          "quantity": 1
         }
       ]
     }
@@ -41,10 +65,28 @@
     "scope": "object",
     "category": "",
     "query": {
-      "processes": [
+      "items": [
         {
-          "process_id": "07e9e916-e02b-45e2-a298-2b5084de6242",
-          "amount": 0.002
+          "name": "Pied 90 cm (plein bois)",
+          "processes": [
+            {
+              "process_id": "07e9e916-e02b-45e2-a298-2b5084de6242",
+              "amount": 0.007065
+            }
+          ],
+
+          "quantity": 4
+        },
+        {
+          "name": "Plateau 200x100 (chêne)",
+          "processes": [
+            {
+              "process_id": "07e9e916-e02b-45e2-a298-2b5084de6242",
+              "amount": 0.14
+            }
+          ],
+
+          "quantity": 1
         }
       ]
     }
@@ -55,10 +97,16 @@
     "scope": "veli",
     "category": "",
     "query": {
-      "processes": [
+      "items": [
         {
-          "process_id": "3295b2a5-328a-4c00-b046-e2ddeb0da823",
-          "amount": 35
+          "name": "Cadre plastique",
+          "processes": [
+            {
+              "process_id": "3295b2a5-328a-4c00-b046-e2ddeb0da823",
+              "amount": 35
+            }
+          ],
+          "quantity": 1
         }
       ]
     }

--- a/src/Data/Object/Query.elm
+++ b/src/Data/Object/Query.elm
@@ -12,9 +12,9 @@ module Data.Object.Query exposing
     , encode
     , parseBase64Query
     , quantityToInt
-    , removeItem
+      -- , removeItem
     , toString
-    , updateItem
+      -- , updateItem
     )
 
 import Base64
@@ -139,34 +139,36 @@ encodeProcessItem processItem =
         ]
 
 
-removeProcessItem : Process.Id -> List ProcessItem -> List ProcessItem
-removeProcessItem processId processes =
-    processes |> List.filter (.processId >> (/=) processId)
 
-
-removeItem : Process.Id -> Query -> Query
-removeItem processId query =
-    -- FIX: implement it for components
-    query
-
-
-updateItem : Item -> Query -> Query
-updateItem newItem query =
-    -- FIX: implement it for components
-    query
-
-
-updateProcessItem : ProcessItem -> List ProcessItem -> List ProcessItem
-updateProcessItem newItem processes =
-    processes
-        |> List.map
-            (\item ->
-                if item.processId == newItem.processId then
-                    newItem
-
-                else
-                    item
-            )
+-- FIX: implement it for components
+-- removeProcessItem : Process.Id -> List ProcessItem -> List ProcessItem
+-- removeProcessItem processId processes =
+--     processes |> List.filter (.processId >> (/=) processId)
+--
+--
+-- removeItem : Process.Id -> Query -> Query
+-- removeItem processId query =
+--     -- FIX: implement it for components
+--     query
+--
+--
+-- updateItem : Item -> Query -> Query
+-- updateItem newItem query =
+--     -- FIX: implement it for components
+--     query
+--
+--
+-- updateProcessItem : ProcessItem -> List ProcessItem -> List ProcessItem
+-- updateProcessItem newItem processes =
+--     processes
+--         |> List.map
+--             (\item ->
+--                 if item.processId == newItem.processId then
+--                     newItem
+--
+--                 else
+--                     item
+--             )
 
 
 toString : List Process -> Query -> Result String String

--- a/src/Data/Object/Query.elm
+++ b/src/Data/Object/Query.elm
@@ -20,6 +20,7 @@ import Base64
 import Data.Object.Process as Process exposing (Process)
 import Data.Scope as Scope exposing (Scope)
 import Json.Decode as Decode exposing (Decoder)
+import Json.Decode.Pipeline as Pipe
 import Json.Encode as Encode
 import Result.Extra as RE
 import Url.Parser as Parser exposing (Parser)
@@ -74,8 +75,8 @@ buildApiQuery scope clientUrl query =
 
 decode : Decoder Query
 decode =
-    Decode.map Query
-        (Decode.field "processes" (Decode.list decodeItem))
+    Decode.succeed Query
+        |> Pipe.required "items" (Decode.list decodeItem)
 
 
 decodeItem : Decoder Item

--- a/src/Data/Object/Query.elm
+++ b/src/Data/Object/Query.elm
@@ -118,7 +118,7 @@ defaultItem =
 encode : Query -> Encode.Value
 encode query =
     Encode.object
-        [ ( "processes"
+        [ ( "items"
           , Encode.list encodeItem query.items
           )
         ]
@@ -129,7 +129,7 @@ encodeItem item =
     Encode.object
         [ ( "name", item.name |> Encode.string )
         , ( "processes", item.processes |> Encode.list encodeProcessItem )
-        , ( "qantity", item.quantity |> quantityToInt |> Encode.int )
+        , ( "quantity", item.quantity |> quantityToInt |> Encode.int )
         ]
 
 

--- a/src/Data/Object/Query.elm
+++ b/src/Data/Object/Query.elm
@@ -11,6 +11,7 @@ module Data.Object.Query exposing
     , defaultItem
     , encode
     , parseBase64Query
+    , quantityToInt
     , removeItem
     , toString
     , updateItem

--- a/src/Data/Object/Query.elm
+++ b/src/Data/Object/Query.elm
@@ -148,8 +148,8 @@ removeItem name ({ items } as query) =
 
 updateItem : Item -> Query -> Query
 updateItem newItem query =
-    let
-        items =
+    { query
+        | items =
             query.items
                 |> List.map
                     (\item ->
@@ -159,8 +159,7 @@ updateItem newItem query =
                         else
                             item
                     )
-    in
-    { query | items = items }
+    }
 
 
 toString : List Process -> Query -> Result String String

--- a/src/Data/Object/Query.elm
+++ b/src/Data/Object/Query.elm
@@ -2,6 +2,7 @@ module Data.Object.Query exposing
     ( Amount
     , Item
     , ProcessItem
+    , Quantity
     , Query
     , amountToFloat
     , b64encode
@@ -12,7 +13,7 @@ module Data.Object.Query exposing
     , encode
     , parseBase64Query
     , quantityToInt
-      -- , removeItem
+    , removeItem
     , toString
       -- , updateItem
     )
@@ -100,17 +101,12 @@ default =
     { items = [] }
 
 
-defaultItem : Process -> Item
-defaultItem process =
+defaultItem : Item
+defaultItem =
     { name = "Composant par défaut"
-    , processes = [ defaultProcessItem process ]
+    , processes = []
     , quantity = Quantity 1
     }
-
-
-defaultProcessItem : Process -> ProcessItem
-defaultProcessItem process =
-    { amount = Amount 1, processId = process.id }
 
 
 encode : Query -> Encode.Value
@@ -139,17 +135,12 @@ encodeProcessItem processItem =
         ]
 
 
+removeItem : String -> Query -> Query
+removeItem name ({ items } as query) =
+    { query | items = items |> List.filter (.name >> (/=) name) }
 
--- FIX: implement it for components
--- removeProcessItem : Process.Id -> List ProcessItem -> List ProcessItem
--- removeProcessItem processId processes =
---     processes |> List.filter (.processId >> (/=) processId)
---
---
--- removeItem : Process.Id -> Query -> Query
--- removeItem processId query =
---     -- FIX: implement it for components
---     query
+
+
 --
 --
 -- updateItem : Item -> Query -> Query
@@ -158,17 +149,6 @@ encodeProcessItem processItem =
 --     query
 --
 --
--- updateProcessItem : ProcessItem -> List ProcessItem -> List ProcessItem
--- updateProcessItem newItem processes =
---     processes
---         |> List.map
---             (\item ->
---                 if item.processId == newItem.processId then
---                     newItem
---
---                 else
---                     item
---             )
 
 
 toString : List Process -> Query -> Result String String

--- a/src/Data/Object/Query.elm
+++ b/src/Data/Object/Query.elm
@@ -12,10 +12,11 @@ module Data.Object.Query exposing
     , defaultItem
     , encode
     , parseBase64Query
+    , quantity
     , quantityToInt
     , removeItem
     , toString
-      -- , updateItem
+    , updateItem
     )
 
 import Base64
@@ -57,6 +58,11 @@ type Quantity
 amountToFloat : Amount -> Float
 amountToFloat (Amount float) =
     float
+
+
+quantity : Int -> Quantity
+quantity int =
+    Quantity int
 
 
 quantityToInt : Quantity -> Int
@@ -140,15 +146,21 @@ removeItem name ({ items } as query) =
     { query | items = items |> List.filter (.name >> (/=) name) }
 
 
+updateItem : Item -> Query -> Query
+updateItem newItem query =
+    let
+        items =
+            query.items
+                |> List.map
+                    (\item ->
+                        if item.name == newItem.name then
+                            newItem
 
---
---
--- updateItem : Item -> Query -> Query
--- updateItem newItem query =
---     -- FIX: implement it for components
---     query
---
---
+                        else
+                            item
+                    )
+    in
+    { query | items = items }
 
 
 toString : List Process -> Query -> Result String String

--- a/src/Data/Object/Query.elm
+++ b/src/Data/Object/Query.elm
@@ -1,8 +1,8 @@
 module Data.Object.Query exposing
     ( Amount
     , Item
+    , ProcessItem
     , Query
-    , amount
     , amountToFloat
     , b64encode
     , buildApiQuery
@@ -31,6 +31,13 @@ type alias Query =
 
 
 type alias Item =
+    { name : String
+    , processes : List ProcessItem
+    , quantity : Quantity
+    }
+
+
+type alias ProcessItem =
     { amount : Amount
     , processId : Process.Id
     }
@@ -40,14 +47,18 @@ type Amount
     = Amount Float
 
 
-amount : Float -> Amount
-amount =
-    Amount
+type Quantity
+    = Quantity Int
 
 
 amountToFloat : Amount -> Float
 amountToFloat (Amount float) =
     float
+
+
+quantityToInt : Quantity -> Int
+quantityToInt (Quantity int) =
+    int
 
 
 buildApiQuery : Scope -> String -> Query -> String
@@ -69,7 +80,15 @@ decode =
 
 decodeItem : Decoder Item
 decodeItem =
-    Decode.map2 Item
+    Decode.map3 Item
+        (Decode.field "name" Decode.string)
+        (Decode.field "processes" (Decode.list decodeProcessItem))
+        (Decode.field "quantity" (Decode.map Quantity Decode.int))
+
+
+decodeProcessItem : Decoder ProcessItem
+decodeProcessItem =
+    Decode.map2 ProcessItem
         (Decode.field "amount" (Decode.map Amount Decode.float))
         (Decode.field "process_id" Process.decodeId)
 
@@ -81,6 +100,14 @@ default =
 
 defaultItem : Process -> Item
 defaultItem process =
+    { name = "Composant par défaut"
+    , processes = [ defaultProcessItem process ]
+    , quantity = Quantity 1
+    }
+
+
+defaultProcessItem : Process -> ProcessItem
+defaultProcessItem process =
     { amount = Amount 1, processId = process.id }
 
 
@@ -96,49 +123,76 @@ encode query =
 encodeItem : Item -> Encode.Value
 encodeItem item =
     Encode.object
-        [ ( "amount", item.amount |> amountToFloat |> Encode.float )
-        , ( "process_id", Process.encodeId item.processId )
+        [ ( "name", item.name |> Encode.string )
+        , ( "processes", item.processes |> Encode.list encodeProcessItem )
+        , ( "qantity", item.quantity |> quantityToInt |> Encode.int )
         ]
+
+
+encodeProcessItem : ProcessItem -> Encode.Value
+encodeProcessItem processItem =
+    Encode.object
+        [ ( "amount", processItem.amount |> amountToFloat |> Encode.float )
+        , ( "process_id", Process.encodeId processItem.processId )
+        ]
+
+
+removeProcessItem : Process.Id -> List ProcessItem -> List ProcessItem
+removeProcessItem processId processes =
+    processes |> List.filter (.processId >> (/=) processId)
 
 
 removeItem : Process.Id -> Query -> Query
 removeItem processId query =
-    { query | items = query.items |> List.filter (.processId >> (/=) processId) }
+    -- FIX: implement it for components
+    query
 
 
 updateItem : Item -> Query -> Query
 updateItem newItem query =
-    { query
-        | items =
-            query.items
-                |> List.map
-                    (\item ->
-                        if item.processId == newItem.processId then
-                            newItem
+    -- FIX: implement it for components
+    query
 
-                        else
-                            item
-                    )
-    }
+
+updateProcessItem : ProcessItem -> List ProcessItem -> List ProcessItem
+updateProcessItem newItem processes =
+    processes
+        |> List.map
+            (\item ->
+                if item.processId == newItem.processId then
+                    newItem
+
+                else
+                    item
+            )
 
 
 toString : List Process -> Query -> Result String String
 toString processes =
     .items
-        >> List.map
-            (\item ->
-                item.processId
-                    |> Process.findById processes
-                    |> Result.map
-                        (\process ->
-                            String.fromFloat (amountToFloat item.amount)
-                                ++ process.unit
-                                ++ " "
-                                ++ process.displayName
-                        )
-            )
-        >> RE.combine
+        >> RE.combineMap (itemToString processes)
         >> Result.map (String.join ", ")
+
+
+itemToString : List Process -> Item -> Result String String
+itemToString processes item =
+    item.processes
+        |> RE.combineMap (processItemToString processes)
+        |> Result.map (String.join " | ")
+        |> Result.map (\processesString -> String.fromInt (quantityToInt item.quantity) ++ " " ++ item.name ++ " [ " ++ processesString ++ " ]")
+
+
+processItemToString : List Process -> ProcessItem -> Result String String
+processItemToString processes processItem =
+    processItem.processId
+        |> Process.findById processes
+        |> Result.map
+            (\process ->
+                String.fromFloat (amountToFloat processItem.amount)
+                    ++ process.unit
+                    ++ " "
+                    ++ process.displayName
+            )
 
 
 

--- a/src/Data/Object/Query.elm
+++ b/src/Data/Object/Query.elm
@@ -1,6 +1,6 @@
 module Data.Object.Query exposing
     ( Amount
-    , Item
+    , Component
     , ProcessItem
     , Quantity
     , Query
@@ -9,14 +9,14 @@ module Data.Object.Query exposing
     , buildApiQuery
     , decode
     , default
-    , defaultItem
+    , defaultComponent
     , encode
     , parseBase64Query
     , quantity
     , quantityToInt
-    , removeItem
+    , removeComponent
     , toString
-    , updateItem
+    , updateComponent
     )
 
 import Base64
@@ -30,11 +30,11 @@ import Url.Parser as Parser exposing (Parser)
 
 
 type alias Query =
-    { items : List Item
+    { components : List Component
     }
 
 
-type alias Item =
+type alias Component =
     { name : String
     , processes : List ProcessItem
     , quantity : Quantity
@@ -87,9 +87,9 @@ decode =
         |> Pipe.required "items" (Decode.list decodeItem)
 
 
-decodeItem : Decoder Item
+decodeItem : Decoder Component
 decodeItem =
-    Decode.map3 Item
+    Decode.map3 Component
         (Decode.field "name" Decode.string)
         (Decode.field "processes" (Decode.list decodeProcessItem))
         (Decode.field "quantity" (Decode.map Quantity Decode.int))
@@ -104,11 +104,11 @@ decodeProcessItem =
 
 default : Query
 default =
-    { items = [] }
+    { components = [] }
 
 
-defaultItem : Item
-defaultItem =
+defaultComponent : Component
+defaultComponent =
     { name = "Composant par défaut"
     , processes = []
     , quantity = Quantity 1
@@ -119,12 +119,12 @@ encode : Query -> Encode.Value
 encode query =
     Encode.object
         [ ( "items"
-          , Encode.list encodeItem query.items
+          , Encode.list encodeItem query.components
           )
         ]
 
 
-encodeItem : Item -> Encode.Value
+encodeItem : Component -> Encode.Value
 encodeItem item =
     Encode.object
         [ ( "name", item.name |> Encode.string )
@@ -141,16 +141,16 @@ encodeProcessItem processItem =
         ]
 
 
-removeItem : String -> Query -> Query
-removeItem name ({ items } as query) =
-    { query | items = items |> List.filter (.name >> (/=) name) }
+removeComponent : String -> Query -> Query
+removeComponent name ({ components } as query) =
+    { query | components = components |> List.filter (.name >> (/=) name) }
 
 
-updateItem : Item -> Query -> Query
-updateItem newItem query =
+updateComponent : Component -> Query -> Query
+updateComponent newItem query =
     { query
-        | items =
-            query.items
+        | components =
+            query.components
                 |> List.map
                     (\item ->
                         if item.name == newItem.name then
@@ -164,12 +164,12 @@ updateItem newItem query =
 
 toString : List Process -> Query -> Result String String
 toString processes =
-    .items
+    .components
         >> RE.combineMap (itemToString processes)
         >> Result.map (String.join ", ")
 
 
-itemToString : List Process -> Item -> Result String String
+itemToString : List Process -> Component -> Result String String
 itemToString processes item =
     item.processes
         |> RE.combineMap (processItemToString processes)

--- a/src/Data/Object/Simulator.elm
+++ b/src/Data/Object/Simulator.elm
@@ -13,7 +13,7 @@ module Data.Object.Simulator exposing
 import Data.Impact as Impact exposing (Impacts, noStepsImpacts)
 import Data.Impact.Definition as Definition
 import Data.Object.Process as Process exposing (Process)
-import Data.Object.Query as Query exposing (ProcessItem, Query)
+import Data.Object.Query as Query exposing (ProcessItem, Query, quantityToInt)
 import Mass exposing (Mass)
 import Quantity
 import Result.Extra as RE
@@ -28,12 +28,9 @@ type Results
         }
 
 
-
--- FIX: implement it for components, don't force unique processes
-
-
 availableProcesses : Db -> Query -> List Process
 availableProcesses { object } query =
+    -- FIX: implement it for components, don't force unique processes
     let
         usedIds =
             List.map .processId (query.items |> List.concatMap .processes)
@@ -45,8 +42,10 @@ availableProcesses { object } query =
 compute : Db -> Query -> Result String Results
 compute db query =
     query.items
-        -- Flatten the processes inside the items
-        |> List.concatMap .processes
+        -- Flatten the processes inside the items, muliplying processes entries by the quantity
+        |> List.concatMap (\item -> List.repeat (quantityToInt item.quantity) item.processes)
+        -- Flatten the list
+        |> List.concat
         |> List.map (computeProcessItemResults db)
         |> RE.combine
         |> Result.map

--- a/src/Data/Object/Simulator.elm
+++ b/src/Data/Object/Simulator.elm
@@ -50,8 +50,8 @@ availableComponents { object } query =
         |> List.sortBy .name
 
 
-accumulateResults : Results -> Results -> Results
-accumulateResults (Results results) (Results acc) =
+addResults : Results -> Results -> Results
+addResults (Results results) (Results acc) =
     Results
         { acc
             | impacts = Impact.sumImpacts [ results.impacts, acc.impacts ]
@@ -65,8 +65,7 @@ compute db query =
     query.components
         |> List.map (computeItemResults db)
         |> RE.combine
-        |> Result.map
-            (List.foldr accumulateResults emptyResults)
+        |> Result.map (List.foldr addResults emptyResults)
 
 
 computeItemResults : Db -> Component -> Result String Results
@@ -74,8 +73,7 @@ computeItemResults db item =
     item.processes
         |> List.map (computeProcessItemResults db)
         |> RE.combine
-        |> Result.map
-            (List.foldr accumulateResults emptyResults)
+        |> Result.map (List.foldr addResults emptyResults)
         |> Result.map
             (\(Results { impacts, mass, items }) ->
                 Results

--- a/src/Data/Object/Simulator.elm
+++ b/src/Data/Object/Simulator.elm
@@ -37,7 +37,7 @@ type Results
 availableComponents : Db -> Query -> List Item
 availableComponents { object } query =
     let
-        -- For now, consider that components are unique by name, we should
+        -- FIX: For now, consider that components are unique by name, we should
         -- replace it with ids later on
         usedNames =
             List.map .name query.items

--- a/src/Page/Object.elm
+++ b/src/Page/Object.elm
@@ -570,20 +570,29 @@ itemView selectedImpact ( quantity, name, processes ) itemResults =
                     , class "form-control text-end"
                     , quantity |> Query.quantityToInt |> String.fromInt |> value
                     , step "1"
+                    , Html.Attributes.min "1"
                     , onInput <|
                         \str ->
-                            case String.toInt str of
-                                -- FIX: don't update components based on their name
-                                -- swith to components ids as soon as they are implemented
-                                Just int ->
-                                    UpdateItem
-                                        { name = name
-                                        , quantity = Query.quantity int
-                                        , processes = processes |> List.map (\( amount, process ) -> { amount = amount, processId = process.id })
-                                        }
+                            String.toInt str
+                                |> Maybe.andThen
+                                    (\int ->
+                                        if int > 0 then
+                                            Just int
 
-                                Nothing ->
-                                    NoOp
+                                        else
+                                            Nothing
+                                    )
+                                |> Maybe.map
+                                    (\nonNullInt ->
+                                        -- FIX: don't update components based on their name
+                                        -- swith to components ids as soon as they are implemented
+                                        UpdateItem
+                                            { name = name
+                                            , quantity = Query.quantity nonNullInt
+                                            , processes = processes |> List.map (\( amount, process ) -> { amount = amount, processId = process.id })
+                                            }
+                                    )
+                                |> Maybe.withDefault NoOp
                     ]
                     []
                 ]
@@ -604,7 +613,7 @@ itemView selectedImpact ( quantity, name, processes ) itemResults =
     , tr []
         [ td [ colspan 5 ]
             [ details [ class "mb-2" ]
-                [ summary [] [ text "Procédés" ]
+                [ summary [ class "ps-3" ] [ text "Procédés" ]
                 , div [ class "table-responsive" ]
                     [ table [ class "table mb-0" ]
                         [ thead []
@@ -614,6 +623,7 @@ itemView selectedImpact ( quantity, name, processes ) itemResults =
                                 , th [ scope "col" ] [ text "Densité" ]
                                 , th [ scope "col" ] [ text "Masse" ]
                                 , th [ scope "col" ] [ text "Impact" ]
+                                , th [ scope "col" ] [ text "" ]
                                 ]
                                 :: List.map2 (processView selectedImpact) processes (Simulator.extractItems itemResults)
                             )
@@ -653,6 +663,8 @@ processView selectedImpact ( amount, process ) itemResults =
             [ Simulator.extractImpacts itemResults
                 |> Format.formatImpact selectedImpact
             ]
+        , td [ class "pe-3 align-middle text-nowrap" ]
+            []
         ]
 
 

--- a/src/Page/Object.elm
+++ b/src/Page/Object.elm
@@ -645,10 +645,10 @@ processView selectedImpact ( amount, process ) itemResults =
         [ td [ class "ps-3 align-middle text-nowrap" ]
             [ case process.unit of
                 "kg" ->
-                    Format.kg (floatAmount |> Mass.kilograms)
+                    floatAmount |> Mass.kilograms |> Format.kg
 
                 "m3" ->
-                    Format.m3 (floatAmount |> Volume.cubicMeters)
+                    floatAmount |> Volume.cubicMeters |> Format.m3
 
                 _ ->
                     text ((floatAmount |> String.fromFloat) ++ " " ++ process.unit)

--- a/src/Page/Object.elm
+++ b/src/Page/Object.elm
@@ -595,7 +595,7 @@ componentView selectedImpact detailedComponents ( quantity, name, processes ) it
                     ]
                 , td [ class "ps-0 align-middle" ]
                     [ quantity |> quantityInput processes name ]
-                , td [ class "align-middle text-truncate w-100", colspan 2 ]
+                , td [ class "align-middle text-truncate w-100 fw-bold", colspan 2 ]
                     [ text name ]
                 , td [ class "text-end align-middle text-nowrap" ]
                     [ Format.kg <| Simulator.extractMass itemResults ]

--- a/src/Page/Object.elm
+++ b/src/Page/Object.elm
@@ -542,17 +542,19 @@ itemView selectedImpact ( amount, process ) itemResults =
 
                             _ ->
                                 "1"
-                    , onInput <|
-                        \str ->
-                            case String.toFloat str of
-                                Just float ->
-                                    UpdateItem
-                                        { amount = Query.amount float
-                                        , processId = process.id
-                                        }
 
-                                Nothing ->
-                                    NoOp
+                    -- FIX: add it back for components
+                    -- , onInput <|
+                    --     \str ->
+                    --         case String.toFloat str of
+                    --             Just float ->
+                    --                 UpdateItem
+                    --                     { amount = Query.amount float
+                    --                     , processId = process.id
+                    --                     }
+                    --
+                    --             Nothing ->
+                    --                 NoOp
                     ]
                     []
                 , span

--- a/src/Page/Object.elm
+++ b/src/Page/Object.elm
@@ -623,7 +623,8 @@ componentView selectedImpact detailedComponents ( quantity, name, processes ) it
                 text ""
           ]
         , if not collapsed then
-            List.map2 (processView selectedImpact) processes (Simulator.extractItems itemResults)
+            Simulator.extractItems itemResults
+                |> List.map2 (processView selectedImpact) processes
 
           else
             []
@@ -634,20 +635,25 @@ processView : Definition -> ( Query.Amount, Process ) -> Results -> Html Msg
 processView selectedImpact ( amount, process ) itemResults =
     let
         floatAmount =
-            amount |> Query.amountToFloat
+            Query.amountToFloat amount
     in
     tr [ class "fs-7" ]
         [ td [] []
         , td [ class "text-end text-nowrap" ]
             [ case process.unit of
                 "kg" ->
-                    floatAmount |> Mass.kilograms |> Format.kg
+                    Mass.kilograms floatAmount
+                        |> Format.kg
 
                 "m3" ->
-                    floatAmount |> Volume.cubicMeters |> Format.m3
+                    Volume.cubicMeters floatAmount
+                        |> Format.m3
 
                 _ ->
-                    text ((floatAmount |> String.fromFloat) ++ " " ++ process.unit)
+                    String.fromFloat floatAmount
+                        ++ " "
+                        ++ process.unit
+                        |> text
             ]
         , td [ class "align-middle text-truncate w-100" ]
             [ text process.displayName ]

--- a/src/Page/Object.elm
+++ b/src/Page/Object.elm
@@ -27,7 +27,6 @@ import Data.Uuid exposing (Uuid)
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (..)
-import Mass
 import Ports
 import Route
 import Set exposing (Set)
@@ -46,7 +45,6 @@ import Views.ImpactTabs as ImpactTabs
 import Views.Link as Link
 import Views.Modal as ModalView
 import Views.Sidebar as SidebarView
-import Volume
 
 
 type alias Model =
@@ -633,28 +631,10 @@ componentView selectedImpact detailedComponents ( quantity, name, processes ) it
 
 processView : Definition -> ( Query.Amount, Process ) -> Results -> Html Msg
 processView selectedImpact ( amount, process ) itemResults =
-    let
-        floatAmount =
-            Query.amountToFloat amount
-    in
     tr [ class "fs-7" ]
         [ td [] []
         , td [ class "text-end text-nowrap" ]
-            [ case process.unit of
-                "kg" ->
-                    Mass.kilograms floatAmount
-                        |> Format.kg
-
-                "m3" ->
-                    Volume.cubicMeters floatAmount
-                        |> Format.m3
-
-                _ ->
-                    String.fromFloat floatAmount
-                        ++ " "
-                        ++ process.unit
-                        |> text
-            ]
+            [ Format.amount process amount ]
         , td [ class "align-middle text-truncate w-100" ]
             [ text process.displayName ]
         , td [ class "align-middle text-end text-nowrap" ]

--- a/src/Page/Object.elm
+++ b/src/Page/Object.elm
@@ -430,7 +430,7 @@ selectComponent query autocompleteState ( model, session, _ ) =
                 |> Maybe.withDefault Query.defaultComponent
     in
     update session (SetModal NoModal) model
-        |> updateQuery { query | components = selectedComponent :: query.components }
+        |> updateQuery { query | components = query.components ++ [ selectedComponent ] }
 
 
 simulatorView : Session -> Model -> Html Msg

--- a/src/Page/Object.elm
+++ b/src/Page/Object.elm
@@ -85,7 +85,10 @@ type Msg
     | SwitchImpactsTab ImpactTabs.Tab
     | ToggleComparedSimulation Bookmark Bool
     | UpdateBookmarkName String
-    | UpdateItem Query.Item
+
+
+
+-- | UpdateItem Query.Item
 
 
 init : Scope -> Definition.Trigram -> Maybe Query -> Session -> ( Model, Session, Cmd Msg )
@@ -262,10 +265,11 @@ update ({ navKey } as session) msg model =
             , Cmd.none
             )
 
-        ( RemoveItem processId, _ ) ->
+        ( RemoveItem _, _ ) ->
             ( model, session, Cmd.none )
-                |> updateQuery (Query.removeItem processId query)
 
+        -- FIX: add it back for components
+        -- |> updateQuery (Query.removeItem processId query)
         ( SaveBookmark, _ ) ->
             ( model
             , session
@@ -356,9 +360,12 @@ update ({ navKey } as session) msg model =
         ( UpdateBookmarkName newName, _ ) ->
             ( { model | bookmarkName = newName }, session, Cmd.none )
 
-        ( UpdateItem item, _ ) ->
-            ( model, session, Cmd.none )
-                |> updateQuery (Query.updateItem item query)
+
+
+-- FIX: add it back for components
+-- ( UpdateItem item, _ ) ->
+--     ( model, session, Cmd.none )
+-- |> updateQuery (Query.updateItem item query)
 
 
 commandsForNoModal : Modal -> Cmd Msg

--- a/src/Page/Object.elm
+++ b/src/Page/Object.elm
@@ -539,7 +539,6 @@ itemListView db selectedImpact results query =
                             [ tr [ class "fs-7 text-muted" ]
                                 [ th [ class "ps-3", scope "col" ] [ text "Quantité" ]
                                 , th [ scope "col" ] [ text "Composant" ]
-                                , th [ scope "col" ] [ text "Densité" ]
                                 , th [ scope "col" ] [ text "Masse" ]
                                 , th [ scope "col" ] [ text "Impact" ]
                                 , th [ scope "col" ] []

--- a/src/Page/Object.elm
+++ b/src/Page/Object.elm
@@ -17,7 +17,7 @@ import Data.Dataset as Dataset
 import Data.Example as Example exposing (Example)
 import Data.Impact.Definition as Definition exposing (Definition)
 import Data.Key as Key
-import Data.Object.Process as Process exposing (Process)
+import Data.Object.Process exposing (Process)
 import Data.Object.Query as Query exposing (Query)
 import Data.Object.Simulator as Simulator exposing (Results)
 import Data.Scope as Scope exposing (Scope)
@@ -73,7 +73,7 @@ type Msg
     | OnAutocompleteExample (Autocomplete.Msg Query)
     | OnAutocompleteSelect
     | OpenComparator
-    | RemoveItem Process.Id
+      -- | RemoveItem Process.Id
     | SaveBookmark
     | SaveBookmarkWithTime String Bookmark.Query Posix
     | SelectAllBookmarks
@@ -265,10 +265,10 @@ update ({ navKey } as session) msg model =
             , Cmd.none
             )
 
-        ( RemoveItem _, _ ) ->
-            ( model, session, Cmd.none )
-
         -- FIX: add it back for components
+        -- ( RemoveItem _, _ ) ->
+        --     ( model, session, Cmd.none )
+        --
         -- |> updateQuery (Query.removeItem processId query)
         ( SaveBookmark, _ ) ->
             ( model
@@ -582,7 +582,9 @@ itemView selectedImpact ( amount, process ) itemResults =
                 |> Format.formatImpact selectedImpact
             ]
         , td [ class "pe-3 align-middle text-nowrap" ]
-            [ button [ class "btn btn-outline-secondary", onClick (RemoveItem process.id) ]
+            -- FIX: add it back for components
+            -- [ button [ class "btn btn-outline-secondary", onClick (RemoveItem process.id) ]
+            [ button [ class "btn btn-outline-secondary" ]
                 [ Icon.trash ]
             ]
         ]

--- a/src/Views/Format.elm
+++ b/src/Views/Format.elm
@@ -1,5 +1,6 @@
 module Views.Format exposing
-    ( complement
+    ( amount
+    , complement
     , days
     , density
     , formatFloat
@@ -28,6 +29,8 @@ module Views.Format exposing
 import Area exposing (Area)
 import Data.Impact as Impact exposing (Impacts)
 import Data.Impact.Definition exposing (Definition)
+import Data.Object.Process as ObjectProcess
+import Data.Object.Query as ObjectQuery
 import Data.Split as Split exposing (Split)
 import Data.Textile.Economics as Economics
 import Data.Unit as Unit
@@ -149,6 +152,28 @@ complement impact =
                 formatted
         , span [ class "fs-unit" ] [ text "\u{202F}Pts" ]
         ]
+
+
+amount : ObjectProcess.Process -> ObjectQuery.Amount -> Html msg
+amount { unit } amount_ =
+    let
+        floatAmount =
+            ObjectQuery.amountToFloat amount_
+    in
+    case unit of
+        "kg" ->
+            Mass.kilograms floatAmount
+                |> kg
+
+        "m3" ->
+            Volume.cubicMeters floatAmount
+                |> m3
+
+        _ ->
+            String.fromFloat floatAmount
+                ++ " "
+                ++ unit
+                |> text
 
 
 kg : Mass -> Html msg

--- a/tests/Data/Object/SimulatorTest.elm
+++ b/tests/Data/Object/SimulatorTest.elm
@@ -36,7 +36,7 @@ suite =
                     |> Example.findByName "Table"
                     |> Result.andThen (.query >> getEcsImpact db)
                     |> Result.withDefault 0
-                    |> Expect.within (Expect.Absolute 1) 47
+                    |> Expect.within (Expect.Absolute 1) 3979
                     |> asTest "should compute impact for an example table"
                 ]
             ]


### PR DESCRIPTION
## :wrench: Problem

We want to be able to model the component notion. See [the card](https://www.notion.so/Objet_V0-S-lection-des-composants-79ca63b368524ee0b1f06321aa1878c5) for more details.

## :cake: Solution

Add a level above the processes with a name and a quantity.


## :rotating_light:  Points to watch/comments

Currently, components are built on the file from the example file. Their uniqueness is based on their name, it should be improved later on with component ids and a file listing the possible components.

It's not possible to modify processes on purpose, it should come later on.

Tests need to be added.

## :desert_island: How to test

- Go on the object tab
- Select the "Chaise", score should be 422
- Select the  "Table", score should be 3 979
- Add and remove some components: score should be updated accordingly
- Expand the "Procédés" summary and check that the totals impacts and mass of the component is the impacts and mass of the process multiplied by the quantity of the component like below

![image](https://github.com/user-attachments/assets/63069916-bf8d-463e-910d-9ee27004c582)
- Check that the bookmarks work as expected

