### PR TITLE
chore: increase API test timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,6 @@
     ".elm"
   ],
   "jest": {
-    "testTimeout": 50
+    "testTimeout": 100
   }
 }


### PR DESCRIPTION
## :wrench: Problem

Our e2e test suite sometimes fails because of a 50ms timeout exhausted.

## :cake: Solution

50ms is not much, increase that value to 100ms.

## :desert_island: How to test

Test suite should be green.