### PR TITLE
fix(dev): npm ci error with `transcrypt`

### DIFF
--- a/bin/run-transcrypt.sh
+++ b/bin/run-transcrypt.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # If $SOURCE_VERSION is set, we are building on Scalingo with npm
 # so we should not decrypt the file.
 # On scalingo, we don't have a git repo, so decrypting is handled
@@ -14,5 +16,11 @@ then
     echo "-> Exiting"
     exit 1
   fi
-  transcrypt -y -c aes-256-cbc -p "$TRANSCRYPT_KEY"
+
+  if ! transcrypt -d &> /dev/null; then
+    transcrypt -y -c aes-256-cbc -p "$TRANSCRYPT_KEY"
+  else
+    echo 'ℹ️ `transcrypt` was already configured for this repo, skipping.'
+  fi
+
 fi


### PR DESCRIPTION
## :wrench: Problem

When `transcrypt` is already configured for your repo locally and you run `npm install` you get an error saying that the current repository is already configured because the npm `postinstall` step is executed no matter what.

## :cake: Solution

Check if the repo was already configured with `transcrypt` before trying to configure it.


## :desert_island: How to test

`npm ci` should not report any error and should display this message:

    ℹ️ `transcrypt` was already configured for this repo, skipping.
    
The ci should be green, validating the case that everything still works fine when setting up a new repo from scratch.