### PR TITLE
chore(data): remove system_description process field.

### DIFF
--- a/public/data/food/processes.json
+++ b/public/data/food/processes.json
@@ -34,7 +34,6 @@
     },
     "name": "Egg, Bleu Blanc Coeur, outdoor system, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -73,7 +72,6 @@
     },
     "name": "Cow milk, national average, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -112,7 +110,6 @@
     },
     "name": "Cow milk, organic, national average, at farm gate/FR U constructed by Ecobalyse",
     "source": "Ecobalyse",
-    "system_description": "Ecobalyse",
     "unit": "kg",
     "waste": 0
   },
@@ -151,7 +148,6 @@
     },
     "name": "Carrot, organic 2023, national average, at farm gate {FR} U",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -190,7 +186,6 @@
     },
     "name": "Wheat flour, at industrial mill {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -229,7 +224,6 @@
     },
     "name": "Wheat flour, at industrial mill {FR} U [organic], constructed by Ecobalyse",
     "source": "Ecobalyse",
-    "system_description": "Ecobalyse",
     "unit": "kg",
     "waste": 0
   },
@@ -268,7 +262,6 @@
     },
     "name": "Sunflower grain, consumption mix, organic 2023 {FR} U",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -307,7 +300,6 @@
     },
     "name": "Sunflower, organic, animal feed, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -346,7 +338,6 @@
     },
     "name": "Winter rapeseed, organic, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -385,7 +376,6 @@
     },
     "name": "Ground beef, fresh, case ready, for direct consumption, at plant {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -424,7 +414,6 @@
     },
     "name": "Ground beef, fresh, case ready, for direct consumption, at plant {FR} U [organic], constructed by Ecobalyse",
     "source": "Ecobalyse",
-    "system_description": "Ecobalyse",
     "unit": "kg",
     "waste": 0
   },
@@ -463,7 +452,6 @@
     },
     "name": "Cull cow, organic, milk system number 1, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -502,7 +490,6 @@
     },
     "name": "Ground beef, fresh, case ready, for direct consumption, at plant {FR} U [feedlot], constructed by Ecobalyse",
     "source": "Ecobalyse",
-    "system_description": "Ecobalyse",
     "unit": "kg",
     "waste": 0
   },
@@ -541,7 +528,6 @@
     },
     "name": "Ground beef, fresh, case ready, for direct consumption, at plant {FR} U [grass-fed], constructed by Ecobalyse",
     "source": "Ecobalyse",
-    "system_description": "Ecobalyse",
     "unit": "kg",
     "waste": 0
   },
@@ -580,7 +566,6 @@
     },
     "name": "Cooked ham, case ready, at plant {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -619,7 +604,6 @@
     },
     "name": "Cooked ham, case ready, at plant {FR} U [organic], constructed by Ecobalyse",
     "source": "Ecobalyse",
-    "system_description": "Ecobalyse",
     "unit": "kg",
     "waste": 0
   },
@@ -658,7 +642,6 @@
     },
     "name": "Cooked ham, case ready, at plant {FR} U [fr], constructed by Ecobalyse",
     "source": "Ecobalyse",
-    "system_description": "Ecobalyse",
     "unit": "kg",
     "waste": 0
   },
@@ -697,7 +680,6 @@
     },
     "name": "Meat without bone, chicken, for direct consumption {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -736,7 +718,6 @@
     },
     "name": "Meat without bone, chicken, for direct consumption {FR} U [organic], constructed by Ecobalyse",
     "source": "Ecobalyse",
-    "system_description": "Ecobalyse",
     "unit": "kg",
     "waste": 0
   },
@@ -775,7 +756,6 @@
     },
     "name": "Meat without bone, chicken, for direct consumption {FR} U [organic], constructed by Ecobalyse [fr-organic]",
     "source": "Ecobalyse",
-    "system_description": "Ecobalyse",
     "unit": "kg",
     "waste": 0
   },
@@ -814,7 +794,6 @@
     },
     "name": "Rapeseed oil, at oil mill {GLO} - Adapted from WFLDB U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -853,7 +832,6 @@
     },
     "name": "Rapeseed oil, at oil mill {GLO} - Adapted from WFLDB U [organic], constructed by Ecobalyse",
     "source": "Ecobalyse",
-    "system_description": "Ecobalyse",
     "unit": "kg",
     "waste": 0
   },
@@ -892,7 +870,6 @@
     },
     "name": "Sunflower oil, at oil mill {GLO} - Adapted from WFLDB U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -931,7 +908,6 @@
     },
     "name": "Sunflower oil, at oil mill {GLO} - Adapted from WFLDB U [organic], constructed by Ecobalyse",
     "source": "Ecobalyse",
-    "system_description": "Ecobalyse",
     "unit": "kg",
     "waste": 0
   },
@@ -970,7 +946,6 @@
     },
     "name": "Zucchini, springtime, under tunnel, organic, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -1009,7 +984,6 @@
     },
     "name": "Peach, organic, national average, at orchard {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -1048,7 +1022,6 @@
     },
     "name": "Melon, organic, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -1087,7 +1060,6 @@
     },
     "name": "Butter, 82% fat, unsalted, at dairy {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -1126,7 +1098,6 @@
     },
     "name": "Butter, 82% fat, unsalted, at dairy {FR} U [organic], constructed by Ecobalyse",
     "source": "Ecobalyse",
-    "system_description": "Ecobalyse",
     "unit": "kg",
     "waste": 0
   },
@@ -1165,7 +1136,6 @@
     },
     "name": "Steel, unalloyed {RER}| steel production, converter, unalloyed | Cut-off, S - Copied from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -1204,7 +1174,6 @@
     },
     "name": "Packaging film, low density polyethylene {RER}| production | Cut-off, S - Copied from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -1243,7 +1212,6 @@
     },
     "name": "Polystyrene, expandable {RER}| production | Cut-off, S - Copied from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -1282,7 +1250,6 @@
     },
     "name": "Packaging glass, white {RER w/o CH+DE}| production | Cut-off, S - Copied from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -1321,7 +1288,6 @@
     },
     "name": "Polypropylene, granulate {RER}| production | Cut-off, S - Copied from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -1360,7 +1326,6 @@
     },
     "name": "Corrugated board box {RER}| production | Cut-off, S - Copied from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -1399,7 +1364,6 @@
     },
     "name": "Kraft paper {RER}| kraft paper production | Cut-off, S - Copied from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -1438,7 +1402,6 @@
     },
     "name": "Polyvinylchloride, suspension polymerised {RER}| polyvinylchloride production, suspension polymerisation | Cut-off, S - Copied from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -1477,7 +1440,6 @@
     },
     "name": "Polyethylene terephthalate, granulate, bottle grade {RER}| production | Cut-off, S - Copied from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -1516,7 +1478,6 @@
     },
     "name": "Polyethylene, high density, granulate {RER}| production | Cut-off, S - Copied from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -1555,7 +1516,6 @@
     },
     "name": "Aluminium, primary, ingot {RoW}| production | Cut-off, S - Copied from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -1594,7 +1554,6 @@
     },
     "name": "Canning fruits or vegetables, industrial, 1kg of canned product {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -1633,7 +1592,6 @@
     },
     "name": "[Dummy] Mixing, processing, at plant {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -1672,7 +1630,6 @@
     },
     "name": "Cooking, industrial, 1kg of cooked product {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -1711,7 +1668,6 @@
     },
     "name": "Transport, freight, lorry 16-32 metric ton, EURO5 {RER}| transport, freight, lorry 16-32 metric ton, EURO5 | Cut-off, S - Copied from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "t⋅km",
     "waste": 0
   },
