### PR TITLE
Add irrigation to the Ecoinvent organic cotton

### DIFF
--- a/data/common/import_.py
+++ b/data/common/import_.py
@@ -224,13 +224,13 @@ def import_simapro_csv(
     print("### Applying strategies...")
     # exclude strategies/migrations
     database.strategies = (
-        first_strategies
+        list(first_strategies)
         + [
             s
             for s in database.strategies
             if not any([e in repr(s) for e in excluded_strategies])
         ]
-        + other_strategies
+        + list(other_strategies)
     )
 
     database.apply_strategies()

--- a/data/import_ecoinvent.py
+++ b/data/import_ecoinvent.py
@@ -20,6 +20,33 @@ EXCLUDED = [
 ]
 
 
+def organic_cotton_irrigation(db):
+    """add irrigation to the organic cotton"""
+    for ds in db:
+        if ds.get("simapro metadata", {}).get("Process identifier") in (
+            "MTE00149000081182217968",  # EI 3.9.1
+            "EI3ARUNI000011519618165",  # EI 3.10
+        ):
+            # add: irrigation//[IN] market for irrigation;m3;0.75;Undefined;0;0;0;;
+            ds["exchanges"].append(
+                {
+                    "amount": 0.75,
+                    "categories": ("Materials/fuels",),
+                    "comment": "",
+                    "loc": 0.75,
+                    "name": "irrigation//[IN] market for irrigation",
+                    "negative": False,
+                    "type": "technosphere",
+                    "uncertainty type": 2,
+                    "unit": "cubic meter",
+                }
+            )
+    return db
+
+
+STRATEGIES = [organic_cotton_irrigation]
+
+
 def main():
     projects.set_current(PROJECT)
     # projects.create_project(PROJECT, activate=True, exist_ok=True)
@@ -31,6 +58,7 @@ def main():
         import_simapro_csv(
             join("..", "..", "dbfiles", EI391),
             db,
+            first_strategies=STRATEGIES,
             excluded_strategies=EXCLUDED,
         )
     else:
@@ -40,6 +68,7 @@ def main():
         import_simapro_csv(
             join("..", "..", "dbfiles", EI310),
             db,
+            first_strategies=STRATEGIES,
             excluded_strategies=EXCLUDED,
         )
 


### PR DESCRIPTION
## :wrench: Problem

The organic cotton is a EI-modified one with only irrigation added. It's impacts are hardcoded and not retrieved from either simapro or brightway.

## :cake: Solution

Add a strategy to add irrigation to the organic cotton.

## :rotating_light:  Points to watch/comments

This may only applies on brightway, as I'm unsure where to find the modified organic cotton in SimaPro. It would be great to first merge https://github.com/MTES-MCT/ecobalyse/pull/822

## :desert_island: How to test

Run the `make clean_data import_ecoinvent` then check in brightway / EI 3.9.1 that the organic cotton has an irrigation.
Compare the new impact with the previous ones.