### PR TITLE
Agribalyse 3.2 final availability in brightway

### DIFF
--- a/data/import_food.py
+++ b/data/import_food.py
@@ -232,7 +232,7 @@ if __name__ == "__main__":
         print(f"{db} already imported")
 
     # AGRIBALYSE 3.2
-    if (db := "Agribalyse 3.2 beta 08/08/2024") not in bw2data.databases:
+    if (db := "Agribalyse 3.2") not in bw2data.databases:
         import_simapro_csv(
             join("..", "..", "dbfiles", AGRIBALYSE32),
             db,

--- a/data/import_food.py
+++ b/data/import_food.py
@@ -17,7 +17,7 @@ from common.import_ import (
 
 PROJECT = "default"
 AGRIBALYSE31 = "AGB3.1.1.20230306.CSV.zip"  # Agribalyse 3.1
-AGRIBALYSE32 = "AGB32beta_08082024.CSV.zip"  # Agribalyse 3.2
+AGRIBALYSE32 = "AGB32_final.CSV.zip"  # Agribalyse 3.2
 GINKO = "CSV_369p_et_298chapeaux_final.csv.zip"  # additional organic processes
 PASTOECO = [
     "CONVEN~1.CSV.zip",


### PR DESCRIPTION
## :wrench: Problem

We still have AGB 3.2 beta but we need the final version in the activities editor and bw explorer.

## :cake: Solution

Just replace the name of the file to load.

## :desert_island: How to test

Run the full `make ` clean && make image import_food` and check you get agb 3.2 in brightway.
(Note this is not a replacement of 3.1 with 3.2 at the processes level)