### PR TITLE
ci: fix score_history workflow for transcrypt

### DIFF
--- a/.github/workflows/score_history.yml
+++ b/.github/workflows/score_history.yml
@@ -9,6 +9,7 @@ on:
 
 env:
   NODE_ENV: test
+  TRANSCRYPT_KEY: ${{ secrets.TRANSCRYPT_KEY }}
 
 jobs:
   score_history:
@@ -23,6 +24,13 @@ jobs:
     steps:
 
       - uses: actions/checkout@v4
+
+      - name: Install transcrypt
+        run: |
+          mkdir -p $HOME/.local/bin
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          wget https://raw.githubusercontent.com/elasticdog/transcrypt/016b2e4b31951be5ea96233d8d2badef9c9836b6/transcrypt -O "$HOME/.local/bin/transcrypt"
+          chmod +x "$HOME/.local/bin/transcrypt"
 
       - name: Install Scalingo CLI
         uses: ./.github/actions/scalingo-cli


### PR DESCRIPTION
## :wrench: Problem

Build is failing on `master` for the `score_history` workflow because it was not updated for `transcrypt`.

## :cake: Solution

Add the `TRANSCRYPT_KEY` env variable and install `transcrypt` in the workflow.


## :desert_island: How to test

Run the workflow by hand here https://github.com/MTES-MCT/ecobalyse/actions/workflows/score_history.yml and check that everything works as expected.