@@ -1750,7 +1706,6 @@
     },
     "name": "Transport, freight, sea, container ship {GLO}| transport, freight, sea, container ship | Cut-off, S - Copied from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "t⋅km",
     "waste": 0
   },
@@ -1789,7 +1744,6 @@
     },
     "name": "Transport, freight, aircraft, unspecified {GLO}| market for transport, freight, aircraft, unspecified | Cut-off, S - Copied from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "t⋅km",
     "waste": 0
   },
@@ -1828,7 +1782,6 @@
     },
     "name": "Transport, freight, sea, container ship with reefer, cooling {GLO}| transport, freight, sea, container ship with reefer, cooling | Cut-off, S - Copied from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "t⋅km",
     "waste": 0
   },
@@ -1867,7 +1820,6 @@
     },
     "name": "Transport, freight, lorry with refrigeration machine, 7.5-16 ton, EURO5, R134a refrigerant, cooling {GLO}| transport, freight, lorry with refrigeration machine, 7.5-16 ton, EURO5, R134a refrigerant, cooling | Cut-off, S - Copied from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "t⋅km",
     "waste": 0
   },
@@ -1906,7 +1858,6 @@
     },
     "name": "Electricity, low voltage {FR}| market for | Cut-off, S - Copied from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kWh",
     "waste": 0
   },
@@ -1945,7 +1896,6 @@
     },
     "name": "Tap water {Europe without Switzerland}| market for | Cut-off, S - Copied from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -1984,7 +1934,6 @@
     },
     "name": "Heat, central or small-scale, natural gas {Europe without Switzerland}| market for heat, central or small-scale, natural gas | Cut-off, S - Copied from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "MJ",
     "waste": 0
   },
@@ -2023,7 +1972,6 @@
     },
     "name": "Comte cheese, from cow's milk, at plant {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -2062,7 +2010,6 @@
     },
     "name": "Emmental cheese, from cow's milk, at plant {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -2101,7 +2048,6 @@
     },
     "name": "Mozzarella cheese, from cow's milk, at plant {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -2140,7 +2086,6 @@
     },
     "name": "Carrot, organic 2023, national average, at farm gate {FR} U",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -2179,7 +2124,6 @@
     },
     "name": "Carrot, organic 2023, national average, at farm gate {FR} U",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -2218,7 +2162,6 @@
     },
     "name": "Carrot, organic, Lower Normandy, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -2257,7 +2200,6 @@
     },
     "name": "Winter pea, from intercrop, organic, system number 1, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -2296,7 +2238,6 @@
     },
     "name": "Soybean, national average, animal feed, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -2335,7 +2276,6 @@
     },
     "name": "Soybean, organic, animal feed, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -2374,7 +2314,6 @@
     },
     "name": "Soybean, not associated to deforestation {BR}| market for soybean | Cut-off, U - Adapted from Ecoinvent",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -2413,7 +2352,6 @@
     },
     "name": "Soybean {BR}| market for soybean | Cut-off, U - Copied from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -2452,7 +2390,6 @@
     },
     "name": "Soybean grain dried, stored and transported, processing {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -2491,7 +2428,6 @@
     },
     "name": "Sausage meat, raw, at plant {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -2530,7 +2466,6 @@
     },
     "name": "Toulouse sausage, raw, at plant {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -2569,7 +2504,6 @@
     },
     "name": "Toulouse sausage, cooked, at plant {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -2608,7 +2542,6 @@
     },
     "name": "Plant-based sausage with tofu (vegan), at plant {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -2647,7 +2580,6 @@
     },
     "name": "Tomato paste, 30 degrees Brix, at plant {GLO} - Adapted from WFLDB U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -2686,7 +2618,6 @@
     },
     "name": "Tomato paste, 30 degrees Brix, for double concentrate, at plant {GLO} - Adapted from WFLDB U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -2725,7 +2656,6 @@
     },
     "name": "Meat with bone, beef, for direct consumption {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -2764,7 +2694,6 @@
     },
     "name": "Meat without bone, beef, for direct consumption {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -2803,7 +2732,6 @@
     },
     "name": "Meat without bone, beef, for direct consumption {FR} U [organic], constructed by Ecobalyse",
     "source": "Ecobalyse",
-    "system_description": "Ecobalyse",
     "unit": "kg",
     "waste": 0
   },
@@ -2842,7 +2770,6 @@
     },
     "name": "Durum wheat, semolina, at plant {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -2881,7 +2808,6 @@
     },
     "name": "Sugar, from sugar beet, at sugar refinery {GLO} - Adapted from WFLDB U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -2920,7 +2846,6 @@
     },
     "name": "Dark chocolate, at plant {RER} - Adapted from WFLDB U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -2959,7 +2884,6 @@
     },
     "name": "Meat without bone, chicken, for direct consumption {FR} U [br-max], constructed by Ecobalyse",
     "source": "Ecobalyse",
-    "system_description": "Ecobalyse",
     "unit": "kg",
     "waste": 0
   },
@@ -2998,7 +2922,6 @@
     },
     "name": "Meat without bone, chicken, for direct consumption {FR} U [fr], constructed by Ecobalyse",
     "source": "Ecobalyse",
-    "system_description": "Ecobalyse",
     "unit": "kg",
     "waste": 0
   },
@@ -3037,7 +2960,6 @@
     },
     "name": "Brown sugar, production, at plant {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -3076,7 +2998,6 @@
     },
     "name": "Tea, dried {RoW}| tea production, dried | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -3115,7 +3036,6 @@
     },
     "name": "Coffee, roast and ground, at plant {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -3154,7 +3074,6 @@
     },
     "name": "Black pepper, dried, consumption mix {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -3193,7 +3112,6 @@
     },
     "name": "Milk, powder, skimmed, non rehydrated, at plant {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -3232,7 +3150,6 @@
     },
     "name": "Red Wine, from grape, in a cooperative cellar, packaged, French production mix, at plant, 1 L of red wine (PGi) {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "L",
     "waste": 0
   },
@@ -3271,7 +3188,6 @@
     },
     "name": "Fresh shrimps, China production {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -3310,7 +3226,6 @@
     },
     "name": "Large trout, 2-4kg, conventional, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -3349,7 +3264,6 @@
     },
     "name": "Egg, conventional, indoor system, non-cage, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -3388,7 +3302,6 @@
     },
     "name": "Egg, conventional, indoor system, cage, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -3427,7 +3340,6 @@
     },
     "name": "Egg, conventional, outdoor system, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -3466,7 +3378,6 @@
     },
     "name": "Egg, organic, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -3505,7 +3416,6 @@
     },
     "name": "Grape, integrated, variety mix, Languedoc-Roussillon, at vineyard, organic 2023 {FR} U",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -3544,7 +3454,6 @@
     },
     "name": "Meat without bone, lamb {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -3583,7 +3492,6 @@
     },
     "name": "Meat without bone, lamb {FR} U [organic], constructed by Ecobalyse",
     "source": "Ecobalyse",
