### PR TITLE
fix: api error on old versions

### DIFF
--- a/server.js
+++ b/server.js
@@ -275,17 +275,11 @@ version.get("/:versionNumber/api", checkVersionAndPath, (req, res) => {
 });
 
 version.all("/:versionNumber/api/*", checkVersionAndPath, bodyParser.json(), async (req, res) => {
-  const foodProcesses = fs
-    .readFileSync(path.join(req.staticDir, "data", "food", "processes_impacts.json"))
-    .toString();
-  const objectProcesses = fs
-    .readFileSync(path.join(req.staticDir, "data", "object", "processes_impacts.json"))
-    .toString();
-  const textileProcesses = fs
-    .readFileSync(path.join(req.staticDir, "data", "textile", "processes_impacts.json"))
-    .toString();
-
-  const processes = { foodProcesses, objectProcesses, textileProcesses };
+  const versionNumber = req.params.versionNumber;
+  const { processesImpacts, processes } = availableVersions.find(
+    (version) => version.dir === versionNumber,
+  );
+  const versionProcesses = await getProcesses(req.headers.token, processesImpacts, processes);
 
   const { Elm } = require(path.join(req.staticDir, "server-app"));
 
@@ -301,7 +295,7 @@ version.all("/:versionNumber/api/*", checkVersionAndPath, bodyParser.json(), asy
     method: req.method,
     url: urlWithoutPrefix,
     body: req.body,
-    processes,
+    processes: versionProcesses,
     jsResponseHandler: ({ status, body }) => {
       res.status(status).send(body);
     },


### PR DESCRIPTION
## :wrench: Problem

Users are reporting errors when using the versioned API.
 
![241209_15-42-32](https://github.com/user-attachments/assets/500e4d50-23cf-4c70-bbab-11418182611e)

We are serving hardcoded versions of the detailed files instead of the one shipped with the release.

## :cake: Solution

Serve the correct files encoded with the release instead of files that don't exist on the disk.

## :desert_island: How to test

`curl https://ecobalyse-pr851.osc-fr1.scalingo.io/versions/v2.7.0/api/textile/countries` should return the country list:

```json
[
  {
    "code": "---",
    "name": "Pays inconnu (par défaut)"
  },
  {
    "code": "REO",
    "name": "Région - Europe de l'Ouest"
  },
  {
    "code": "REE",
    "name": "Région - Europe de l'Est"
  },
  {
    "code": "RAS",
    "name": "Région - Asie"
  },
  {
    "code": "RAF",
    "name": "Région - Afrique"
  },
  {
    "code": "RME",
    "name": "Région - Moyen-Orient"
  },
  {
    "code": "RLA",
    "name": "Région - Amérique Latine"
  },
  {
    "code": "RNA",
    "name": "Région - Amérique du nord"
  },
  {
    "code": "ROC",
    "name": "Région - Océanie"
  },
  {
    "code": "MM",
    "name": "Myanmar"
  },
  {
    "code": "BD",
    "name": "Bangladesh"
  },
  {
    "code": "CN",
    "name": "Chine"
  },
  {
    "code": "FR",
    "name": "France"
  },
  {
    "code": "IN",
    "name": "Inde"
  },
  {
    "code": "KH",
    "name": "Cambodge"
  },
  {
    "code": "MA",
    "name": "Maroc"
  },
  {
    "code": "PK",
    "name": "Pakistan"
  },
  {
    "code": "TN",
    "name": "Tunisie"
  },
  {
    "code": "TR",
    "name": "Turquie"
  },
  {
    "code": "VN",
    "name": "Vietnam"
  }
]
```