### PR TITLE
feat: introduce components db

### DIFF
--- a/bin/build-db
+++ b/bin/build-db
@@ -63,6 +63,7 @@ const elmWithFixtures = elmTemplate
   )
   .replace("%foodProductExamplesJson%", parseAndValidate("public/data/food/examples.json", "id"))
   // Object JSON data
+  .replace("%objectComponentsJson%", parseAndValidate("public/data/object/components.json", "id"))
   .replace("%objectExamplesJson%", parseAndValidate("public/data/object/examples.json", "id"))
   .replace(
     "%objectProcessesJson%",

--- a/public/data/object/components.json
+++ b/public/data/object/components.json
@@ -8,5 +8,55 @@
         "amount": 0.00022
       }
     ]
+  },
+  {
+    "id": "ad9d7f23-076b-49c5-93a4-ee1cd7b53973",
+    "name": "Dossier plastique (PP)",
+    "processes": [
+      {
+        "process_id": "3295b2a5-328a-4c00-b046-e2ddeb0da823",
+        "amount": 0.734063
+      }
+    ]
+  },
+  {
+    "id": "eda5dd7e-52e4-450f-8658-1876efc62bd6",
+    "name": "Assise plastique (PP)",
+    "processes": [
+      {
+        "process_id": "3295b2a5-328a-4c00-b046-e2ddeb0da823",
+        "amount": 0.91125
+      }
+    ]
+  },
+  {
+    "id": "6f8d1621-324a-4c00-abe3-f90813d878d2",
+    "name": "Pied 90 cm (plein bois)",
+    "processes": [
+      {
+        "process_id": "07e9e916-e02b-45e2-a298-2b5084de6242",
+        "amount": 0.007065
+      }
+    ]
+  },
+  {
+    "id": "3d1ba21f-a139-4e1f-8192-082327ad855e",
+    "name": "Plateau 200x100 (chêne)",
+    "processes": [
+      {
+        "process_id": "07e9e916-e02b-45e2-a298-2b5084de6242",
+        "amount": 0.14
+      }
+    ]
+  },
+  {
+    "id": "190276e9-5b90-42d6-8fbd-bc7ddfd4c960",
+    "name": "Cadre plastique",
+    "processes": [
+      {
+        "process_id": "3295b2a5-328a-4c00-b046-e2ddeb0da823",
+        "amount": 35
+      }
+    ]
   }
 ]

--- a/public/data/object/components.json
+++ b/public/data/object/components.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": "64fa65b3-c2df-4fd0-958b-83965bd6aa08",
+    "name": "Pied 70 cm (plein bois)",
+    "processes": [
+      {
+        "process_id": "07e9e916-e02b-45e2-a298-2b5084de6242",
+        "amount": 0.00022
+      }
+    ]
+  }
+]