-    "system_description": "Ecobalyse",
     "unit": "kg",
     "waste": 0
   },
@@ -3622,7 +3530,6 @@
     },
     "name": "Pear, consumption mix, organic 2023 {FR} U",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -3661,7 +3568,6 @@
     },
     "name": "Carrot, conventional, national average, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -3700,7 +3606,6 @@
     },
     "name": "Carrot {NL}| carrot production | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -3739,7 +3644,6 @@
     },
     "name": "Carrot {RoW}| carrot production | Cut-off, U - Copied from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -3778,7 +3682,6 @@
     },
     "name": "Zucchini, springtime, under tunnel, conventionel, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -3817,7 +3720,6 @@
     },
     "name": "Zucchini, conventional, national average, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -3856,7 +3758,6 @@
     },
     "name": "Pear, conventional, at orchard {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -3895,7 +3796,6 @@
     },
     "name": "Pear {BE}| pear production | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -3934,7 +3834,6 @@
     },
     "name": "Peach, production mix, national average, at orchard {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -3973,7 +3872,6 @@
     },
     "name": "Peach {ES}| peach production | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -4012,7 +3910,6 @@
     },
     "name": "Melon, conventional, national average, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -4051,7 +3948,6 @@
     },
     "name": "Melon, conventional, national average, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -4090,7 +3986,6 @@
     },
     "name": "Ware potato, conventional, for industrial use, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -4129,7 +4024,6 @@
     },
     "name": "Ware potato, conventional, for fresh market, other varieties, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -4168,7 +4062,6 @@
     },
     "name": "Potato starch {GLO}| market for | Cut-off, S - Copied from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -4207,7 +4100,6 @@
     },
     "name": "Wheat grain, feed {GLO}| market for | Cut-off, S - Copied from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -4246,7 +4138,6 @@
     },
     "name": "Onion, national average, at farm {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -4285,7 +4176,6 @@
     },
     "name": "Onion {NL}| onion production | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -4324,7 +4214,6 @@
     },
     "name": "Onion {RoW}| onion production | Cut-off, U - Copied from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -4363,7 +4252,6 @@
     },
     "name": "Zucchini, springtime, under tunnel, conventionel, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -4402,7 +4290,6 @@
     },
     "name": "Zucchini, springtime, under tunnel, conventionel, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -4441,7 +4328,6 @@
     },
     "name": "French bean, conventional, national average, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -4480,7 +4366,6 @@
     },
     "name": "French bean, conventional, national average, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -4519,7 +4404,6 @@
     },
     "name": "French bean, conventional, national average, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -4558,7 +4442,6 @@
     },
     "name": "Lettuce, conventional, national average, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -4597,7 +4480,6 @@
     },
     "name": "Iceberg lettuce {GLO}| production | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -4636,7 +4518,6 @@
     },
     "name": "Iceberg lettuce {GLO}| production | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -4675,7 +4556,6 @@
     },
     "name": "Annual vining pea for industry, Conventional, National average, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -4714,7 +4594,6 @@
     },
     "name": "Annual vining pea for industry, Conventional, National average, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -4753,7 +4632,6 @@
     },
     "name": "Cherry, conventional, national average, at orchard {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -4792,7 +4670,6 @@
     },
     "name": "Lemon {ES}| lemon production | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -4831,7 +4708,6 @@
     },
     "name": "Cherry, conventional, national average, at orchard {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -4870,7 +4746,6 @@
     },
     "name": "Zucchini, springtime, under tunnel, conventionel, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -4909,7 +4784,6 @@
     },
     "name": "Zucchini, conventional, national average, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -4948,7 +4822,6 @@
     },
     "name": "Zucchini, springtime, under tunnel, organic, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -4987,7 +4860,6 @@
     },
     "name": "Tomato, medium size, conventional, heated greenhouse, at greenhouse {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -5026,7 +4898,6 @@
     },
     "name": "Tomato, medium size, conventional, soil based, non-heated greenhouse, at greenhouse {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -5065,7 +4936,6 @@
     },
     "name": "Tomato, fresh grade {ES}| tomato production, fresh grade, in unheated greenhouse | Cut-off, U - Copied from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -5104,7 +4974,6 @@
     },
     "name": "Apricot {FR}| apricot production | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -5143,7 +5012,6 @@
     },
     "name": "Apricot {FR}| apricot production | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -5182,7 +5050,6 @@
     },
     "name": "Hazelnut, in shell, at farm {TR} - Adapted from WFLDB U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -5221,7 +5088,6 @@
     },
     "name": "Hazelnut, in shell, at farm {IT} - Adapted from WFLDB U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -5260,7 +5126,6 @@
     },
     "name": "Hazelnut, unshelled, at plant {IT} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -5299,7 +5164,6 @@
     },
     "name": "Hazelnut, unshelled, at plant {TR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -5338,7 +5202,6 @@
     },
     "name": "Cauliflower, conventional, national average, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -5377,7 +5240,6 @@
     },
     "name": "Cauliflower, organic 2023, national average, at farm gate {FR} U",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -5416,7 +5278,6 @@
     },
     "name": "Cauliflower, winter, organic, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -5455,7 +5316,6 @@
     },
     "name": "Cauliflower, winter, conventional, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -5494,7 +5354,6 @@
     },
     "name": "Leek, national average, at plant {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -5533,7 +5392,6 @@
     },
     "name": "Carrot, conventional, national average, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -5572,7 +5430,6 @@
     },
     "name": "Carrot, conventional, national average, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -5611,7 +5468,6 @@
     },
     "name": "Carrot {NL}| carrot production | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -5650,7 +5506,6 @@
     },
     "name": "Carrot {RoW}| carrot production | Cut-off, U - Copied from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -5689,7 +5544,6 @@
     },
     "name": "Cauliflower, winter, conventional, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -5728,7 +5582,6 @@
     },
     "name": "Chinese cabbage (nappa cabbage or bok choy), consumption mix, organic 2023 {FR} U",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -5767,7 +5620,6 @@
     },
     "name": "Cabbage white {RoW}| cabbage white production | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -5806,7 +5658,6 @@
     },
     "name": "Cauliflower, winter, conventional, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -5845,7 +5696,6 @@
     },
     "name": "Cauliflower, winter, organic, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -5884,7 +5734,6 @@
     },
     "name": "Cabbage red {GLO}| production | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -5923,7 +5772,6 @@
     },
     "name": "Onion, national average, at farm {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -5962,7 +5810,6 @@
     },
     "name": "Orange, fresh grade, at farm {ES} - Adapted from WFLDB U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -6001,7 +5848,6 @@
     },
     "name": "Orange, fresh grade {ZA}| orange production, fresh grade | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -6040,7 +5886,6 @@
     },
     "name": "Olive {ES}| olive production | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -6079,7 +5924,6 @@
     },
     "name": "Rape seed {FR}| production | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -6118,7 +5962,6 @@
     },
     "name": "Rapeseed, at farm {GLO} - Adapted from WFLDB U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -6157,7 +6000,6 @@
     },
     "name": "Rapeseed, at farm {CA} - Adapted from WFLDB U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -6196,7 +6038,6 @@
     },
     "name": "Peanut {CN}| peanut production | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -6235,7 +6076,6 @@
     },
     "name": "Peanut {IN}| peanut production | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -6274,7 +6114,6 @@
     },
     "name": "Extra Virgin Olive Oil, consumption mix {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -6313,7 +6152,6 @@
     },
     "name": "Avocado {GLO}| production | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -6352,7 +6190,6 @@
     },
     "name": "Winter pea, conventional, 15% moisture, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -6391,7 +6228,6 @@
     },
     "name": "Sunflower, at farm {FR} - Adapted from WFLDB U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -6430,7 +6266,6 @@
     },
     "name": "Sunflower, at farm {HU} - Adapted from WFLDB U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -6469,7 +6304,6 @@
     },
     "name": "Sunflower, at farm {GLO} - Adapted from WFLDB U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -6508,7 +6342,6 @@
     },
     "name": "Kiwi FR, conventional, national average, at orchard {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -6547,7 +6380,6 @@
     },
     "name": "Kiwi {GLO}| production | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -6586,7 +6418,6 @@
     },
     "name": "Kiwi {GLO}| production | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -6625,7 +6456,6 @@
     },
     "name": "Mango, conventional, Val de San Francisco, at orchard {BR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -6664,7 +6494,6 @@
     },
     "name": "Spinach {GLO}| production | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -6703,7 +6532,6 @@
     },
     "name": "Fennel {GLO}| production | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -6742,7 +6570,6 @@
     },
     "name": "Fennel {GLO}| production | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -6781,7 +6608,6 @@
     },
     "name": "Broccoli {GLO}| production | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -6820,7 +6646,6 @@
     },
     "name": "Blueberry, at farm {CA} - Adapted from WFLDB U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -6859,7 +6684,6 @@
     },
     "name": "Raspberry, at farm {RS} - Adapted from WFLDB U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -6898,7 +6722,6 @@
     },
     "name": "Strawberry for processing, open field, conventional, at farm gate {ES} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -6937,7 +6760,6 @@
     },
     "name": "Strawberry for processing, open field, conventional, at farm gate {MA} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -6976,7 +6798,6 @@
     },
     "name": "Banana, mixed production, West Indies, at farm gate {WI} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -7015,7 +6836,6 @@
     },
     "name": "Banana, at farm {GLO} - Adapted from WFLDB U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -7054,7 +6874,6 @@
     },
     "name": "Tomato, medium size, conventional, soil based, non-heated greenhouse, at greenhouse {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -7093,7 +6912,6 @@
     },
     "name": "Cucumber {GLO}| cucumber production, in heated greenhouse | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -7132,7 +6950,6 @@
     },
     "name": "Cucumber {GLO}| cucumber production, in heated greenhouse | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -7171,7 +6988,6 @@
     },
     "name": "Strawberry, open field, conventional, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -7210,7 +7026,6 @@
     },
     "name": "Strawberry, soilless protected crops, heated, conventional, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -7249,7 +7064,6 @@
     },
     "name": "Celery {GLO}| 675 production | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -7288,7 +7102,6 @@
     },
     "name": "Celery {GLO}| 675 production | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -7327,7 +7140,6 @@
     },
     "name": "Carrot, conventional, national average, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -7366,7 +7178,6 @@
     },
     "name": "Carrot {NL}| carrot production | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -7405,7 +7216,6 @@
     },
     "name": "Carrot {RoW}| carrot production | Cut-off, U - Copied from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -7444,7 +7254,6 @@
     },
     "name": "Walnut, dried inshell, national average, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -7483,7 +7292,6 @@
     },
     "name": "Walnut, dried, husked, processed in FR | Ambient (long) | LDPE | at packaging {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -7522,7 +7330,6 @@
     },
     "name": "Walnut, dried, husked, processed in FR | Ambient (long) | LDPE | at packaging {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -7561,7 +7368,6 @@
     },
     "name": "Walnut, dried inshell, conventional, national average, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -7600,7 +7406,6 @@
     },
     "name": "Mandarin {ES}| mandarin production | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -7639,7 +7444,6 @@
     },
     "name": "Agaricus bisporus mushroom, fresh, at plant {NL} - Adapted from WFLDB U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -7678,7 +7482,6 @@
     },
     "name": "Cauliflower, winter, conventional, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -7717,7 +7520,6 @@
     },
     "name": "Cauliflower, winter, organic, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -7756,7 +7558,6 @@
     },
     "name": "Lentils, dry, at farm (WFLDB)",
     "source": "WFLDB",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -7795,7 +7596,6 @@
     },
     "name": "Cauliflower, winter, conventional, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -7834,7 +7634,6 @@
     },
     "name": "Cauliflower, winter, organic, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -7873,7 +7672,6 @@
     },
     "name": "Zucchini, conventional, national average, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -7912,7 +7710,6 @@
     },
     "name": "Clementine, export quality, Souss, at orchard {MA} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -7951,7 +7748,6 @@
     },
     "name": "Lettuce, conventional, national average, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -7990,7 +7786,6 @@
     },
     "name": "Iceberg lettuce {GLO}| production | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -8029,7 +7824,6 @@
     },
     "name": "Grape, full production (phase), integrated, variety mix, Languedoc-Roussillon, at vineyard {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -8068,7 +7862,6 @@
     },
     "name": "Lettuce, conventional, national average, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -8107,7 +7900,6 @@
     },
     "name": "Iceberg lettuce {GLO}| production | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -8146,7 +7938,6 @@
     },
     "name": "Maize grain, conventional, 28% moisture, national average, animal feed, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -8185,7 +7976,6 @@
     },
     "name": "Grain maize, organic, animal feed, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -8224,7 +8014,6 @@
     },
     "name": "Maize grain, non-irrigated, at farm {BR} - Adapted from WFLDB U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -8263,7 +8052,6 @@
     },
     "name": "Pineapple {GLO}| production | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -8302,7 +8090,6 @@
     },
     "name": "Fava bean, Swiss integrated production {CH}| fava bean production, Swiss integrated production, at farm | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -8341,7 +8128,6 @@
     },
     "name": "Fava bean, Swiss integrated production {CH}| fava bean production, Swiss integrated production, at farm | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -8380,7 +8166,6 @@
     },
     "name": "Spinach {GLO}| production | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -8419,7 +8204,6 @@
     },
     "name": "Spinach {GLO}| production | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -8458,7 +8242,6 @@
     },
     "name": "Fava bean, Swiss integrated production {CH}| fava bean production, Swiss integrated production, at farm | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -8497,7 +8280,6 @@
     },
     "name": "Fava bean, Swiss integrated production {CH}| fava bean production, Swiss integrated production, at farm | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -8536,7 +8318,6 @@
     },
     "name": "Rice, basmati {IN}| rice production, basmati | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -8575,7 +8356,6 @@
     },
     "name": "Wheat, organic, national average, at farm gate/FR U constructed by Ecobalyse",
     "source": "Ecobalyse",
