### PR TITLE
refactor: unzip in a temporary folder instead

### DIFF
--- a/data/common/import_.py
+++ b/data/common/import_.py
@@ -1,9 +1,9 @@
 import functools
 import json
-import os
 import re
 import sys
-from os.path import dirname
+import tempfile
+from os.path import basename, join, splitext
 from subprocess import call
 from zipfile import ZipFile
 
@@ -186,29 +186,29 @@ def import_simapro_csv(
     """
     print(f"### Importing {datapath}...")
     # unzip
-    with ZipFile(datapath) as zf:
-        print("### Extracting the zip file...")
-        zf.extractall(path=dirname(datapath))
-        unzipped = datapath[0:-4]
+    with tempfile.TemporaryDirectory() as tempdir:
+        with ZipFile(datapath) as zf:
+            print(f"### Extracting the zip file in {tempdir}...")
+            zf.extractall(path=tempdir)
+            unzipped, _ = splitext(join(tempdir, basename(datapath)))
 
-    if "AGB" in datapath:
-        print("### Patching Agribalyse...")
-        # `yield` is used as a variable in some Simapro parameters. bw2parameters cannot handle it:
-        # (sed is faster than Python)
-        call("sed -i 's/yield/Yield_/g' " + unzipped, shell=True)
-        # Fix some errors in Agribalyse:
-        call("sed -i 's/01\\/03\\/2005/1\\/3\\/5/g' " + unzipped, shell=True)
-        call("sed -i 's/\"0;001172\"/0,001172/' " + unzipped, shell=True)
+        if "AGB" in datapath:
+            print("### Patching Agribalyse...")
+            # `yield` is used as a variable in some Simapro parameters. bw2parameters cannot handle it:
+            # (sed is faster than Python)
+            call("sed -i 's/yield/Yield_/g' " + unzipped, shell=True)
+            # Fix some errors in Agribalyse:
+            call("sed -i 's/01\\/03\\/2005/1\\/3\\/5/g' " + unzipped, shell=True)
+            call("sed -i 's/\"0;001172\"/0,001172/' " + unzipped, shell=True)
 
-    print(f"### Importing into {dbname}...")
-    # Do the import
-    database = bw2io.importers.simapro_csv.SimaProCSVImporter(
-        unzipped, dbname, normalize_biosphere=True
-    )
-    if source:
-        for ds in database:
-            ds["source"] = source
-    os.unlink(unzipped)
+        print(f"### Importing into {dbname}...")
+        # Do the import
+        database = bw2io.importers.simapro_csv.SimaProCSVImporter(
+            unzipped, dbname, normalize_biosphere=True
+        )
+        if source:
+            for ds in database:
+                ds["source"] = source
 
     print("### Applying migrations...")
     # Apply provided migrations


### PR DESCRIPTION
## :wrench: Problem

We cannot run two imports in parallel because the csv files are unzipped in the same directory.
 
## :cake: Solution

Unzip in a temporary folder instead

## :desert_island: How to test

Extract two clones of ecobalyse in two different folders, and launch the make process at the same time. Check both work.