### PR TITLE
refactor: patch only AGB, not CTCPA which also contains 'AGB' in the filename

### DIFF
--- a/data/common/import_.py
+++ b/data/common/import_.py
@@ -192,7 +192,7 @@ def import_simapro_csv(
             zf.extractall(path=tempdir)
             unzipped, _ = splitext(join(tempdir, basename(datapath)))
 
-        if "AGB" in datapath:
+        if "AGB3" in datapath:
             print("### Patching Agribalyse...")
             # `yield` is used as a variable in some Simapro parameters. bw2parameters cannot handle it:
             # (sed is faster than Python)


### PR DESCRIPTION
## :wrench: Problem

the Agribalyse source file is patched with sed at import, but CTCPA is also patched and shoud not.

## :cake: Solution

Check we target "AGB3..." and not all files containing "AGB"

## :desert_island: How to test

`make clean import` and check you don't have `sed` errors like that:
`sed: can't read /tmp/tmpepq615gb/Export: No such file or directory`