-    "system_description": "Ecobalyse",
     "unit": "kg",
     "waste": 0
   },
@@ -8614,7 +8394,6 @@
     },
     "name": "Soft wheat grain, conventional, national average, animal feed, at farm gate, production {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -8653,7 +8432,6 @@
     },
     "name": "Wheat grain, at farm {GLO} - Adapted from WFLDB U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -8692,7 +8470,6 @@
     },
     "name": "Durum wheat grain, conventional, national average, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -8731,7 +8508,6 @@
     },
     "name": "Durum wheat grain, at farm {GR} - Adapted from WFLDB U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -8770,7 +8546,6 @@
     },
     "name": "Durum wheat grain, at farm {AU} - Adapted from WFLDB U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -8809,7 +8584,6 @@
     },
     "name": "Table apple, consumption mix, organic 2023 {FR} U",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -8848,7 +8622,6 @@
     },
     "name": "Apple, conventional, national average, at orchard {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -8887,7 +8660,6 @@
     },
     "name": "Ware potato, organic 2023, variety mix, national average, at farm gate {FR} U",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -8926,7 +8698,6 @@
     },
     "name": "Ware potato, organic 2023, for industrial use, at farm gate {FR} U",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -8965,7 +8736,6 @@
     },
     "name": "Kiwi, consumption mix, organic 2023 {FR} U",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -9004,7 +8774,6 @@
     },
     "name": "Red Cabbage, consumption mix, organic 2023 {FR} U",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -9043,7 +8812,6 @@
     },
     "name": "Sugar beet, organic 2023 {FR}| sugar beet production | Cut-off, U",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -9082,7 +8850,6 @@
     },
     "name": "Papaya, consumption mix, organic 2023 {FR} U",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -9121,7 +8888,6 @@
     },
     "name": "Fresh tomato, consumption mix, organic 2023 {FR} U",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -9160,7 +8926,6 @@
     },
     "name": "Pineapple, organic 2023 {GLO}| production | Cut-off, U",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -9199,7 +8964,6 @@
     },
     "name": "Garden peas, consumption mix, organic 2023 {FR} U",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -9238,7 +9002,6 @@
     },
     "name": "Almonds, in shell, at farm, organic 2023 {CN}",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -9277,7 +9040,6 @@
     },
     "name": "Lettuce, organic 2023, national average, at farm gate {FR} U",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -9316,7 +9078,6 @@
     },
     "name": "Mango, organic 2023, Val de San Francisco, at orchard {BR} U",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -9355,7 +9116,6 @@
     },
     "name": "Mango, organic 2023, Val de San Francisco, at orchard {BR} U",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -9394,7 +9154,6 @@
     },
     "name": "Mango, conventional, Val de San Francisco, at orchard {BR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -9433,7 +9192,6 @@
     },
     "name": "Oats, at farm {GLO} - Adapted from WFLDB U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -9472,7 +9230,6 @@
     },
     "name": "Spring oats, organic, national average, at feed plant {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -9511,7 +9268,6 @@
     },
     "name": "Barley, feed grain, conventional, national average, animal feed, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -9550,7 +9306,6 @@
     },
     "name": "Barley, organic, animal feed, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -9589,7 +9344,6 @@
     },
     "name": "Banana, consumption mix, organic 2023 {FR} U",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -9628,7 +9382,6 @@
     },
     "name": "Orange, fresh grade, at farm, organic 2023 {ES}",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -9667,7 +9420,6 @@
     },
     "name": "Lemon, organic 2023 {ES}| lemon production | Cut-off, U",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -9706,7 +9458,6 @@
     },
     "name": "Celery, organic 2023 {GLO}| 675 production | Cut-off, U",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -9745,7 +9496,6 @@
     },
     "name": "Olive, organic 2023 {ES}| olive production | Cut-off, U",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -9784,7 +9534,6 @@
     },
     "name": "Peanut, organic 2023 {RoW}| peanut production | Cut-off, U",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -9823,7 +9572,6 @@
     },
     "name": "Raspberry, at farm, organic 2023 {RS}",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -9862,7 +9610,6 @@
     },
     "name": "Lettuce, organic 2023, national average, at farm gate {FR} U",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -9901,7 +9648,6 @@
     },
     "name": "Lettuce, organic 2023, national average, at farm gate {FR} U",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -9940,7 +9686,6 @@
     },
     "name": "Durum wheat grain, organic 2023, national average, at farm gate {FR} U",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -9979,7 +9724,6 @@
     },
     "name": "Onion, national average, at farm, organic 2023 {FR} U",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -10018,7 +9762,6 @@
     },
     "name": "Rice, non-basmati, organic 2023 {GLO}| market for rice, non-basmati | Cut-off, U",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -10057,7 +9800,6 @@
     },
     "name": "Triticale, organic, animal feed, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -10096,7 +9838,6 @@
     },
     "name": "Pea, organic, animal feed, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -10135,7 +9876,6 @@
     },
     "name": "Alfalfa, hay, organic, animal feed, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -10174,7 +9914,6 @@
     },
     "name": "Radish, organic 2023 {GLO}| radish production, in unheated greenhouse | Cut-off, U",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -10213,7 +9952,6 @@
     },
     "name": "Lentil, organic 2023 {RoW}| lentil production | Cut-off, U",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -10252,7 +9990,6 @@
     },
     "name": "Apricot, organic 2023 {FR}| apricot production | Cut-off, U",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -10291,7 +10028,6 @@
     },
     "name": "Leek, national average, at plant, organic 2023 {FR} U",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -10330,7 +10066,6 @@
     },
     "name": "Cherry, organic 2023, national average, at orchard {FR} U",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -10369,7 +10104,6 @@
     },
     "name": "Cherry, organic 2023, national average, at orchard {FR} U",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -10408,7 +10142,6 @@
     },
     "name": "Onion, national average, at farm, organic 2023 {FR} U",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -10447,7 +10180,6 @@
     },
     "name": "Blueberry, at farm, organic 2023 {CA}",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -10486,7 +10218,6 @@
     },
     "name": "Spinach, organic 2023 {GLO}| production | Cut-off, U",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -10525,7 +10256,6 @@
     },
     "name": "Melon, organic 2023, national average, at farm gate {FR} U",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -10564,7 +10294,6 @@
     },
     "name": "Silage maize, conventional, national average, animal feed, at farm gate, production {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -10603,7 +10332,6 @@
     },
     "name": "Silage maize, conventional, national average, animal feed, at farm gate, production {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -10642,7 +10370,6 @@
     },
     "name": "Oilseed meal mix, as feed, at regional warehouse, as DM {RER} - Adapted from WFLDB U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -10681,7 +10408,6 @@
     },
     "name": "Grazed grass, temporary meadow, without clover, Northwestern region, on field {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -10720,7 +10446,6 @@
     },
     "name": "Grazed grass, permanent meadow, without clover, Northwestern region, on field {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -10759,7 +10484,6 @@
     },
     "name": "Cherry, at farm (WFLDB)",
     "source": "WFLDB",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -10798,7 +10522,6 @@
     },
     "name": "Palm oil, refined, processed in EU, at plant {RER} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -10837,7 +10560,6 @@
     },
     "name": "Linseed oil, refined, at oil mill { FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -10876,7 +10598,6 @@
     },
     "name": "Grapeseed oil, refined at plant {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -10915,7 +10636,6 @@
     },
     "name": "Soybean oil, refined, at plant  {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -10954,7 +10674,6 @@
     },
     "name": "Hazelnut oil, crude, at plant {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -10993,7 +10712,6 @@
     },
     "name": "Peanut oil, at oil mill {SN} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -11032,7 +10750,6 @@
     },
     "name": "Sunflower oil, refined, low dehulling at plant {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -11071,7 +10788,6 @@
     },
     "name": "Rapeseed oil, refined, at oil mill {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -11110,7 +10826,6 @@
     },
     "name": "Extra Virgin Olive Oil, at plant {ES} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -11149,7 +10864,6 @@
     },
     "name": "Fresh cream cheese, plain, creamy, around 8% fat, at plant {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -11188,7 +10902,6 @@
     },
     "name": "Chicken egg, raw, without shell, at plant {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -11227,7 +10940,6 @@
     },
     "name": "Egg yolk, powder, at plant {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -11266,7 +10978,6 @@
     },
     "name": "Egg white, powder, at plant {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -11305,7 +11016,6 @@
     },
     "name": "Emmental cheese, grated, cheese production, from cow's milk, hard cheese, French production mix, at plant, 1 kg of Emmental, grated cheese (PGi) {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -11344,7 +11054,6 @@
     },
     "name": "Cocoa powder, at plant {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -11383,7 +11092,6 @@
     },
     "name": "Salt {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -11422,7 +11130,6 @@
     },
     "name": "Bacon, back, at plant {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -11461,7 +11168,6 @@
     },
     "name": "Corn glucose syrup, at plant {GLO} - Adapted from WFLDB U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -11500,7 +11206,6 @@
     },
     "name": "Apple compote, at plant {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -11539,7 +11244,6 @@
     },
     "name": "Goat milk, consumption mix {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -11578,7 +11282,6 @@
     },
     "name": "Breakfast cereals, rich in fibre, with chocolate, fortified with vitamins and chemical elements, at plant {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -11617,7 +11320,6 @@
     },
     "name": "Pasta, dried, from durum wheat, at plant {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -11656,7 +11358,6 @@
     },
     "name": "Garlic, consumption mix {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -11695,7 +11396,6 @@
     },
     "name": "Diced mixed vegetables, canned, at plant {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -11734,7 +11434,6 @@
     },
     "name": "Tomato sauce, with meat or Bolognese sauce, prepacked, at plant {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -11773,7 +11472,6 @@
     },
     "name": "Honey, at plant {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -11812,7 +11510,6 @@
     },
     "name": "Turkey, conventional, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -11851,7 +11548,6 @@
     },
     "name": "Liver, pork, raw, processed in FR | Chilled | PS | at distribution {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -11890,7 +11586,6 @@
     },
     "name": "Whey, at plant {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -11929,7 +11624,6 @@
     },
     "name": "Strawberry, coulis, at plant {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -11968,7 +11662,6 @@
     },
     "name": "Yogurt, from cow milk, at plant {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -12007,7 +11700,6 @@
     },
     "name": "Cheese, from goat's milk, consumption mix {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -12046,7 +11738,6 @@
     },
     "name": "Cocoa butter at plant {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -12085,7 +11776,6 @@
     },
     "name": "Soy protein, textured, dehydrated, from soy flour, at plant {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -12124,7 +11814,6 @@
     },
     "name": "Vinegar alcohol, consumption mix {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -12163,7 +11852,6 @@
     },
     "name": "Meat without bone, veal {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -12202,7 +11890,6 @@
     },
     "name": "French fries or chips, frozen, at processing {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -12241,7 +11928,6 @@
     },
     "name": "Tomato sauce, w vegetables, prepacked, at plant {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -12280,7 +11966,6 @@
     },
     "name": "Mustard, at plant {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -12319,7 +12004,6 @@
     },
     "name": "Rice flour, at industrial mill {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -12358,7 +12042,6 @@
     },
     "name": "Brie cheese, from cow's milk, consumption mix {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -12397,7 +12080,6 @@
     },
     "name": "Turmeric, consumption mix {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -12436,7 +12118,6 @@
     },
     "name": "Candied fruits, at plant {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -12475,7 +12156,6 @@
     },
     "name": "Reblochon cheese, from cow's milk, at plant {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -12514,7 +12194,6 @@
     },
     "name": "Fruits puree, without sugar added, at plant {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -12553,7 +12232,6 @@
     },
     "name": "Apple juice, reconstituted from a concentrate, at plant {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -12592,7 +12270,6 @@
     },
     "name": "Orange nectar, at plant {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -12631,7 +12308,6 @@
     },
     "name": "Soy drink, plain, at plant {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -12670,7 +12346,6 @@
     },
     "name": "Lemon juice, pure juice, at plant {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -12709,7 +12384,6 @@
     },
     "name": "Tomato juice, pure juice, at plant {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -12748,7 +12422,6 @@
     },
     "name": "Vinegar, balsamic, processed in FR | Ambient (long) | Already packed - Glass | at packaging {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -12787,7 +12460,6 @@
     },
     "name": "Apricot, at farm (WFLDB)",
     "source": "WFLDB",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -12826,7 +12498,6 @@
     },
     "name": "Lamb, fresh meat, at slaughterhouse (WFLDB)",
     "source": "WFLDB",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -12865,7 +12536,6 @@
     },
     "name": "Lamb, fresh meat, at slaughterhouse (WFLDB)",
     "source": "WFLDB",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -12904,7 +12574,6 @@
     },
     "name": "Almond, consumption mix {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -12943,7 +12612,6 @@
     },
     "name": "Almond, consumption mix {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -12982,7 +12650,6 @@
     },
     "name": "Almond, consumption mix {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -13021,7 +12688,6 @@
     },
     "name": "Cauliflower, conventional, national average, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -13060,7 +12726,6 @@
     },
     "name": "Cauliflower, conventional, national average, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -13099,7 +12764,6 @@
     },
     "name": "Avocado, consumption mix {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -13138,7 +12802,6 @@
     },
     "name": "Avocado {GLO}| production | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -13177,7 +12840,6 @@
     },
     "name": "Oats, at farm {GLO} - Adapted from WFLDB U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -13216,7 +12878,6 @@
     },
     "name": "Spinach, organic 2023 {GLO}| production | Cut-off, U",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -13255,7 +12916,6 @@
     },
     "name": "Spinach {GLO}| production | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -13294,7 +12954,6 @@
     },
     "name": "Broccoli, consumption mix, organic 2023 {FR} U",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -13333,7 +12992,6 @@
     },
     "name": "Broccoli, consumption mix {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -13372,7 +13030,6 @@
     },
     "name": "Broccoli {GLO}| production | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -13411,7 +13068,6 @@
     },
     "name": "Celery {GLO}| 675 production | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -13450,7 +13106,6 @@
     },
     "name": "Cherry, at farm (WFLDB)",
     "source": "WFLDB",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -13489,7 +13144,6 @@
     },
     "name": "Agaricus bisporus mushroom, fresh, at plant {NL} - Adapted from WFLDB U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -13528,7 +13182,6 @@
     },
     "name": "Walnut, dried inshell, organic 2023, national average, at farm gate {FR} U",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -13567,7 +13220,6 @@
     },
     "name": "Cabbage white {RoW}| cabbage white production | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -13606,7 +13258,6 @@
     },
     "name": "Cabbage white {RoW}| cabbage white production | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -13645,7 +13296,6 @@
     },
     "name": "Cabbage white, organic 2023 {RoW}| cabbage white production | Cut-off, U",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -13684,7 +13334,6 @@
     },
     "name": "Cauliflower, winter, conventional, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -13723,7 +13372,6 @@
     },
     "name": "Cauliflower, winter, conventional, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -13762,7 +13410,6 @@
     },
     "name": "Cauliflower, winter, conventional, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -13801,7 +13448,6 @@
     },
     "name": "Cauliflower, winter, conventional, at farm gate {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -13840,7 +13486,6 @@
     },
     "name": "Palm oil, refined, consumption mix {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -13879,7 +13524,6 @@
     },
     "name": "Sunflower oil, at plant {IT} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -13918,7 +13562,6 @@
     },
     "name": "Raw cow milk archetype, feed mix IT-154, at farm (WFLDB)",
     "source": "WFLDB",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -13957,7 +13600,6 @@
     },
     "name": "Cow milk {CA-QC}| milk production, from cow | Cut-off, U - Copied from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -13996,7 +13638,6 @@
     },
     "name": "Lentils, dry, at farm (WFLDB)",
     "source": "WFLDB",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -14035,7 +13676,6 @@
     },
     "name": "Lentils, dry, at farm (WFLDB)",
     "source": "WFLDB",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -14074,7 +13714,6 @@
     },
     "name": "Iceberg lettuce {GLO}| production | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -14113,7 +13752,6 @@
     },
     "name": "Sweet corn, at farm (WFLDB)",
     "source": "WFLDB",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -14152,7 +13790,6 @@
     },
     "name": "Sunflower, at farm {HU} - Adapted from WFLDB U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -14191,7 +13828,6 @@
     },
     "name": "Butter, 82% fat, unsalted, at dairy {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -14230,7 +13866,6 @@
     },
     "name": "Clementine, export quality, Souss, at orchard {MA} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -14269,7 +13904,6 @@
     },
     "name": "Meat without bone, beef, for direct consumption {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -14308,7 +13942,6 @@
     },
     "name": "Tea, dried {RoW}| tea production, dried | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -14347,7 +13980,6 @@
     },
     "name": "Tap water {Europe without Switzerland}| market for | Cut-off, S - Copied from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -14386,7 +14018,6 @@
     },
     "name": "Meat without bone, chicken, for direct consumption {FR} U [br-max], constructed by Ecobalyse",
     "source": "Ecobalyse",