--- a/public/data/object/examples.json
+++ b/public/data/object/examples.json
@@ -5,7 +5,7 @@
     "scope": "object",
     "category": "",
     "query": {
-      "items": []
+      "components": []
     }
   },
   {
@@ -14,7 +14,7 @@
     "scope": "veli",
     "category": "",
     "query": {
-      "items": [{ "name": "Composant par défaut", "processes": [], "quantity": 0 }]
+      "components": [{ "name": "Composant par défaut", "processes": [], "quantity": 0 }]
     }
   },
   {
@@ -23,9 +23,15 @@
     "scope": "object",
     "category": "",
     "query": {
-      "items": [
+      "components": [
         {
-          "id": "64fa65b3-c2df-4fd0-958b-83965bd6aa08",
+          "name": "Pied 70 cm (plein bois)",
+          "processes": [
+            {
+              "process_id": "07e9e916-e02b-45e2-a298-2b5084de6242",
+              "amount": 0.00022
+            }
+          ],
           "quantity": 4
         },
         {
@@ -57,7 +63,7 @@
     "scope": "object",
     "category": "",
     "query": {
-      "items": [
+      "components": [
         {
           "name": "Pied 90 cm (plein bois)",
           "processes": [
@@ -87,7 +93,7 @@
     "scope": "veli",
     "category": "",
     "query": {
-      "items": [
+      "components": [
         {
           "name": "Cadre plastique",
           "processes": [

--- a/public/data/object/examples.json
+++ b/public/data/object/examples.json
@@ -25,13 +25,7 @@
     "query": {
       "items": [
         {
-          "name": "Pied 70 cm (plein bois)",
-          "processes": [
-            {
-              "process_id": "07e9e916-e02b-45e2-a298-2b5084de6242",
-              "amount": 0.00022
-            }
-          ],
+          "id": "64fa65b3-c2df-4fd0-958b-83965bd6aa08",
           "quantity": 4
         },
         {
@@ -42,7 +36,6 @@
               "amount": 0.734063
             }
           ],
-
           "quantity": 1
         },
         {
@@ -53,7 +46,6 @@
               "amount": 0.91125
             }
           ],
-
           "quantity": 1
         }
       ]
@@ -74,7 +66,6 @@
               "amount": 0.007065
             }
           ],
-
           "quantity": 4
         },
         {
@@ -85,7 +76,6 @@
               "amount": 0.14
             }
           ],
-
           "quantity": 1
         }
       ]

--- a/public/data/object/examples.json
+++ b/public/data/object/examples.json
@@ -25,6 +25,7 @@
     "query": {
       "components": [
         {
+          "id": "64fa65b3-c2df-4fd0-958b-83965bd6aa08",
           "name": "Pied 70 cm (plein bois)",
           "processes": [
             {
@@ -35,6 +36,7 @@
           "quantity": 4
         },
         {
+          "id": "ad9d7f23-076b-49c5-93a4-ee1cd7b53973",
           "name": "Dossier plastique (PP)",
           "processes": [
             {
@@ -45,6 +47,7 @@
           "quantity": 1
         },
         {
+          "id": "eda5dd7e-52e4-450f-8658-1876efc62bd6",
           "name": "Assise plastique (PP)",
           "processes": [
             {
@@ -65,6 +68,7 @@
     "query": {
       "components": [
         {
+          "id": "6f8d1621-324a-4c00-abe3-f90813d878d2",
           "name": "Pied 90 cm (plein bois)",
           "processes": [
             {
@@ -75,6 +79,7 @@
           "quantity": 4
         },
         {
+          "id": "3d1ba21f-a139-4e1f-8192-082327ad855e",
           "name": "Plateau 200x100 (chêne)",
           "processes": [
             {
@@ -95,6 +100,7 @@
     "query": {
       "components": [
         {
+          "id": "190276e9-5b90-42d6-8fbd-bc7ddfd4c960",
           "name": "Cadre plastique",
           "processes": [
             {

--- a/public/data/object/examples.json
+++ b/public/data/object/examples.json
@@ -14,7 +14,7 @@
     "scope": "veli",
     "category": "",
     "query": {
-      "components": [{ "name": "Composant par défaut", "processes": [], "quantity": 0 }]
+      "components": []
     }
   },
   {
@@ -26,35 +26,14 @@
       "components": [
         {
           "id": "64fa65b3-c2df-4fd0-958b-83965bd6aa08",
-          "name": "Pied 70 cm (plein bois)",
-          "processes": [
-            {
-              "process_id": "07e9e916-e02b-45e2-a298-2b5084de6242",
-              "amount": 0.00022
-            }
-          ],
           "quantity": 4
         },
         {
           "id": "ad9d7f23-076b-49c5-93a4-ee1cd7b53973",
-          "name": "Dossier plastique (PP)",
-          "processes": [
-            {
-              "process_id": "3295b2a5-328a-4c00-b046-e2ddeb0da823",
-              "amount": 0.734063
-            }
-          ],
           "quantity": 1
         },
         {
           "id": "eda5dd7e-52e4-450f-8658-1876efc62bd6",
-          "name": "Assise plastique (PP)",
-          "processes": [
-            {
-              "process_id": "3295b2a5-328a-4c00-b046-e2ddeb0da823",
-              "amount": 0.91125
-            }
-          ],
           "quantity": 1
         }
       ]
@@ -69,24 +48,10 @@
       "components": [
         {
           "id": "6f8d1621-324a-4c00-abe3-f90813d878d2",
-          "name": "Pied 90 cm (plein bois)",
-          "processes": [
-            {
-              "process_id": "07e9e916-e02b-45e2-a298-2b5084de6242",
-              "amount": 0.007065
-            }
-          ],
           "quantity": 4
         },
         {
           "id": "3d1ba21f-a139-4e1f-8192-082327ad855e",
-          "name": "Plateau 200x100 (chêne)",
-          "processes": [
-            {
-              "process_id": "07e9e916-e02b-45e2-a298-2b5084de6242",
-              "amount": 0.14
-            }
-          ],
           "quantity": 1
         }
       ]
@@ -101,13 +66,6 @@
       "components": [
         {
           "id": "190276e9-5b90-42d6-8fbd-bc7ddfd4c960",
-          "name": "Cadre plastique",
-          "processes": [
-            {
-              "process_id": "3295b2a5-328a-4c00-b046-e2ddeb0da823",
-              "amount": 35
-            }
-          ],
           "quantity": 1
         }
       ]

--- a/public/data/object/examples.json
+++ b/public/data/object/examples.json
@@ -26,35 +26,14 @@
       "components": [
         {
           "id": "64fa65b3-c2df-4fd0-958b-83965bd6aa08",
-          "name": "Pied 70 cm (plein bois)",
-          "processes": [
-            {
-              "process_id": "07e9e916-e02b-45e2-a298-2b5084de6242",
-              "amount": 0.00022
-            }
-          ],
           "quantity": 4
         },
         {
           "id": "ad9d7f23-076b-49c5-93a4-ee1cd7b53973",
-          "name": "Dossier plastique (PP)",
-          "processes": [
-            {
-              "process_id": "3295b2a5-328a-4c00-b046-e2ddeb0da823",
-              "amount": 0.734063
-            }
-          ],
           "quantity": 1
         },
         {
           "id": "eda5dd7e-52e4-450f-8658-1876efc62bd6",
-          "name": "Assise plastique (PP)",
-          "processes": [
-            {
-              "process_id": "3295b2a5-328a-4c00-b046-e2ddeb0da823",
-              "amount": 0.91125
-            }
-          ],
           "quantity": 1
         }
       ]
@@ -69,24 +48,10 @@
       "components": [
         {
           "id": "6f8d1621-324a-4c00-abe3-f90813d878d2",
-          "name": "Pied 90 cm (plein bois)",
-          "processes": [
-            {
-              "process_id": "07e9e916-e02b-45e2-a298-2b5084de6242",
-              "amount": 0.007065
-            }
-          ],
           "quantity": 4
         },
         {
           "id": "3d1ba21f-a139-4e1f-8192-082327ad855e",
-          "name": "Plateau 200x100 (chêne)",
-          "processes": [
-            {
-              "process_id": "07e9e916-e02b-45e2-a298-2b5084de6242",
-              "amount": 0.14
-            }
-          ],
           "quantity": 1
         }
       ]
@@ -101,13 +66,6 @@
       "components": [
         {
           "id": "190276e9-5b90-42d6-8fbd-bc7ddfd4c960",
-          "name": "Cadre plastique",
-          "processes": [
-            {
-              "process_id": "3295b2a5-328a-4c00-b046-e2ddeb0da823",
-              "amount": 35
-            }
-          ],
           "quantity": 1
         }
       ]

--- a/public/data/object/examples.json
+++ b/public/data/object/examples.json
@@ -26,14 +26,35 @@
       "components": [
         {
           "id": "64fa65b3-c2df-4fd0-958b-83965bd6aa08",
+          "name": "Pied 70 cm (plein bois)",
+          "processes": [
+            {
+              "process_id": "07e9e916-e02b-45e2-a298-2b5084de6242",
+              "amount": 0.00022
+            }
+          ],
           "quantity": 4
         },
         {
           "id": "ad9d7f23-076b-49c5-93a4-ee1cd7b53973",
+          "name": "Dossier plastique (PP)",
+          "processes": [
+            {
+              "process_id": "3295b2a5-328a-4c00-b046-e2ddeb0da823",
+              "amount": 0.734063
+            }
+          ],
           "quantity": 1
         },
         {
           "id": "eda5dd7e-52e4-450f-8658-1876efc62bd6",
+          "name": "Assise plastique (PP)",
+          "processes": [
+            {
+              "process_id": "3295b2a5-328a-4c00-b046-e2ddeb0da823",
+              "amount": 0.91125
+            }
+          ],
           "quantity": 1
         }
       ]
@@ -48,10 +69,24 @@
       "components": [
         {
           "id": "6f8d1621-324a-4c00-abe3-f90813d878d2",
+          "name": "Pied 90 cm (plein bois)",
+          "processes": [
+            {
+              "process_id": "07e9e916-e02b-45e2-a298-2b5084de6242",
+              "amount": 0.007065
+            }
+          ],
           "quantity": 4
         },
         {
           "id": "3d1ba21f-a139-4e1f-8192-082327ad855e",
+          "name": "Plateau 200x100 (chêne)",
+          "processes": [
+            {
+              "process_id": "07e9e916-e02b-45e2-a298-2b5084de6242",
+              "amount": 0.14
+            }
+          ],
           "quantity": 1
         }
       ]
@@ -66,6 +101,13 @@
       "components": [
         {
           "id": "190276e9-5b90-42d6-8fbd-bc7ddfd4c960",
+          "name": "Cadre plastique",
+          "processes": [
+            {
+              "process_id": "3295b2a5-328a-4c00-b046-e2ddeb0da823",
+              "amount": 35
+            }
+          ],
           "quantity": 1
         }
       ]

--- a/src/Data/Bookmark.elm
+++ b/src/Data/Bookmark.elm
@@ -204,7 +204,7 @@ toQueryDescription db bookmark =
 
         Object objectQuery ->
             objectQuery
-                |> ObjectQuery.toString db.object.processes
+                |> ObjectQuery.toString db.object.components db.object.processes
                 |> Result.withDefault "N/A"
 
         Textile textileQuery ->
@@ -215,5 +215,5 @@ toQueryDescription db bookmark =
 
         Veli objectQuery ->
             objectQuery
-                |> ObjectQuery.toString db.object.processes
+                |> ObjectQuery.toString db.object.components db.object.processes
                 |> Result.withDefault "N/A"

--- a/src/Data/Dataset.elm
+++ b/src/Data/Dataset.elm
@@ -14,6 +14,7 @@ import Data.Country as Country
 import Data.Food.Ingredient as Ingredient
 import Data.Food.Process as FoodProcess
 import Data.Impact.Definition as Definition
+import Data.Object.Component as ObjectComponent
 import Data.Object.Process as ObjectProcess
 import Data.Scope as Scope exposing (Scope)
 import Data.Textile.Material as Material
@@ -34,6 +35,7 @@ type Dataset
     | FoodIngredients (Maybe Ingredient.Id)
     | FoodProcesses (Maybe FoodProcess.Identifier)
     | Impacts (Maybe Definition.Trigram)
+    | ObjectComponents (Maybe ObjectComponent.Id)
     | ObjectExamples (Maybe Uuid)
     | ObjectProcesses (Maybe ObjectProcess.Id)
     | TextileExamples (Maybe Uuid)
@@ -54,9 +56,10 @@ datasets scope =
             ]
 
         Scope.Object ->
-            [ Impacts Nothing
-            , ObjectExamples Nothing
+            [ ObjectExamples Nothing
+            , ObjectComponents Nothing
             , ObjectProcesses Nothing
+            , Impacts Nothing
             ]
 
         Scope.Textile ->
@@ -94,6 +97,9 @@ fromSlug string =
         "materials" ->
             TextileMaterials Nothing
 
+        "object-components" ->
+            ObjectComponents Nothing
+
         "object-examples" ->
             ObjectExamples Nothing
 
@@ -126,6 +132,9 @@ isDetailed dataset =
             True
 
         Impacts (Just _) ->
+            True
+
+        ObjectComponents (Just _) ->
             True
 
         ObjectExamples (Just _) ->
@@ -178,6 +187,9 @@ reset dataset =
         Impacts _ ->
             Impacts Nothing
 
+        ObjectComponents _ ->
+            ObjectComponents Nothing
+
         ObjectExamples _ ->
             ObjectExamples Nothing
 
@@ -218,6 +230,9 @@ same a b =
         ( TextileExamples _, TextileExamples _ ) ->
             True
 
+        ( ObjectComponents _, ObjectComponents _ ) ->
+            True
+
         ( ObjectExamples _, ObjectExamples _ ) ->
             True
 
@@ -254,6 +269,9 @@ setIdFromString idString dataset =
 
         Impacts _ ->
             Impacts (Definition.toTrigram idString |> Result.toMaybe)
+
+        ObjectComponents _ ->
+            ObjectComponents (ObjectComponent.idFromString idString)
 
         ObjectExamples _ ->
             ObjectExamples (Uuid.fromString idString)
@@ -296,6 +314,9 @@ strings dataset =
 
         Impacts _ ->
             { label = "Impacts", slug = "impacts" }
+
+        ObjectComponents _ ->
+            { label = "Composants", slug = "object-components" }
 
         ObjectExamples _ ->
             { label = "Exemples", slug = "object-examples" }
@@ -347,6 +368,12 @@ toRoutePath dataset =
             [ slug dataset, Definition.toString trigram ]
 
         Impacts Nothing ->
+            [ slug dataset ]
+
+        ObjectComponents (Just id) ->
+            [ slug dataset, ObjectComponent.idToString id ]
+
+        ObjectComponents Nothing ->
             [ slug dataset ]
 
         ObjectExamples (Just id) ->

--- a/src/Data/Object/Component.elm
+++ b/src/Data/Object/Component.elm
@@ -1,0 +1,64 @@
+module Data.Object.Component exposing (Component)
+
+import Data.Object.Process as Process exposing (Process)
+import Data.Uuid as Uuid exposing (Uuid)
+import Json.Decode as Decode exposing (Decoder)
+import Json.Decode.Pipeline as JDP
+import Json.Encode as Encode
+
+
+type Id
+    = Id Uuid
+
+
+type alias Component =
+    { id : Id
+    , name : String
+    , processes : List ProcessItem
+    , quantity : Quantity
+    }
+
+
+type alias ProcessItem =
+    { amount : Amount
+    , processId : Process.Id
+    }
+
+
+type Amount
+    = Amount Float
+
+
+type Quantity
+    = Quantity Int
+
+
+amountToFloat : Amount -> Float
+amountToFloat (Amount float) =
+    float
+
+
+quantity : Int -> Quantity
+quantity int =
+    Quantity int
+
+
+quantityToInt : Quantity -> Int
+quantityToInt (Quantity int) =
+    int
+
+
+decode : Decoder Component
+decode =
+    Decode.succeed Component
+        |> JDP.required "id" (Decode.map Id Uuid.decoder)
+        |> JDP.required "name" Decode.string
+        |> JDP.required "processes" (Decode.list decodeProcessItem)
+        |> JDP.required "quantity" (Decode.map Quantity Decode.int)
+
+
+decodeProcessItem : Decoder ProcessItem
+decodeProcessItem =
+    Decode.map2 ProcessItem
+        (Decode.field "amount" (Decode.map Amount Decode.float))
+        (Decode.field "process_id" Process.decodeId)

--- a/src/Data/Object/Component.elm
+++ b/src/Data/Object/Component.elm
@@ -1,13 +1,20 @@
 module Data.Object.Component exposing
-    ( Component
+    ( Amount
+    , Component
     , ComponentItem
+    , Id
     , ProcessItem
+    , Quantity
     , amountToFloat
+    , decodeComponentItem
     , decodeList
+    , encodeComponentItem
+    , findById
+    , quantityFromInt
     , quantityToInt
     )
 
-import Data.Object.Process as Process exposing (Process)
+import Data.Object.Process as Process
 import Data.Uuid as Uuid exposing (Uuid)
 import Json.Decode as Decode exposing (Decoder)
 import Json.Decode.Pipeline as JDP
@@ -107,13 +114,20 @@ extractUuid (Id uuid) =
     uuid
 
 
+findById : Id -> List Component -> Result String Component
+findById id =
+    List.filter (.id >> (==) id)
+        >> List.head
+        >> Result.fromMaybe ("Aucun composant avec id=" ++ idToString id)
+
+
 idToString : Id -> String
 idToString (Id uuid) =
     Uuid.toString uuid
 
 
-quantity : Int -> Quantity
-quantity int =
+quantityFromInt : Int -> Quantity
+quantityFromInt int =
     Quantity int
 
 

--- a/src/Data/Object/Component.elm
+++ b/src/Data/Object/Component.elm
@@ -84,34 +84,12 @@ decodeProcessItem =
         (Decode.field "process_id" Process.decodeId)
 
 
-encode : Component -> Encode.Value
-encode item =
-    Encode.object
-        [ ( "id", item.id |> extractUuid |> Uuid.encoder )
-        , ( "name", item.name |> Encode.string )
-        , ( "processes", item.processes |> Encode.list encodeProcessItem )
-        ]
-
-
 encodeComponentItem : ComponentItem -> Encode.Value
 encodeComponentItem componentItem =
     Encode.object
         [ ( "id", componentItem.id |> idToString |> Encode.string )
         , ( "quantity", componentItem.quantity |> quantityToInt |> Encode.int )
         ]
-
-
-encodeProcessItem : ProcessItem -> Encode.Value
-encodeProcessItem processItem =
-    Encode.object
-        [ ( "amount", processItem.amount |> amountToFloat |> Encode.float )
-        , ( "process_id", Process.encodeId processItem.processId )
-        ]
-
-
-extractUuid : Id -> Uuid
-extractUuid (Id uuid) =
-    uuid
 
 
 findById : Id -> List Component -> Result String Component

--- a/src/Data/Object/Component.elm
+++ b/src/Data/Object/Component.elm
@@ -1,4 +1,11 @@
-module Data.Object.Component exposing (Component)
+module Data.Object.Component exposing
+    ( Component
+    , ComponentItem
+    , ProcessItem
+    , amountToFloat
+    , decodeList
+    , quantityToInt
+    )
 
 import Data.Object.Process as Process exposing (Process)
 import Data.Uuid as Uuid exposing (Uuid)
@@ -15,6 +22,11 @@ type alias Component =
     { id : Id
     , name : String
     , processes : List ProcessItem
+    }
+
+
+type alias ComponentItem =
+    { id : Id
     , quantity : Quantity
     }
 
@@ -38,22 +50,23 @@ amountToFloat (Amount float) =
     float
 
 
-quantity : Int -> Quantity
-quantity int =
-    Quantity int
-
-
-quantityToInt : Quantity -> Int
-quantityToInt (Quantity int) =
-    int
-
-
 decode : Decoder Component
 decode =
     Decode.succeed Component
         |> JDP.required "id" (Decode.map Id Uuid.decoder)
         |> JDP.required "name" Decode.string
         |> JDP.required "processes" (Decode.list decodeProcessItem)
+
+
+decodeList : Decoder (List Component)
+decodeList =
+    Decode.list decode
+
+
+decodeComponentItem : Decoder ComponentItem
+decodeComponentItem =
+    Decode.succeed ComponentItem
+        |> JDP.required "id" (Decode.map Id Uuid.decoder)
         |> JDP.required "quantity" (Decode.map Quantity Decode.int)
 
 
@@ -62,3 +75,48 @@ decodeProcessItem =
     Decode.map2 ProcessItem
         (Decode.field "amount" (Decode.map Amount Decode.float))
         (Decode.field "process_id" Process.decodeId)
+
+
+encode : Component -> Encode.Value
+encode item =
+    Encode.object
+        [ ( "id", item.id |> extractUuid |> Uuid.encoder )
+        , ( "name", item.name |> Encode.string )
+        , ( "processes", item.processes |> Encode.list encodeProcessItem )
+        ]
+
+
+encodeComponentItem : ComponentItem -> Encode.Value
+encodeComponentItem componentItem =
+    Encode.object
+        [ ( "id", componentItem.id |> idToString |> Encode.string )
+        , ( "quantity", componentItem.quantity |> quantityToInt |> Encode.int )
+        ]
+
+
+encodeProcessItem : ProcessItem -> Encode.Value
+encodeProcessItem processItem =
+    Encode.object
+        [ ( "amount", processItem.amount |> amountToFloat |> Encode.float )
+        , ( "process_id", Process.encodeId processItem.processId )
+        ]
+
+
+extractUuid : Id -> Uuid
+extractUuid (Id uuid) =
+    uuid
+
+
+idToString : Id -> String
+idToString (Id uuid) =
+    Uuid.toString uuid
+
+
+quantity : Int -> Quantity
+quantity int =
+    Quantity int
+
+
+quantityToInt : Quantity -> Int
+quantityToInt (Quantity int) =
+    int

--- a/src/Data/Object/Component.elm
+++ b/src/Data/Object/Component.elm
@@ -11,6 +11,8 @@ module Data.Object.Component exposing
     , decodeList
     , encodeComponentItem
     , findById
+    , idFromString
+    , idToString
     , quantityFromInt
     , quantityToInt
     )
@@ -133,6 +135,11 @@ findById id =
     List.filter (.id >> (==) id)
         >> List.head
         >> Result.fromMaybe ("Aucun composant avec id=" ++ idToString id)
+
+
+idFromString : String -> Maybe Id
+idFromString str =
+    Uuid.fromString str |> Maybe.map Id
 
 
 idToString : Id -> String

--- a/src/Data/Object/Process.elm
+++ b/src/Data/Object/Process.elm
@@ -4,7 +4,6 @@ module Data.Object.Process exposing
     , decodeId
     , decodeList
     , encode
-    , encodeId
     , findById
     , idFromString
     , idToString

--- a/src/Data/Object/Query.elm
+++ b/src/Data/Object/Query.elm
@@ -14,7 +14,7 @@ module Data.Object.Query exposing
 
 import Base64
 import Data.Object.Component as Component exposing (Component, ComponentItem)
-import Data.Object.Process as Process exposing (Process)
+import Data.Object.Process exposing (Process)
 import Data.Scope as Scope exposing (Scope)
 import Json.Decode as Decode exposing (Decoder)
 import Json.Decode.Pipeline as Pipe
@@ -71,7 +71,11 @@ addComponentItem id query =
 
 removeComponent : Component.Id -> Query -> Query
 removeComponent id ({ components } as query) =
-    { query | components = components |> List.filter (.id >> (/=) id) }
+    { query
+        | components =
+            components
+                |> List.filter (.id >> (/=) id)
+    }
 
 
 updateComponentItem : ComponentItem -> Query -> Query
@@ -91,44 +95,10 @@ updateComponentItem newItem query =
 
 
 toString : List Component -> List Process -> Query -> Result String String
-toString components processes =
-    .components
-        >> RE.combineMap (componentItemToString components processes)
-        >> Result.map (String.join ", ")
-
-
-componentItemToString : List Component -> List Process -> ComponentItem -> Result String String
-componentItemToString components processes componentItem =
-    case Component.findById componentItem.id components of
-        Err err ->
-            Err err
-
-        Ok component ->
-            component.processes
-                |> RE.combineMap (processItemToString processes)
-                |> Result.map (String.join " | ")
-                |> Result.map
-                    (\processesString ->
-                        String.fromInt (Component.quantityToInt componentItem.quantity)
-                            ++ " "
-                            ++ component.name
-                            ++ " [ "
-                            ++ processesString
-                            ++ " ]"
-                    )
-
-
-processItemToString : List Process -> Component.ProcessItem -> Result String String
-processItemToString processes processItem =
-    processItem.processId
-        |> Process.findById processes
-        |> Result.map
-            (\process ->
-                String.fromFloat (Component.amountToFloat processItem.amount)
-                    ++ process.unit
-                    ++ " "
-                    ++ process.displayName
-            )
+toString components processes query =
+    query.components
+        |> RE.combineMap (Component.componentItemToString components processes)
+        |> Result.map (String.join ", ")
 
 
 

--- a/src/Data/Object/Query.elm
+++ b/src/Data/Object/Query.elm
@@ -84,11 +84,11 @@ buildApiQuery scope clientUrl query =
 decode : Decoder Query
 decode =
     Decode.succeed Query
-        |> Pipe.required "components" (Decode.list decodeItem)
+        |> Pipe.required "components" (Decode.list decodeComponent)
 
 
-decodeItem : Decoder Component
-decodeItem =
+decodeComponent : Decoder Component
+decodeComponent =
     Decode.map3 Component
         (Decode.field "name" Decode.string)
         (Decode.field "processes" (Decode.list decodeProcessItem))

--- a/src/Data/Object/Query.elm
+++ b/src/Data/Object/Query.elm
@@ -84,7 +84,7 @@ buildApiQuery scope clientUrl query =
 decode : Decoder Query
 decode =
     Decode.succeed Query
-        |> Pipe.required "items" (Decode.list decodeItem)
+        |> Pipe.required "components" (Decode.list decodeItem)
 
 
 decodeItem : Decoder Component
@@ -118,7 +118,7 @@ defaultComponent =
 encode : Query -> Encode.Value
 encode query =
     Encode.object
-        [ ( "items"
+        [ ( "components"
           , Encode.list encodeItem query.components
           )
         ]

--- a/src/Data/Object/Simulator.elm
+++ b/src/Data/Object/Simulator.elm
@@ -4,6 +4,7 @@ module Data.Object.Simulator exposing
     , compute
     , emptyResults
     , expandProcessItems
+    , expandProcesses
     , extractImpacts
     , extractItems
     , extractMass

--- a/src/Data/Object/Simulator.elm
+++ b/src/Data/Object/Simulator.elm
@@ -3,8 +3,6 @@ module Data.Object.Simulator exposing
     , availableComponents
     , compute
     , emptyResults
-    , expandProcessItems
-    , expandProcesses
     , extractImpacts
     , extractItems
     , extractMass
@@ -14,7 +12,7 @@ module Data.Object.Simulator exposing
 import Data.Impact as Impact exposing (Impacts, noStepsImpacts)
 import Data.Impact.Definition as Definition
 import Data.Object.Component as Component exposing (Component, ComponentItem, ProcessItem)
-import Data.Object.Process as Process exposing (Process)
+import Data.Object.Process as Process
 import Data.Object.Query exposing (Query)
 import Mass exposing (Mass)
 import Quantity
@@ -111,31 +109,6 @@ emptyResults =
         , items = []
         , mass = Quantity.zero
         }
-
-
-expandProcessItems : Db -> Query -> Result String (List ( Component.Quantity, Component, List ( Component.Amount, Process ) ))
-expandProcessItems db =
-    .components
-        >> List.map
-            (\componentItem ->
-                db.object.components
-                    |> Component.findById componentItem.id
-                    |> Result.andThen
-                        (\component ->
-                            component.processes
-                                |> expandProcesses db
-                                |> Result.map (\processes -> ( componentItem.quantity, component, processes ))
-                        )
-            )
-        >> RE.combine
-
-
-expandProcesses : Db -> List ProcessItem -> Result String (List ( Component.Amount, Process ))
-expandProcesses db processes =
-    processes
-        |> List.map (\{ amount, processId } -> ( amount, processId ))
-        |> List.map (RE.combineMapSecond (Process.findById db.object.processes))
-        |> RE.combine
 
 
 extractImpacts : Results -> Impacts

--- a/src/Data/Object/Simulator.elm
+++ b/src/Data/Object/Simulator.elm
@@ -14,8 +14,7 @@ import Data.Impact as Impact exposing (Impacts, noStepsImpacts)
 import Data.Impact.Definition as Definition
 import Data.Object.Component as Component exposing (Component, ComponentItem, ProcessItem)
 import Data.Object.Process as Process exposing (Process)
-import Data.Object.Query as Query exposing (Query)
-import List.Extra as LE
+import Data.Object.Query exposing (Query)
 import Mass exposing (Mass)
 import Quantity
 import Result.Extra as RE

--- a/src/Page/Explore.elm
+++ b/src/Page/Explore.elm
@@ -428,7 +428,7 @@ objectComponentsExplorer :
 objectComponentsExplorer db tableConfig tableState maybeId =
     [ db.object.components
         |> List.sortBy .name
-        |> Table.viewList OpenDetail tableConfig tableState Scope.Object ObjectComponents.table
+        |> Table.viewList OpenDetail tableConfig tableState Scope.Object (ObjectComponents.table db)
     , case maybeId of
         Just id ->
             detailsModal
@@ -438,7 +438,7 @@ objectComponentsExplorer db tableConfig tableState maybeId =
 
                     Ok component ->
                         component
-                            |> Table.viewDetails Scope.Object ObjectComponents.table
+                            |> Table.viewDetails Scope.Object (ObjectComponents.table db)
                 )
 
         Nothing ->

--- a/src/Page/Explore.elm
+++ b/src/Page/Explore.elm
@@ -22,6 +22,7 @@ import Data.Food.Recipe as Recipe
 import Data.Impact as Impact
 import Data.Impact.Definition as Definition exposing (Definition, Definitions)
 import Data.Key as Key
+import Data.Object.Component as ObjectComponent
 import Data.Object.Process as ObjectProcess
 import Data.Object.Query as ObjectQuery
 import Data.Object.Simulator as ObjectSimulator
@@ -42,6 +43,7 @@ import Page.Explore.FoodExamples as FoodExamples
 import Page.Explore.FoodIngredients as FoodIngredients
 import Page.Explore.FoodProcesses as FoodProcesses
 import Page.Explore.Impacts as ExploreImpacts
+import Page.Explore.ObjectComponents as ObjectComponents
 import Page.Explore.ObjectExamples as ObjectExamples
 import Page.Explore.ObjectProcesses as ObjectProcesses
 import Page.Explore.Table as Table
@@ -91,6 +93,9 @@ init scope dataset session =
 
                 Dataset.Impacts _ ->
                     "Code"
+
+                Dataset.ObjectComponents _ ->
+                    "Nom"
 
                 Dataset.ObjectExamples _ ->
                     "Coût Environnemental"
@@ -414,6 +419,33 @@ foodProcessesExplorer { food } tableConfig tableState maybeId =
     ]
 
 
+objectComponentsExplorer :
+    Db
+    -> Table.Config ObjectComponent.Component Msg
+    -> SortableTable.State
+    -> Maybe ObjectComponent.Id
+    -> List (Html Msg)
+objectComponentsExplorer db tableConfig tableState maybeId =
+    [ db.object.components
+        |> List.sortBy .name
+        |> Table.viewList OpenDetail tableConfig tableState Scope.Object ObjectComponents.table
+    , case maybeId of
+        Just id ->
+            detailsModal
+                (case ObjectComponent.findById id db.object.components of
+                    Err error ->
+                        alert error
+
+                    Ok component ->
+                        component
+                            |> Table.viewDetails Scope.Object ObjectComponents.table
+                )
+
+        Nothing ->
+            text ""
+    ]
+
+
 objectExamplesExplorer :
     Db
     -> Table.Config ( Example ObjectQuery.Query, { score : Float } ) Msg
@@ -707,6 +739,9 @@ explore { db } { scope, dataset, tableState } =
 
         Dataset.Impacts maybeTrigram ->
             impactsExplorer db.definitions tableConfig tableState scope maybeTrigram
+
+        Dataset.ObjectComponents maybeId ->
+            objectComponentsExplorer db tableConfig tableState maybeId
 
         Dataset.ObjectExamples maybeId ->
             objectExamplesExplorer db tableConfig tableState maybeId

--- a/src/Page/Explore/ObjectComponents.elm
+++ b/src/Page/Explore/ObjectComponents.elm
@@ -2,7 +2,6 @@ module Page.Explore.ObjectComponents exposing (table)
 
 import Data.Dataset as Dataset
 import Data.Object.Component as ObjectComponent
-import Data.Object.Simulator as Simulator
 import Data.Scope exposing (Scope)
 import Html exposing (..)
 import Html.Attributes exposing (..)
@@ -39,7 +38,7 @@ table db { detailed, scope } =
           , toValue =
                 Table.StringValue <|
                     \{ processes } ->
-                        case Simulator.expandProcesses db processes of
+                        case ObjectComponent.expandProcessItems db.object.processes processes of
                             Err _ ->
                                 ""
 
@@ -55,7 +54,7 @@ table db { detailed, scope } =
                                     |> String.join ", "
           , toCell =
                 \{ processes } ->
-                    case Simulator.expandProcesses db processes of
+                    case ObjectComponent.expandProcessItems db.object.processes processes of
                         Err err ->
                             Alert.simple
                                 { close = Nothing

--- a/src/Page/Explore/ObjectComponents.elm
+++ b/src/Page/Explore/ObjectComponents.elm
@@ -1,0 +1,34 @@
+module Page.Explore.ObjectComponents exposing (table)
+
+import Data.Dataset as Dataset
+import Data.Object.Component as ObjectComponent
+import Data.Scope exposing (Scope)
+import Html exposing (..)
+import Page.Explore.Table as Table exposing (Table)
+import Route
+
+
+table : { detailed : Bool, scope : Scope } -> Table ObjectComponent.Component String msg
+table { detailed, scope } =
+    { filename = "components"
+    , toId = .id >> ObjectComponent.idToString
+    , toRoute = .id >> Just >> Dataset.ObjectComponents >> Route.Explore scope
+    , legend = []
+    , columns =
+        [ { label = "Identifiant"
+          , toValue = Table.StringValue <| .id >> ObjectComponent.idToString
+          , toCell =
+                \component ->
+                    if detailed then
+                        code [] [ text (ObjectComponent.idToString component.id) ]
+
+                    else
+                        a [ Route.href (Route.Explore scope (Dataset.ObjectComponents (Just component.id))) ]
+                            [ code [] [ text (ObjectComponent.idToString component.id) ] ]
+          }
+        , { label = "Nom"
+          , toValue = Table.StringValue .name
+          , toCell = .name >> text
+          }
+        ]
+    }

--- a/src/Page/Explore/Table.elm
+++ b/src/Page/Explore/Table.elm
@@ -149,12 +149,19 @@ viewList routeToMsg defaultConfig tableState scope createTable items =
 
 toCSV : Table data comparable msg -> List data -> Csv
 toCSV { columns } items =
-    { headers = List.map .label columns
+    let
+        nonEmptyColumns =
+            columns
+                |> List.filter (.label >> (/=) "")
+    in
+    { headers =
+        nonEmptyColumns
+            |> List.map .label
     , records =
         items
             |> List.map
                 (\item ->
-                    columns
+                    nonEmptyColumns
                         |> List.map (.toValue >> valueToString item)
                 )
     }

--- a/src/Page/Object.elm
+++ b/src/Page/Object.elm
@@ -535,7 +535,7 @@ componentListView db { detailedComponents, impact, results } query =
         div [ class "card-body" ] [ text "Aucun élément." ]
 
       else
-        case Simulator.expandProcessItems db query of
+        case Component.expandComponentItems db.object query.components of
             Err error ->
                 Alert.simple
                     { close = Nothing
@@ -568,7 +568,7 @@ componentListView db { detailedComponents, impact, results } query =
 
 
 componentView : Definition -> List Component.Id -> ( Component.Quantity, Component, List ( Component.Amount, Process ) ) -> Results -> List (Html Msg)
-componentView selectedImpact detailedComponents ( quantity, component, processes ) itemResults =
+componentView selectedImpact detailedComponents ( quantity, component, processAmounts ) itemResults =
     let
         collapsed =
             not <| List.member component.id detailedComponents
@@ -627,7 +627,7 @@ componentView selectedImpact detailedComponents ( quantity, component, processes
           ]
         , if not collapsed then
             Simulator.extractItems itemResults
-                |> List.map2 (processView selectedImpact) processes
+                |> List.map2 (processView selectedImpact) processAmounts
 
           else
             []

--- a/src/Page/Object.elm
+++ b/src/Page/Object.elm
@@ -18,6 +18,7 @@ import Data.Dataset as Dataset
 import Data.Example as Example exposing (Example)
 import Data.Impact.Definition as Definition exposing (Definition)
 import Data.Key as Key
+import Data.Object.Component as Component exposing (Component, ComponentItem)
 import Data.Object.Process exposing (Process)
 import Data.Object.Query as Query exposing (Query)
 import Data.Object.Simulator as Simulator exposing (Results)
@@ -27,9 +28,9 @@ import Data.Uuid exposing (Uuid)
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (..)
+import List.Extra as LE
 import Ports
 import Route
-import Set exposing (Set)
 import Static.Db exposing (Db)
 import Task
 import Time exposing (Posix)
@@ -52,7 +53,7 @@ type alias Model =
     , bookmarkName : String
     , bookmarkTab : BookmarkView.ActiveTab
     , comparisonType : ComparatorView.ComparisonType
-    , detailedComponents : Set String
+    , detailedComponents : List Component.Id
     , examples : List (Example Query)
     , impact : Definition
     , initialQuery : Query
@@ -63,7 +64,7 @@ type alias Model =
 
 
 type Modal
-    = AddComponentModal (Autocomplete Query.Component)
+    = AddComponentModal (Autocomplete Component)
     | ComparatorModal
     | NoModal
     | SelectExampleModal (Autocomplete Query)
@@ -73,17 +74,17 @@ type Msg
     = CopyToClipBoard String
     | DeleteBookmark Bookmark
     | NoOp
-    | OnAutocompleteAddComponent (Autocomplete.Msg Query.Component)
+    | OnAutocompleteAddComponent (Autocomplete.Msg Component)
     | OnAutocompleteExample (Autocomplete.Msg Query)
     | OnAutocompleteSelect
     | OnAutocompleteSelectComponent
     | OpenComparator
-    | RemoveComponent String
+    | RemoveComponentItem Component.Id
     | SaveBookmark
     | SaveBookmarkWithTime String Bookmark.Query Posix
     | SelectAllBookmarks
     | SelectNoBookmarks
-    | SetDetailedComponents (Set String)
+    | SetDetailedComponents (List Component.Id)
     | SetModal Modal
     | SwitchBookmarksTab BookmarkView.ActiveTab
     | SwitchComparisonType ComparatorView.ComparisonType
@@ -91,7 +92,7 @@ type Msg
     | SwitchImpactsTab ImpactTabs.Tab
     | ToggleComparedSimulation Bookmark Bool
     | UpdateBookmarkName String
-    | UpdateComponent Query.Component
+    | UpdateComponentItem ComponentItem
 
 
 init : Scope -> Definition.Trigram -> Maybe Query -> Session -> ( Model, Session, Cmd Msg )
@@ -116,7 +117,7 @@ init scope trigram maybeUrlQuery session =
 
             else
                 ComparatorView.Steps
-      , detailedComponents = Set.empty
+      , detailedComponents = []
       , examples = examples
       , impact = Definition.get trigram session.db.definitions
       , initialQuery = initialQuery
@@ -161,7 +162,7 @@ initFromExample session scope uuid =
       , bookmarkName = exampleQuery |> suggestBookmarkName session examples
       , bookmarkTab = BookmarkView.SaveTab
       , comparisonType = ComparatorView.Subscores
-      , detailedComponents = Set.empty
+      , detailedComponents = []
       , examples = examples
       , impact = Definition.get Definition.Ecs session.db.definitions
       , initialQuery = exampleQuery
@@ -286,9 +287,9 @@ update ({ navKey } as session) msg model =
             , Cmd.none
             )
 
-        ( RemoveComponent name, _ ) ->
+        ( RemoveComponentItem id, _ ) ->
             ( model, session, Cmd.none )
-                |> updateQuery (Query.removeComponent name query)
+                |> updateQuery (Query.removeComponent id query)
 
         ( SaveBookmark, _ ) ->
             ( model
@@ -324,7 +325,7 @@ update ({ navKey } as session) msg model =
             ( model, Session.selectNoBookmarks session, Cmd.none )
 
         ( SetDetailedComponents detailedComponents, _ ) ->
-            ( { model | detailedComponents = detailedComponents }
+            ( { model | detailedComponents = LE.unique detailedComponents }
             , session
             , Cmd.none
             )
@@ -392,9 +393,9 @@ update ({ navKey } as session) msg model =
         ( UpdateBookmarkName newName, _ ) ->
             ( { model | bookmarkName = newName }, session, Cmd.none )
 
-        ( UpdateComponent component, _ ) ->
+        ( UpdateComponentItem component, _ ) ->
             ( model, session, Cmd.none )
-                |> updateQuery (Query.updateComponent component query)
+                |> updateQuery (Query.updateComponentItem component query)
 
 
 commandsForNoModal : Modal -> Cmd Msg
@@ -422,15 +423,15 @@ selectExample autocompleteState ( model, session, _ ) =
         |> updateQuery exampleQuery
 
 
-selectComponent : Query -> Autocomplete Query.Component -> ( Model, Session, Cmd Msg ) -> ( Model, Session, Cmd Msg )
+selectComponent : Query -> Autocomplete Component -> ( Model, Session, Cmd Msg ) -> ( Model, Session, Cmd Msg )
 selectComponent query autocompleteState ( model, session, _ ) =
-    let
-        selectedComponent =
-            Autocomplete.selectedValue autocompleteState
-                |> Maybe.withDefault Query.defaultComponent
-    in
-    update session (SetModal NoModal) model
-        |> updateQuery { query | components = query.components ++ [ selectedComponent ] }
+    case Autocomplete.selectedValue autocompleteState of
+        Just component ->
+            update session (SetModal NoModal) model
+                |> updateQuery (Query.addComponentItem component.id query)
+
+        Nothing ->
+            ( model, session |> Session.notifyError "Erreur" "Aucun composant sélectionné", Cmd.none )
 
 
 simulatorView : Session -> Model -> Html Msg
@@ -534,7 +535,7 @@ componentListView db { detailedComponents, impact, results } query =
         div [ class "card-body" ] [ text "Aucun élément." ]
 
       else
-        case Simulator.expandItems db query of
+        case Simulator.expandProcessItems db query of
             Err error ->
                 Alert.simple
                     { close = Nothing
@@ -543,7 +544,7 @@ componentListView db { detailedComponents, impact, results } query =
                     , title = Just "Erreur"
                     }
 
-            Ok items ->
+            Ok elements ->
                 div [ class "table-responsive" ]
                     [ table [ class "table mb-0" ]
                         [ thead []
@@ -557,7 +558,7 @@ componentListView db { detailedComponents, impact, results } query =
                                 ]
                             ]
                         , Simulator.extractItems results
-                            |> List.map2 (componentView impact detailedComponents) items
+                            |> List.map2 (componentView impact detailedComponents) elements
                             |> List.concat
                             |> tbody []
                         ]
@@ -566,11 +567,11 @@ componentListView db { detailedComponents, impact, results } query =
     ]
 
 
-componentView : Definition -> Set String -> ( Query.Quantity, String, List ( Query.Amount, Process ) ) -> Results -> List (Html Msg)
-componentView selectedImpact detailedComponents ( quantity, name, processes ) itemResults =
+componentView : Definition -> List Component.Id -> ( Component.Quantity, Component, List ( Component.Amount, Process ) ) -> Results -> List (Html Msg)
+componentView selectedImpact detailedComponents ( quantity, component, processes ) itemResults =
     let
         collapsed =
-            not <| Set.member name detailedComponents
+            not <| List.member component.id detailedComponents
     in
     List.concat
         [ [ tr []
@@ -579,11 +580,11 @@ componentView selectedImpact detailedComponents ( quantity, name, processes ) it
                         [ class "btn btn-link text-dark text-decoration-none font-monospace fs-5  p-0 m-0"
                         , onClick <|
                             SetDetailedComponents
-                                (if collapsed then
-                                    Set.insert name detailedComponents
+                                (if collapsed && not (List.member component.id detailedComponents) then
+                                    LE.unique <| component.id :: detailedComponents
 
                                  else
-                                    Set.remove name detailedComponents
+                                    List.filter ((/=) component.id) detailedComponents
                                 )
                         ]
                         [ if collapsed then
@@ -594,15 +595,19 @@ componentView selectedImpact detailedComponents ( quantity, name, processes ) it
                         ]
                     ]
                 , td [ class "ps-0 align-middle" ]
-                    [ quantity |> quantityInput processes name ]
+                    [ quantity |> quantityInput component.id ]
                 , td [ class "align-middle text-truncate w-100 fw-bold", colspan 2 ]
-                    [ text name ]
+                    [ text component.name ]
                 , td [ class "text-end align-middle text-nowrap" ]
-                    [ Format.kg <| Simulator.extractMass itemResults ]
+                    [ Simulator.extractMass itemResults
+                        |> Format.kg
+                    ]
                 , td [ class "text-end align-middle text-nowrap" ]
-                    [ Simulator.extractImpacts itemResults |> Format.formatImpact selectedImpact ]
+                    [ Simulator.extractImpacts itemResults
+                        |> Format.formatImpact selectedImpact
+                    ]
                 , td [ class "pe-3 align-middle text-nowrap" ]
-                    [ button [ class "btn btn-outline-secondary", onClick (RemoveComponent name) ]
+                    [ button [ class "btn btn-outline-secondary", onClick (RemoveComponentItem component.id) ]
                         [ Icon.trash ]
                     ]
                 ]
@@ -629,7 +634,7 @@ componentView selectedImpact detailedComponents ( quantity, name, processes ) it
         ]
 
 
-processView : Definition -> ( Query.Amount, Process ) -> Results -> Html Msg
+processView : Definition -> ( Component.Amount, Process ) -> Results -> Html Msg
 processView selectedImpact ( amount, process ) itemResults =
     tr [ class "fs-7" ]
         [ td [] []
@@ -650,13 +655,13 @@ processView selectedImpact ( amount, process ) itemResults =
         ]
 
 
-quantityInput : List ( Query.Amount, Process ) -> String -> Query.Quantity -> Html Msg
-quantityInput processes name quantity =
+quantityInput : Component.Id -> Component.Quantity -> Html Msg
+quantityInput id quantity =
     div [ class "input-group", style "min-width" "90px", style "max-width" "120px" ]
         [ input
             [ type_ "number"
             , class "form-control text-end"
-            , quantity |> Query.quantityToInt |> String.fromInt |> value
+            , quantity |> Component.quantityToInt |> String.fromInt |> value
             , step "1"
             , Html.Attributes.min "1"
             , onInput <|
@@ -672,12 +677,9 @@ quantityInput processes name quantity =
                             )
                         |> Maybe.map
                             (\nonNullInt ->
-                                -- FIX: don't update components based on their name
-                                -- swith to components ids as soon as they are implemented
-                                UpdateComponent
-                                    { name = name
-                                    , quantity = Query.quantity nonNullInt
-                                    , processes = processes |> List.map (\( amount, process ) -> { amount = amount, processId = process.id })
+                                UpdateComponentItem
+                                    { id = id
+                                    , quantity = Component.quantityFromInt nonNullInt
                                     }
                             )
                         |> Maybe.withDefault NoOp

--- a/src/Page/Object.elm
+++ b/src/Page/Object.elm
@@ -200,7 +200,7 @@ suggestBookmarkName { db, store } examples query =
             name
 
         _ ->
-            Query.toString db.object.processes query
+            Query.toString db.object.components db.object.processes query
                 |> Result.withDefault "N/A"
 
 

--- a/src/Static/Json.elm-template
+++ b/src/Static/Json.elm-template
@@ -86,6 +86,11 @@ transportsJson =
     """%transportsJson%"""
 
 
+objectComponentsJson : String
+objectComponentsJson =
+   """%objectComponentsJson%"""
+
+
 objectExamplesJson : String
 objectExamplesJson =
    """%objectExamplesJson%"""
@@ -98,7 +103,7 @@ objectProcessesJson =
 
 objectDb : String -> Result String ObjectDb.Db
 objectDb objectProcesses =
-    ObjectDb.buildFromJson objectExamplesJson objectProcesses
+    ObjectDb.buildFromJson objectComponentsJson objectExamplesJson objectProcesses
 
 
 rawJsonProcesses : RawJsonProcesses

--- a/src/Views/Format.elm
+++ b/src/Views/Format.elm
@@ -31,7 +31,6 @@ import Data.Impact as Impact exposing (Impacts)
 import Data.Impact.Definition exposing (Definition)
 import Data.Object.Component as Component
 import Data.Object.Process as ObjectProcess
-import Data.Object.Query as ObjectQuery
 import Data.Split as Split exposing (Split)
 import Data.Textile.Economics as Economics
 import Data.Unit as Unit

--- a/src/Views/Format.elm
+++ b/src/Views/Format.elm
@@ -29,6 +29,7 @@ module Views.Format exposing
 import Area exposing (Area)
 import Data.Impact as Impact exposing (Impacts)
 import Data.Impact.Definition exposing (Definition)
+import Data.Object.Component as Component
 import Data.Object.Process as ObjectProcess
 import Data.Object.Query as ObjectQuery
 import Data.Split as Split exposing (Split)
@@ -154,11 +155,11 @@ complement impact =
         ]
 
 
-amount : ObjectProcess.Process -> ObjectQuery.Amount -> Html msg
+amount : ObjectProcess.Process -> Component.Amount -> Html msg
 amount { unit } amount_ =
     let
         floatAmount =
-            ObjectQuery.amountToFloat amount_
+            Component.amountToFloat amount_
     in
     case unit of
         "kg" ->


### PR DESCRIPTION
## :wrench: Problem

[Notion card](https://www.notion.so/Migrer-les-donn-es-de-composants-Objets-dans-un-fichier-JSON-d-di-et-proposer-une-premi-re-version--d91e4f0aeebb41a8b2ad618389de02b3)

We don't have a components database and explorer for objects and veli just yet. Also, a component db and handling api would establish good foundations for further work with textile trims (though this patch doesn't make components totally generic just yet, but that'd be the next step).

## :cake: Solution

Introduce a components JSON database with reusable default components for objects and veli. Add a component explorer as well.

## :desert_island: How to test

Ensure the explorer works well and that the objects and veli simulators still work as expected. 