### PR TITLE
feat(textile): update number of references index thresholds.

### DIFF
--- a/src/Data/Textile/Economics.elm
+++ b/src/Data/Textile/Economics.elm
@@ -161,24 +161,20 @@ computeNumberOfReferencesIndex n =
             (low - toFloat n) / (low - high)
     in
     Unit.ratio <|
-        if n <= 3000 then
-            -- From 0 to 3000: 100%
+        if n <= 1000 then
+            -- From 0 to 1000: 100%
             1
 
-        else if n <= 6000 then
-            -- From 3000 to 6000: decreasing from 100% to 80%
-            0.8 + (fromThreshold 3000 6000 * 0.2)
+        else if n <= 7000 then
+            -- From 1000 to 7000: decreasing from 100% to 50%
+            0.5 + (fromThreshold 1000 7000 * (1 - 0.5))
 
-        else if n <= 10000 then
-            -- From 6000 to 10000: decreasing from 80% to 50%
-            0.5 + (fromThreshold 6000 10000 * (0.8 - 0.5))
-
-        else if n <= 50000 then
-            -- From 10000 to 50000: decreasing from 50% to 0%
-            fromThreshold 10000 50000 * 0.5
+        else if n <= 16000 then
+            -- From 7000 to 16000: decreasing from 50% to 0%
+            fromThreshold 7000 16000 * 0.5
 
         else
-            -- Over 50000: 0%
+            -- Over 16000: 0%
             0
 
 

--- a/tests/Data/Textile/EconomicsTest.elm
+++ b/tests/Data/Textile/EconomicsTest.elm
@@ -25,19 +25,20 @@ suite =
                 , traceability = False
                 }
                 |> Unit.nonPhysicalDurabilityToFloat
-                |> Expect.within (Expect.Absolute 0.01) 1.1
+                |> Expect.within (Expect.Absolute 0.01) 0.98
                 |> asTest "should compute durability index"
             ]
         , describe "computeNumberOfReferencesIndex"
             ([ ( 1, 1 )
-             , ( 3000, 1 )
-             , ( 3750, 0.95 )
-             , ( 4500, 0.9 )
-             , ( 5250, 0.85 )
-             , ( 6000, 0.8 )
-             , ( 8000, 0.65 )
-             , ( 10000, 0.5 )
-             , ( 30000, 0.25 )
+             , ( 500, 1 )
+             , ( 750, 1 )
+             , ( 1000, 1 )
+             , ( 2000, 0.91 )
+             , ( 3000, 0.83 )
+             , ( 4500, 0.7 )
+             , ( 7000, 0.5 )
+             , ( 11500, 0.25 )
+             , ( 16000, 0 )
              , ( 50000, 0 )
              , ( 100000, 0 )
              ]


### PR DESCRIPTION
## :wrench: Problem

[Notion card](https://www.notion.so/Largeur-de-gamme-modification-des-seuils-135b056852fc809b9595ccfd6939ff97)

Two problems:

1. We want the thresholds applied to clearly distinguish:
    - Ultra fast fashion which should be at 0%
    - Fast fashion which should be around 50%
2. We do not want the thresholds to:
    - Penalize brands that offer, for example, clothing for large sizes (this does not increase the choice offered to people who are not concerned)

## :cake: Solution

Update thresholds; today the “largeur de gamme” index takes the following thresholds:

- 100% when the number of references is less than 3000
- 80% for 6,000 references
- 50% for 10,000 references
- 0% when the number of references is greater than 50,000

These should be replaced as following:
- 100% when the number of references is less than 1,000
- 80% for 6,000 references ⇒ this threshold is deleted
- 50% for 7,000 references
- 0% when the number of references is greater than 16,000

## :desert_island: How to test

Check that the computed non-physical durability index incorporates these changes adjusting the *Nombre de références* field value.

Note: unit tests have been updated, precise acceptance tests may eventually be added to the card as requested over mattermost.