-    "system_description": "Ecobalyse",
     "unit": "kg",
     "waste": 0
   },
@@ -14425,7 +14056,6 @@
     },
     "name": "Fresh shrimps, China production {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -14464,7 +14094,6 @@
     },
     "name": "Hazelnut, unshelled, at plant {TR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -14503,7 +14132,6 @@
     },
     "name": "Sunflower oil, at oil mill {GLO} - Adapted from WFLDB U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -14542,7 +14170,6 @@
     },
     "name": "Anchovy, consumption mix {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -14581,7 +14208,6 @@
     },
     "name": "Anchovy, consumption mix {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -14620,7 +14246,6 @@
     },
     "name": "Anchovy, consumption mix {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -14659,7 +14284,6 @@
     },
     "name": "European Pilchard, BBiscay, Seine, average, at landing {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -14698,7 +14322,6 @@
     },
     "name": "European pilchard or sardine, consumption mix {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -14737,7 +14360,6 @@
     },
     "name": "European pilchard or sardine, consumption mix {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -14776,7 +14398,6 @@
     },
     "name": "Cod, consumption mix {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -14815,7 +14436,6 @@
     },
     "name": "Brown crab, 1 kg of product, at landing {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -14854,7 +14474,6 @@
     },
     "name": "Brown crab, 1 kg of product, at landing {GB} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -14893,7 +14512,6 @@
     },
     "name": "Hake, consumption mix {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -14932,7 +14550,6 @@
     },
     "name": "Lobster, 1 kg of product, at landing {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -14971,7 +14588,6 @@
     },
     "name": "Lobster, 1 kg of product, at landing {GB} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -15010,7 +14626,6 @@
     },
     "name": "Lobster, 1 kg of product, at landing {US} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -15049,7 +14664,6 @@
     },
     "name": "Salmon, fillet, raw, at processing {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -15088,7 +14702,6 @@
     },
     "name": "Squid, consumption mix {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -15127,7 +14740,6 @@
     },
     "name": "Mandarin, at farm (WFLDB)",
     "source": "WFLDB",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -15166,7 +14778,6 @@
     },
     "name": "Melon {GLO}| melon production | Cut-off, U",
     "source": "Ecoinvent 3.10",
-    "system_description": "Ecoinvent v3 Cut-off U",
     "unit": "kg",
     "waste": 0
   },
@@ -15205,7 +14816,6 @@
     },
     "name": "Blueberry, at farm {CA} - Adapted from WFLDB U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -15244,7 +14854,6 @@
     },
     "name": "Blueberry, at farm {CA} - Adapted from WFLDB U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -15283,7 +14892,6 @@
     },
     "name": "Hazelnut, in shell, at farm, organic 2023 {IT}",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -15322,7 +14930,6 @@
     },
     "name": "Hazelnut, unshelled, consumption mix, organic 2023 {FR} U",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -15361,7 +14968,6 @@
     },
     "name": "Hazelnut, unshelled, consumption mix {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -15400,7 +15006,6 @@
     },
     "name": "Walnut, dried inshell, traditional varieties, organic 2023, at farm gate {FR} U",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -15439,7 +15044,6 @@
     },
     "name": "Walnut, in shell, dried, at farm (WFLDB)",
     "source": "WFLDB",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -15478,7 +15082,6 @@
     },
     "name": "Walnut, in shell, dried, at farm (WFLDB)",
     "source": "WFLDB",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -15517,7 +15120,6 @@
     },
     "name": "Olive {ES}| olive production | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -15556,7 +15158,6 @@
     },
     "name": "Barley grain, non-irrigated, at farm {DE} - Adapted from WFLDB U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -15595,7 +15196,6 @@
     },
     "name": "Barley grain, non-irrigated, at farm {DE} - Adapted from WFLDB U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -15634,7 +15234,6 @@
     },
     "name": "Peanut, in shell, at farm, organic 2023 {GLO}",
     "source": "Ginko",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -15673,7 +15272,6 @@
     },
     "name": "Leek, consumption mix {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -15712,7 +15310,6 @@
     },
     "name": "Leek, consumption mix {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -15751,7 +15348,6 @@
     },
     "name": "Protein pea {ES}| protein pea production | Cut-off, U",
     "source": "Ecoinvent 3.10",
-    "system_description": "Ecoinvent v3 Cut-off U",
     "unit": "kg",
     "waste": 0
   },
@@ -15790,7 +15386,6 @@
     },
     "name": "Protein pea {ES}| protein pea production | Cut-off, U",
     "source": "Ecoinvent 3.10",
-    "system_description": "Ecoinvent v3 Cut-off U",
     "unit": "kg",
     "waste": 0
   },
@@ -15829,7 +15424,6 @@
     },
     "name": "Spring pea, conventional, 15% moisture, animal feed, at farm gate, production {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -15868,7 +15462,6 @@
     },
     "name": "Chickpea {RoW}| chickpea production | Cut-off, U",
     "source": "Ecoinvent 3.10",
-    "system_description": "Ecoinvent v3 Cut-off U",
     "unit": "kg",
     "waste": 0
   },
@@ -15907,7 +15500,6 @@
     },
     "name": "Bell pepper {GLO}| bell pepper production, in unheated greenhouse | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -15946,7 +15538,6 @@
     },
     "name": "Bell pepper {GLO}| bell pepper production, in unheated greenhouse | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -15985,7 +15576,6 @@
     },
     "name": "Bell pepper {GLO}| bell pepper production, in unheated greenhouse | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -16024,7 +15614,6 @@
     },
     "name": "Apple, at farm (WFLDB)",
     "source": "WFLDB",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -16063,7 +15652,6 @@
     },
     "name": "Potato, at farm (WFLDB)",
     "source": "WFLDB",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -16102,7 +15690,6 @@
     },
     "name": "Potato, at farm (WFLDB)",
     "source": "WFLDB",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -16141,7 +15728,6 @@
     },
     "name": "Chicken, fresh meat, at slaughterhouse (WFLDB)",
     "source": "WFLDB",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -16180,7 +15766,6 @@
     },
     "name": "Tomato puree, canned, processed in FR | Ambient (long) | Steel | at packaging {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -16219,7 +15804,6 @@
     },
     "name": "Radish, consumption mix {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -16258,7 +15842,6 @@
     },
     "name": "Radish {GLO}| radish production, in unheated greenhouse | Cut-off, U - Adapted from Ecoinvent U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "Ecoinvent v3 - Copied from Ecoinvent",
     "unit": "kg",
     "waste": 0
   },
@@ -16297,7 +15880,6 @@
     },
     "name": "Basmati rice, consumption mix {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -16336,7 +15918,6 @@
     },
     "name": "Durum wheat, semolina, at plant {GLO} - Adapted from WFLDB U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -16375,7 +15956,6 @@
     },
     "name": "Durum wheat, semolina, at plant {GLO} - Adapted from WFLDB U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -16414,7 +15994,6 @@
     },
     "name": "Cherry, at farm (WFLDB)",
     "source": "WFLDB",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -16453,7 +16032,6 @@
     },
     "name": "Cherry, at farm (WFLDB)",
     "source": "WFLDB",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -16492,7 +16070,6 @@
     },
     "name": "Wheat grain, at farm {GLO} - Adapted from WFLDB U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -16531,7 +16108,6 @@
     },
     "name": "Onions, dried, consumption mix {FR} U",
     "source": "Agribalyse 3.1.1",
-    "system_description": "AGRIBALYSE",
     "unit": "kg",
     "waste": 0
   },
@@ -16570,7 +16146,6 @@
     },
     "name": "Beer, 1500g | Packaging System, Proxy Pack, Glass {FR} U",
     "source": "Agribalyse 3.2 beta 08/08/2024",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -16609,7 +16184,6 @@
     },
     "name": "Beer, 1500g | Packaging System, Proxy Pack, Glass {FR} U",
     "source": "Agribalyse 3.2 beta 08/08/2024",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -16648,7 +16222,6 @@
     },
     "name": "Vanilla, 10g | Packaging System, Proxy Pack, Glass {FR} U",
     "source": "Agribalyse 3.2 beta 08/08/2024",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -16687,7 +16260,6 @@
     },
     "name": "Cocktails, 700g | Packaging System, Proxy Pack, Glass {FR} U",
     "source": "Agribalyse 3.2 beta 08/08/2024",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -16726,7 +16298,6 @@
     },
     "name": "Tea, 30g | Packaging System, Proxy Pack, Cardboard {FR} U",
     "source": "Agribalyse 3.2 beta 08/08/2024",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -16765,7 +16336,6 @@
     },
     "name": "Honey, 375g | Packaging System, Proxy Pack, Glass {FR} U",
     "source": "Agribalyse 3.2 beta 08/08/2024",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -16804,7 +16374,6 @@
     },
     "name": "Honey, 375g | Packaging System, Proxy Pack, Glass {FR} U",
     "source": "Agribalyse 3.2 beta 08/08/2024",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -16843,7 +16412,6 @@
     },
     "name": "Syrups, 600g | Packaging System, Proxy Pack, Steel {FR} U",
     "source": "Agribalyse 3.2 beta 08/08/2024",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -16882,7 +16450,6 @@
     },
     "name": "Cider, 750g | Packaging System, Proxy Pack, Glass {FR} U",
     "source": "Agribalyse 3.2 beta 08/08/2024",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   },
@@ -16921,7 +16488,6 @@
     },
     "name": "Sugar, 1000g | Packaging System, Proxy Pack, Cardboard {FR} U",
     "source": "Agribalyse 3.2 beta 08/08/2024",
-    "system_description": "",
     "unit": "kg",
     "waste": 0
   }

--- a/src/Data/Food/Process.elm
+++ b/src/Data/Food/Process.elm
@@ -49,7 +49,6 @@ type alias Process =
     , impacts : Impacts
     , name : String
     , source : String
-    , systemDescription : String
     , unit : String
     , waste : Split
     }
@@ -194,7 +193,6 @@ decodeProcess impactsDecoder =
         |> Pipe.required "impacts" impactsDecoder
         |> Pipe.required "name" Decode.string
         |> Pipe.required "source" Decode.string
-        |> Pipe.required "system_description" Decode.string
         |> Pipe.required "unit" Decode.string
         |> Pipe.required "waste" Split.decodeFloat
 
@@ -214,7 +212,6 @@ encode process =
         , ( "impacts", Impact.encode process.impacts )
         , ( "name", Encode.string process.name )
         , ( "source", Encode.string process.source )
-        , ( "system_description", Encode.string process.systemDescription )
         , ( "unit", Encode.string process.unit )
         , ( "waste", Split.encodeFloat process.waste )
         ]

--- a/src/Page/Explore/FoodProcesses.elm
+++ b/src/Page/Explore/FoodProcesses.elm
@@ -63,10 +63,6 @@ table _ { detailed, scope } =
           , toValue = Table.StringValue <| .unit
           , toCell = .unit >> text
           }
-        , { label = "Description du système"
-          , toValue = Table.StringValue <| .systemDescription
-          , toCell = .systemDescription >> text
-          }
         , { label = "Commentaire"
           , toValue = Table.StringValue <| .comment >> Maybe.withDefault "N/A"
           , toCell = .comment >> Maybe.withDefault "N/A" >> text


### PR DESCRIPTION
## :wrench: Problem

The `system_description` field in the food processes file format is obsolete and redundant with the `source` one ([Mattermost discussion](https://mattermost.incubateur.net/fabnum-mte/pl/crb13ou4s7rx9nhztaa8kgfwww))

## :cake: Solution

Remove it.

## :desert_island: How to test

This one is straightforward, the build should be green.

ecobalyse-private: chore/remove-unused-system-description
