### PR TITLE
refactor: abstract components.

### DIFF
--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -74,6 +74,8 @@ type Quantity
     = Quantity Int
 
 
+{-| A data structure carrying the impacts and mass resulting from a computation
+-}
 type Results
     = Results
         { impacts : Impacts
@@ -124,6 +126,8 @@ componentItemToString components processes { id, quantity } =
             )
 
 
+{-| Computes impacts from a list of available components, processes and specified component items
+-}
 compute : List Component -> List Process -> List ComponentItem -> Result String Results
 compute components processes =
     List.map (computeComponentItemResults components processes)

--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -1,4 +1,4 @@
-module Data.Object.Component exposing
+module Data.Component exposing
     ( Amount
     , Component
     , ComponentItem

--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -6,11 +6,10 @@ module Data.Component exposing
     , ProcessItem
     , Quantity
     , Results
-    , addResults
     , amountToFloat
     , available
     , componentItemToString
-    , computeComponentItemResults
+    , compute
     , decodeComponentItem
     , decodeList
     , emptyResults
@@ -42,6 +41,8 @@ type Id
     = Id Uuid
 
 
+{-| A component is a named collection of processes and amounts of them
+-}
 type alias Component =
     { id : Id
     , name : String
@@ -121,6 +122,13 @@ componentItemToString components processes { id, quantity } =
                                 ++ " ]"
                         )
             )
+
+
+compute : List Component -> List Process -> List ComponentItem -> Result String Results
+compute components processes =
+    List.map (computeComponentItemResults components processes)
+        >> RE.combine
+        >> Result.map (List.foldr addResults emptyResults)
 
 
 computeComponentItemResults : List Component -> List Process -> ComponentItem -> Result String Results

--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -113,8 +113,8 @@ amountToFloat (Amount float) =
 {-| List components which ids are not part of the provided list of ids
 -}
 available : List Id -> List Component -> List Component
-available ids =
-    List.filter (\{ id } -> not <| List.member id ids)
+available alreadyUsedIds =
+    List.filter (\{ id } -> not <| List.member id alreadyUsedIds)
         >> List.sortBy .name
 
 

--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -41,7 +41,7 @@ type Id
     = Id Uuid
 
 
-{-| A component is a named collection of processes and amounts of them
+{-| A Component is a named collection of processes and amounts of them
 -}
 type alias Component =
     { id : Id
@@ -67,7 +67,7 @@ type alias DataContainer db =
     }
 
 
-{-| A compact representation of a component process, and an amount of it
+{-| A compact representation of a component process and an amount of it
 -}
 type alias ProcessItem =
     { amount : Amount
@@ -83,7 +83,7 @@ type Quantity
     = Quantity Int
 
 
-{-| A data structure carrying the impacts and mass resulting from a computation
+{-| A nested data structure carrying the impacts and mass resulting from a computation
 -}
 type Results
     = Results
@@ -93,6 +93,8 @@ type Results
         }
 
 
+{-| Add two results together
+-}
 addResults : Results -> Results -> Results
 addResults (Results results) (Results acc) =
     Results
@@ -108,6 +110,8 @@ amountToFloat (Amount float) =
     float
 
 
+{-| List components which ids are not part of the provided list of ids
+-}
 available : List Id -> List Component -> List Component
 available ids =
     List.filter (\{ id } -> not <| List.member id ids)
@@ -194,6 +198,8 @@ computeProcessItemResults processes { amount, processId } =
             )
 
 
+{-| Take a list of component items and resolve them with actual components and processes
+-}
 expandComponentItems :
     DataContainer a
     -> List ComponentItem
@@ -212,6 +218,8 @@ expandComponentItems { components, processes } =
         >> RE.combine
 
 
+{-| Take a list of process items and resolve them with actual processes
+-}
 expandProcessItems : List Process -> List ProcessItem -> Result String (List ( Amount, Process ))
 expandProcessItems processes =
     List.map (\{ amount, processId } -> ( amount, processId ))
@@ -254,6 +262,8 @@ encodeComponentItem componentItem =
         ]
 
 
+{-| Lookup a Component from a provided Id
+-}
 findById : Id -> List Component -> Result String Component
 findById id =
     List.filter (.id >> (==) id)

--- a/src/Data/Dataset.elm
+++ b/src/Data/Dataset.elm
@@ -10,10 +10,10 @@ module Data.Dataset exposing
     , toRoutePath
     )
 
+import Data.Component as Component
 import Data.Country as Country
 import Data.Food.Ingredient as Ingredient
 import Data.Impact.Definition as Definition
-import Data.Object.Component as ObjectComponent
 import Data.Process as Process
 import Data.Scope as Scope exposing (Scope)
 import Data.Textile.Material as Material
@@ -33,7 +33,7 @@ type Dataset
     | FoodIngredients (Maybe Ingredient.Id)
     | FoodProcesses (Maybe Process.Id)
     | Impacts (Maybe Definition.Trigram)
-    | ObjectComponents (Maybe ObjectComponent.Id)
+    | ObjectComponents (Maybe Component.Id)
     | ObjectExamples (Maybe Uuid)
     | ObjectProcesses (Maybe Process.Id)
     | TextileExamples (Maybe Uuid)
@@ -269,7 +269,7 @@ setIdFromString idString dataset =
             Impacts (Definition.toTrigram idString |> Result.toMaybe)
 
         ObjectComponents _ ->
-            ObjectComponents (ObjectComponent.idFromString idString)
+            ObjectComponents (Component.idFromString idString)
 
         ObjectExamples _ ->
             ObjectExamples (Uuid.fromString idString)
@@ -369,7 +369,7 @@ toRoutePath dataset =
             [ slug dataset ]
 
         ObjectComponents (Just id) ->
-            [ slug dataset, ObjectComponent.idToString id ]
+            [ slug dataset, Component.idToString id ]
 
         ObjectComponents Nothing ->
             [ slug dataset ]

--- a/src/Data/Object/Db.elm
+++ b/src/Data/Object/Db.elm
@@ -3,9 +3,9 @@ module Data.Object.Db exposing
     , buildFromJson
     )
 
+import Data.Component as Component exposing (Component)
 import Data.Example as Example exposing (Example)
 import Data.Impact as Impact
-import Data.Object.Component as Component exposing (Component)
 import Data.Object.Query as Query exposing (Query)
 import Data.Process as Process exposing (Process)
 import Json.Decode as Decode

--- a/src/Data/Object/Query.elm
+++ b/src/Data/Object/Query.elm
@@ -97,7 +97,7 @@ updateComponentItem newItem query =
 toString : List Component -> List Process -> Query -> Result String String
 toString components processes query =
     query.components
-        |> RE.combineMap (Component.componentItemToString components processes)
+        |> RE.combineMap (Component.componentItemToString { components = components, processes = processes })
         |> Result.map (String.join ", ")
 
 

--- a/src/Data/Object/Query.elm
+++ b/src/Data/Object/Query.elm
@@ -13,7 +13,7 @@ module Data.Object.Query exposing
     )
 
 import Base64
-import Data.Object.Component as Component exposing (Component, ComponentItem)
+import Data.Component as Component exposing (Component, ComponentItem)
 import Data.Process exposing (Process)
 import Data.Scope as Scope exposing (Scope)
 import Json.Decode as Decode exposing (Decoder)

--- a/src/Data/Object/Simulator.elm
+++ b/src/Data/Object/Simulator.elm
@@ -9,9 +9,9 @@ module Data.Object.Simulator exposing
     , toStepsImpacts
     )
 
+import Data.Component as Component exposing (Component, ComponentItem, ProcessItem)
 import Data.Impact as Impact exposing (Impacts, noStepsImpacts)
 import Data.Impact.Definition as Definition
-import Data.Object.Component as Component exposing (Component, ComponentItem, ProcessItem)
 import Data.Object.Query exposing (Query)
 import Data.Process as Process
 import Mass exposing (Mass)

--- a/src/Data/Object/Simulator.elm
+++ b/src/Data/Object/Simulator.elm
@@ -1,129 +1,36 @@
 module Data.Object.Simulator exposing
-    ( Results(..)
-    , availableComponents
+    ( availableComponents
     , compute
-    , emptyResults
-    , extractImpacts
-    , extractItems
-    , extractMass
     , toStepsImpacts
     )
 
-import Data.Component as Component exposing (Component, ComponentItem, ProcessItem)
-import Data.Impact as Impact exposing (Impacts, noStepsImpacts)
+import Data.Component as Component exposing (Component, Results)
+import Data.Impact as Impact exposing (noStepsImpacts)
 import Data.Impact.Definition as Definition
 import Data.Object.Query exposing (Query)
-import Data.Process as Process
-import Mass exposing (Mass)
-import Quantity
 import Result.Extra as RE
 import Static.Db exposing (Db)
 
 
-type Results
-    = Results
-        { impacts : Impacts
-        , items : List Results
-        , mass : Mass
-        }
-
-
 availableComponents : Db -> Query -> List Component
 availableComponents { object } query =
-    let
-        usedIds =
-            query.components
-                |> List.map .id
-    in
     object.components
-        |> List.filter (\{ id } -> not (List.member id usedIds))
+        |> List.filter
+            (\{ id } ->
+                query.components
+                    |> List.map .id
+                    |> List.member id
+                    |> not
+            )
         |> List.sortBy .name
 
 
-addResults : Results -> Results -> Results
-addResults (Results results) (Results acc) =
-    Results
-        { acc
-            | impacts = Impact.sumImpacts [ results.impacts, acc.impacts ]
-            , items = Results results :: acc.items
-            , mass = Quantity.sum [ results.mass, acc.mass ]
-        }
-
-
 compute : Db -> Query -> Result String Results
-compute db query =
+compute { object } query =
     query.components
-        |> List.map (computeComponentItemResults db)
+        |> List.map (Component.computeComponentItemResults object.components object.processes)
         |> RE.combine
-        |> Result.map (List.foldr addResults emptyResults)
-
-
-computeComponentItemResults : Db -> ComponentItem -> Result String Results
-computeComponentItemResults db componentItem =
-    db.object.components
-        |> Component.findById componentItem.id
-        |> Result.andThen (.processes >> List.map (computeProcessItemResults db) >> RE.combine)
-        |> Result.map (List.foldr addResults emptyResults)
-        |> Result.map
-            (\(Results { impacts, mass, items }) ->
-                Results
-                    { impacts = Impact.sumImpacts (List.repeat (Component.quantityToInt componentItem.quantity) impacts)
-                    , items = items
-                    , mass = Quantity.sum (List.repeat (Component.quantityToInt componentItem.quantity) mass)
-                    }
-            )
-
-
-computeProcessItemResults : Db -> ProcessItem -> Result String Results
-computeProcessItemResults { object } { amount, processId } =
-    object.processes
-        |> Process.findById processId
-        |> Result.map
-            (\process ->
-                let
-                    impacts =
-                        process.impacts
-                            |> Impact.mapImpacts (\_ -> Quantity.multiplyBy (Component.amountToFloat amount))
-
-                    mass =
-                        Mass.kilograms <|
-                            if process.unit == "kg" then
-                                Component.amountToFloat amount
-
-                            else
-                                -- apply density
-                                Component.amountToFloat amount * process.density
-                in
-                Results
-                    { impacts = impacts
-                    , items = [ Results { impacts = impacts, items = [], mass = mass } ]
-                    , mass = mass
-                    }
-            )
-
-
-emptyResults : Results
-emptyResults =
-    Results
-        { impacts = Impact.empty
-        , items = []
-        , mass = Quantity.zero
-        }
-
-
-extractImpacts : Results -> Impacts
-extractImpacts (Results { impacts }) =
-    impacts
-
-
-extractItems : Results -> List Results
-extractItems (Results { items }) =
-    items
-
-
-extractMass : Results -> Mass
-extractMass (Results { mass }) =
-    mass
+        |> Result.map (List.foldr Component.addResults Component.emptyResults)
 
 
 toStepsImpacts : Definition.Trigram -> Results -> Impact.StepsImpacts
@@ -131,7 +38,7 @@ toStepsImpacts trigram results =
     { noStepsImpacts
       -- FIXME: for now, as we only have materials, assign everything to the material step
         | materials =
-            extractImpacts results
+            Component.extractImpacts results
                 |> Impact.getImpact trigram
                 |> Just
     }

--- a/src/Data/Object/Simulator.elm
+++ b/src/Data/Object/Simulator.elm
@@ -13,7 +13,7 @@ import Static.Db exposing (Db)
 compute : Db -> Query -> Result String Results
 compute { object } =
     -- FIXME: for now, the impact of an Object is solely the summed impacts of its components
-    .components >> Component.compute object.components object.processes
+    .components >> Component.compute object
 
 
 toStepsImpacts : Definition.Trigram -> Results -> Impact.StepsImpacts

--- a/src/Data/Object/Simulator.elm
+++ b/src/Data/Object/Simulator.elm
@@ -7,16 +7,13 @@ import Data.Component as Component exposing (Results)
 import Data.Impact as Impact exposing (noStepsImpacts)
 import Data.Impact.Definition as Definition
 import Data.Object.Query exposing (Query)
-import Result.Extra as RE
 import Static.Db exposing (Db)
 
 
 compute : Db -> Query -> Result String Results
-compute { object } query =
-    query.components
-        |> List.map (Component.computeComponentItemResults object.components object.processes)
-        |> RE.combine
-        |> Result.map (List.foldr Component.addResults Component.emptyResults)
+compute { object } =
+    -- FIXME: for now, the impact of an Object is solely the summed impacts of its components
+    .components >> Component.compute object.components object.processes
 
 
 toStepsImpacts : Definition.Trigram -> Results -> Impact.StepsImpacts

--- a/src/Data/Object/Simulator.elm
+++ b/src/Data/Object/Simulator.elm
@@ -1,28 +1,14 @@
 module Data.Object.Simulator exposing
-    ( availableComponents
-    , compute
+    ( compute
     , toStepsImpacts
     )
 
-import Data.Component as Component exposing (Component, Results)
+import Data.Component as Component exposing (Results)
 import Data.Impact as Impact exposing (noStepsImpacts)
 import Data.Impact.Definition as Definition
 import Data.Object.Query exposing (Query)
 import Result.Extra as RE
 import Static.Db exposing (Db)
-
-
-availableComponents : Db -> Query -> List Component
-availableComponents { object } query =
-    object.components
-        |> List.filter
-            (\{ id } ->
-                query.components
-                    |> List.map .id
-                    |> List.member id
-                    |> not
-            )
-        |> List.sortBy .name
 
 
 compute : Db -> Query -> Result String Results

--- a/src/Page/Explore.elm
+++ b/src/Page/Explore.elm
@@ -11,6 +11,7 @@ module Page.Explore exposing
 
 import Browser.Events
 import Browser.Navigation as Nav
+import Data.Component as ObjectComponent
 import Data.Country as Country exposing (Country)
 import Data.Dataset as Dataset exposing (Dataset)
 import Data.Example as Example exposing (Example)
@@ -21,7 +22,6 @@ import Data.Food.Recipe as Recipe
 import Data.Impact as Impact
 import Data.Impact.Definition as Definition exposing (Definition, Definitions)
 import Data.Key as Key
-import Data.Object.Component as ObjectComponent
 import Data.Object.Query as ObjectQuery
 import Data.Object.Simulator as ObjectSimulator
 import Data.Process as Process exposing (Process)

--- a/src/Page/Explore.elm
+++ b/src/Page/Explore.elm
@@ -11,7 +11,7 @@ module Page.Explore exposing
 
 import Browser.Events
 import Browser.Navigation as Nav
-import Data.Component as ObjectComponent
+import Data.Component as Component exposing (Component)
 import Data.Country as Country exposing (Country)
 import Data.Dataset as Dataset exposing (Dataset)
 import Data.Example as Example exposing (Example)
@@ -419,9 +419,9 @@ foodProcessesExplorer { food } tableConfig tableState maybeId =
 
 objectComponentsExplorer :
     Db
-    -> Table.Config ObjectComponent.Component Msg
+    -> Table.Config Component Msg
     -> SortableTable.State
-    -> Maybe ObjectComponent.Id
+    -> Maybe Component.Id
     -> List (Html Msg)
 objectComponentsExplorer db tableConfig tableState maybeId =
     [ db.object.components
@@ -430,7 +430,7 @@ objectComponentsExplorer db tableConfig tableState maybeId =
     , case maybeId of
         Just id ->
             detailsModal
-                (case ObjectComponent.findById id db.object.components of
+                (case Component.findById id db.object.components of
                     Err error ->
                         alert error
 
@@ -681,7 +681,7 @@ getObjectScore : Db -> Example ObjectQuery.Query -> Float
 getObjectScore db =
     .query
         >> ObjectSimulator.compute db
-        >> Result.map (ObjectSimulator.extractImpacts >> Impact.getImpact Definition.Ecs >> Unit.impactToFloat)
+        >> Result.map (Component.extractImpacts >> Impact.getImpact Definition.Ecs >> Unit.impactToFloat)
         >> Result.withDefault 0
 
 

--- a/src/Page/Explore/ObjectComponents.elm
+++ b/src/Page/Explore/ObjectComponents.elm
@@ -1,7 +1,7 @@
 module Page.Explore.ObjectComponents exposing (table)
 
+import Data.Component as Component
 import Data.Dataset as Dataset
-import Data.Object.Component as ObjectComponent
 import Data.Process as Process
 import Data.Scope exposing (Scope)
 import Html exposing (..)
@@ -13,23 +13,23 @@ import Views.Alert as Alert
 import Views.Format as Format
 
 
-table : Db -> { detailed : Bool, scope : Scope } -> Table ObjectComponent.Component String msg
+table : Db -> { detailed : Bool, scope : Scope } -> Table Component.Component String msg
 table db { detailed, scope } =
     { filename = "components"
-    , toId = .id >> ObjectComponent.idToString
+    , toId = .id >> Component.idToString
     , toRoute = .id >> Just >> Dataset.ObjectComponents >> Route.Explore scope
     , legend = []
     , columns =
         [ { label = "Identifiant"
-          , toValue = Table.StringValue <| .id >> ObjectComponent.idToString
+          , toValue = Table.StringValue <| .id >> Component.idToString
           , toCell =
                 \component ->
                     if detailed then
-                        code [] [ text (ObjectComponent.idToString component.id) ]
+                        code [] [ text (Component.idToString component.id) ]
 
                     else
                         a [ Route.href (Route.Explore scope (Dataset.ObjectComponents (Just component.id))) ]
-                            [ code [] [ text (ObjectComponent.idToString component.id) ] ]
+                            [ code [] [ text (Component.idToString component.id) ] ]
           }
         , { label = "Nom"
           , toValue = Table.StringValue .name
@@ -39,7 +39,7 @@ table db { detailed, scope } =
           , toValue =
                 Table.StringValue <|
                     \{ processes } ->
-                        case ObjectComponent.expandProcessItems db.object.processes processes of
+                        case Component.expandProcessItems db.object.processes processes of
                             Err _ ->
                                 ""
 
@@ -47,7 +47,7 @@ table db { detailed, scope } =
                                 list
                                     |> List.map
                                         (\( amount, process ) ->
-                                            String.fromFloat (ObjectComponent.amountToFloat amount)
+                                            String.fromFloat (Component.amountToFloat amount)
                                                 ++ process.unit
                                                 ++ " de "
                                                 ++ Process.getDisplayName process
@@ -55,7 +55,7 @@ table db { detailed, scope } =
                                     |> String.join ", "
           , toCell =
                 \{ processes } ->
-                    case ObjectComponent.expandProcessItems db.object.processes processes of
+                    case Component.expandProcessItems db.object.processes processes of
                         Err err ->
                             Alert.simple
                                 { close = Nothing

--- a/src/Page/Object.elm
+++ b/src/Page/Object.elm
@@ -14,11 +14,11 @@ import Browser.Events
 import Browser.Navigation as Navigation
 import Data.AutocompleteSelector as AutocompleteSelector
 import Data.Bookmark as Bookmark exposing (Bookmark)
+import Data.Component as Component exposing (Component, ComponentItem)
 import Data.Dataset as Dataset
 import Data.Example as Example exposing (Example)
 import Data.Impact.Definition as Definition exposing (Definition)
 import Data.Key as Key
-import Data.Object.Component as Component exposing (Component, ComponentItem)
 import Data.Object.Query as Query exposing (Query)
 import Data.Object.Simulator as Simulator exposing (Results)
 import Data.Process as Process exposing (Process)

--- a/src/Page/Object.elm
+++ b/src/Page/Object.elm
@@ -499,7 +499,8 @@ addComponentButton : Db -> Query -> Html Msg
 addComponentButton db query =
     let
         availableComponents =
-            Simulator.availableComponents db query
+            db.object.components
+                |> Component.available (List.map .id query.components)
 
         autocompleteState =
             AutocompleteSelector.init .name availableComponents

--- a/src/Page/Object.elm
+++ b/src/Page/Object.elm
@@ -20,7 +20,7 @@ import Data.Example as Example exposing (Example)
 import Data.Impact.Definition as Definition exposing (Definition)
 import Data.Key as Key
 import Data.Object.Query as Query exposing (Query)
-import Data.Object.Simulator as Simulator exposing (Results)
+import Data.Object.Simulator as Simulator
 import Data.Process as Process exposing (Process)
 import Data.Scope as Scope exposing (Scope)
 import Data.Session as Session exposing (Session)
@@ -58,7 +58,7 @@ type alias Model =
     , impact : Definition
     , initialQuery : Query
     , modal : Modal
-    , results : Results
+    , results : Component.Results
     , scope : Scope
     }
 
@@ -124,7 +124,7 @@ init scope trigram maybeUrlQuery session =
       , modal = NoModal
       , results =
             Simulator.compute session.db initialQuery
-                |> Result.withDefault Simulator.emptyResults
+                |> Result.withDefault Component.emptyResults
       , scope = scope
       }
     , session
@@ -169,7 +169,7 @@ initFromExample session scope uuid =
       , modal = NoModal
       , results =
             Simulator.compute session.db exampleQuery
-                |> Result.withDefault Simulator.emptyResults
+                |> Result.withDefault Component.emptyResults
       , scope = scope
       }
     , session
@@ -214,7 +214,7 @@ updateQuery query ( model, session, commands ) =
         , results =
             query
                 |> Simulator.compute session.db
-                |> Result.withDefault Simulator.emptyResults
+                |> Result.withDefault Component.emptyResults
       }
     , session |> Session.updateObjectQuery model.scope query
     , commands
@@ -470,8 +470,8 @@ simulatorView session model =
 
                 -- Score
                 , customScoreInfo = Nothing
-                , productMass = Simulator.extractMass model.results
-                , totalImpacts = Simulator.extractImpacts model.results
+                , productMass = Component.extractMass model.results
+                , totalImpacts = Component.extractImpacts model.results
                 , totalImpactsWithoutDurability = Nothing
 
                 -- Impacts tabs
@@ -557,7 +557,7 @@ componentListView db { detailedComponents, impact, results } query =
                                 , th [ scope "col" ] []
                                 ]
                             ]
-                        , Simulator.extractItems results
+                        , Component.extractItems results
                             |> List.map2 (componentView impact detailedComponents) elements
                             |> List.concat
                             |> tbody []
@@ -567,7 +567,12 @@ componentListView db { detailedComponents, impact, results } query =
     ]
 
 
-componentView : Definition -> List Component.Id -> ( Component.Quantity, Component, List ( Component.Amount, Process ) ) -> Results -> List (Html Msg)
+componentView :
+    Definition
+    -> List Component.Id
+    -> ( Component.Quantity, Component, List ( Component.Amount, Process ) )
+    -> Component.Results
+    -> List (Html Msg)
 componentView selectedImpact detailedComponents ( quantity, component, processAmounts ) itemResults =
     let
         collapsed =
@@ -599,11 +604,11 @@ componentView selectedImpact detailedComponents ( quantity, component, processAm
                 , td [ class "align-middle text-truncate w-100 fw-bold", colspan 2 ]
                     [ text component.name ]
                 , td [ class "text-end align-middle text-nowrap" ]
-                    [ Simulator.extractMass itemResults
+                    [ Component.extractMass itemResults
                         |> Format.kg
                     ]
                 , td [ class "text-end align-middle text-nowrap" ]
-                    [ Simulator.extractImpacts itemResults
+                    [ Component.extractImpacts itemResults
                         |> Format.formatImpact selectedImpact
                     ]
                 , td [ class "pe-3 align-middle text-nowrap" ]
@@ -626,7 +631,7 @@ componentView selectedImpact detailedComponents ( quantity, component, processAm
                 text ""
           ]
         , if not collapsed then
-            Simulator.extractItems itemResults
+            Component.extractItems itemResults
                 |> List.map2 (processView selectedImpact) processAmounts
 
           else
@@ -634,7 +639,7 @@ componentView selectedImpact detailedComponents ( quantity, component, processAm
         ]
 
 
-processView : Definition -> ( Component.Amount, Process ) -> Results -> Html Msg
+processView : Definition -> ( Component.Amount, Process ) -> Component.Results -> Html Msg
 processView selectedImpact ( amount, process ) itemResults =
     tr [ class "fs-7" ]
         [ td [] []
@@ -645,9 +650,9 @@ processView selectedImpact ( amount, process ) itemResults =
         , td [ class "align-middle text-end text-nowrap" ]
             [ Format.density process ]
         , td [ class "text-end align-middle text-nowrap" ]
-            [ Format.kg <| Simulator.extractMass itemResults ]
+            [ Format.kg <| Component.extractMass itemResults ]
         , td [ class "text-end align-middle text-nowrap" ]
-            [ Simulator.extractImpacts itemResults
+            [ Component.extractImpacts itemResults
                 |> Format.formatImpact selectedImpact
             ]
         , td [ class "pe-3 align-middle text-nowrap" ]

--- a/src/Views/Comparator.elm
+++ b/src/Views/Comparator.elm
@@ -4,6 +4,7 @@ module Views.Comparator exposing
     )
 
 import Data.Bookmark as Bookmark exposing (Bookmark)
+import Data.Component as Component
 import Data.Food.Recipe as Recipe
 import Data.Impact as Impact
 import Data.Impact.Definition as Definition exposing (Definition, Definitions)
@@ -128,7 +129,7 @@ addToComparison session label query =
                 |> Result.map
                     (\results ->
                         { complementsImpact = Impact.noComplementsImpacts
-                        , impacts = ObjectSimulator.extractImpacts results
+                        , impacts = Component.extractImpacts results
                         , label = label
                         , stepsImpacts =
                             results
@@ -156,7 +157,7 @@ addToComparison session label query =
                 |> Result.map
                     (\results ->
                         { complementsImpact = Impact.noComplementsImpacts
-                        , impacts = ObjectSimulator.extractImpacts results
+                        , impacts = Component.extractImpacts results
                         , label = label
                         , stepsImpacts =
                             results

--- a/src/Views/Format.elm
+++ b/src/Views/Format.elm
@@ -27,9 +27,9 @@ module Views.Format exposing
     )
 
 import Area exposing (Area)
+import Data.Component as Component
 import Data.Impact as Impact exposing (Impacts)
 import Data.Impact.Definition exposing (Definition)
-import Data.Object.Component as Component
 import Data.Process exposing (Process)
 import Data.Split as Split exposing (Split)
 import Data.Textile.Economics as Economics

--- a/src/Views/ImpactTabs.elm
+++ b/src/Views/ImpactTabs.elm
@@ -8,10 +8,10 @@ module Views.ImpactTabs exposing
     , view
     )
 
+import Data.Component as Component
 import Data.Food.Recipe as Recipe
 import Data.Impact as Impact exposing (Impacts)
 import Data.Impact.Definition as Definition exposing (Definition, Definitions)
-import Data.Object.Simulator as ObjectSimulator
 import Data.Scoring as Scoring exposing (Scoring)
 import Data.Session as Session exposing (Session)
 import Data.Textile.Simulator as TextileSimulator exposing (Simulator)
@@ -190,14 +190,17 @@ forFood results config =
     }
 
 
-forObject : ObjectSimulator.Results -> Config msg -> Config msg
+{-| Note: for now, object simulation impacts are only the impacts of its components, but
+this will change as soon as we add more steps to the life cycle.
+-}
+forObject : Component.Results -> Config msg -> Config msg
 forObject results config =
     { config
         | stepsImpacts =
             { distribution = Nothing
             , endOfLife = Nothing
             , materials =
-                ObjectSimulator.extractImpacts results
+                Component.extractImpacts results
                     |> Impact.getImpact config.impactDefinition.trigram
                     |> Just
             , packaging = Nothing

--- a/tests/Data/ComponentTest.elm
+++ b/tests/Data/ComponentTest.elm
@@ -1,0 +1,46 @@
+module Data.ComponentTest exposing (..)
+
+import Data.Component as Component
+import Expect
+import Json.Decode as Decode
+import Test exposing (..)
+import TestUtils exposing (asTest, suiteWithDb)
+
+
+sampleJsonComponentsItems : String
+sampleJsonComponentsItems =
+    """[
+        {
+          "id": "64fa65b3-c2df-4fd0-958b-83965bd6aa08",
+          "quantity": 4
+        },
+        {
+          "id": "ad9d7f23-076b-49c5-93a4-ee1cd7b53973",
+          "quantity": 1
+        },
+        {
+          "id": "eda5dd7e-52e4-450f-8658-1876efc62bd6",
+          "quantity": 1
+        }
+      ]
+      """
+
+
+suite : Test
+suite =
+    suiteWithDb "Data.Component"
+        (\db ->
+            let
+                { components, processes } =
+                    db.object
+            in
+            [ describe "Component.compute"
+                [ sampleJsonComponentsItems
+                    |> Decode.decodeString (Decode.list Component.decodeComponentItem)
+                    |> Result.mapError Decode.errorToString
+                    |> Result.andThen (Component.compute components processes)
+                    |> Expect.ok
+                    |> asTest "should compute results from decoded component items"
+                ]
+            ]
+        )

--- a/tests/Data/ComponentTest.elm
+++ b/tests/Data/ComponentTest.elm
@@ -30,15 +30,11 @@ suite : Test
 suite =
     suiteWithDb "Data.Component"
         (\db ->
-            let
-                { components, processes } =
-                    db.object
-            in
             [ describe "Component.compute"
                 [ sampleJsonComponentsItems
                     |> Decode.decodeString (Decode.list Component.decodeComponentItem)
                     |> Result.mapError Decode.errorToString
-                    |> Result.andThen (Component.compute components processes)
+                    |> Result.andThen (Component.compute db.object)
                     |> Expect.ok
                     |> asTest "should compute results from decoded component items"
                 ]

--- a/tests/Data/ComponentTest.elm
+++ b/tests/Data/ComponentTest.elm
@@ -1,29 +1,29 @@
 module Data.ComponentTest exposing (..)
 
 import Data.Component as Component
+import Data.Impact as Impact
+import Data.Impact.Definition as Definition
+import Data.Unit as Unit
 import Expect
 import Json.Decode as Decode
 import Test exposing (..)
 import TestUtils exposing (asTest, suiteWithDb)
 
 
+getEcsImpact : Component.Results -> Float
+getEcsImpact =
+    Component.extractImpacts >> (Impact.getImpact Definition.Ecs >> Unit.impactToFloat)
+
+
 sampleJsonComponentsItems : String
 sampleJsonComponentsItems =
-    """[
-        {
-          "id": "64fa65b3-c2df-4fd0-958b-83965bd6aa08",
-          "quantity": 4
-        },
-        {
-          "id": "ad9d7f23-076b-49c5-93a4-ee1cd7b53973",
-          "quantity": 1
-        },
-        {
-          "id": "eda5dd7e-52e4-450f-8658-1876efc62bd6",
-          "quantity": 1
-        }
-      ]
-      """
+    """
+    [
+      { "id": "64fa65b3-c2df-4fd0-958b-83965bd6aa08", "quantity": 4 },
+      { "id": "ad9d7f23-076b-49c5-93a4-ee1cd7b53973", "quantity": 1 },
+      { "id": "eda5dd7e-52e4-450f-8658-1876efc62bd6", "quantity": 1 }
+    ]
+    """
 
 
 suite : Test
@@ -35,7 +35,8 @@ suite =
                     |> Decode.decodeString (Decode.list Component.decodeComponentItem)
                     |> Result.mapError Decode.errorToString
                     |> Result.andThen (Component.compute db.object)
-                    |> Expect.ok
+                    |> Result.map getEcsImpact
+                    |> TestUtils.expectResultWithin (Expect.Absolute 1) 422
                     |> asTest "should compute results from decoded component items"
                 ]
             ]

--- a/tests/Data/ComponentTest.elm
+++ b/tests/Data/ComponentTest.elm
@@ -18,10 +18,9 @@ getEcsImpact =
 sampleJsonComponentsItems : String
 sampleJsonComponentsItems =
     """
-    [
-      { "id": "64fa65b3-c2df-4fd0-958b-83965bd6aa08", "quantity": 4 },
-      { "id": "ad9d7f23-076b-49c5-93a4-ee1cd7b53973", "quantity": 1 },
-      { "id": "eda5dd7e-52e4-450f-8658-1876efc62bd6", "quantity": 1 }
+    [ { "id": "64fa65b3-c2df-4fd0-958b-83965bd6aa08", "quantity": 4 }
+    , { "id": "ad9d7f23-076b-49c5-93a4-ee1cd7b53973", "quantity": 1 }
+    , { "id": "eda5dd7e-52e4-450f-8658-1876efc62bd6", "quantity": 1 }
     ]
     """
 

--- a/tests/Data/Object/SimulatorTest.elm
+++ b/tests/Data/Object/SimulatorTest.elm
@@ -1,5 +1,6 @@
 module Data.Object.SimulatorTest exposing (..)
 
+import Data.Component as Component
 import Data.Example as Example
 import Data.Impact as Impact
 import Data.Impact.Definition as Definition
@@ -16,7 +17,7 @@ getEcsImpact : Db -> Query -> Result String Float
 getEcsImpact db =
     Simulator.compute db
         >> Result.map
-            (Simulator.extractImpacts
+            (Component.extractImpacts
                 >> (Impact.getImpact Definition.Ecs >> Unit.impactToFloat)
             )
 

--- a/tests/TestUtils.elm
+++ b/tests/TestUtils.elm
@@ -2,6 +2,7 @@ module TestUtils exposing
     ( asTest
     , createServerRequest
     , expectImpactsEqual
+    , expectResultWithin
     , suiteWithDb
     )
 
@@ -9,7 +10,7 @@ import Data.Impact as Impact exposing (Impacts)
 import Data.Impact.Definition as Definition exposing (Trigrams)
 import Data.Process as Process
 import Data.Unit as Unit
-import Expect exposing (Expectation)
+import Expect exposing (Expectation, FloatingPointTolerance)
 import Json.Encode as Encode
 import Server.Request exposing (Request)
 import Static.Db as StaticDb exposing (Db)
@@ -45,6 +46,16 @@ expectImpactsEqual impacts subject =
         |> (\expectations ->
                 Expect.all expectations subject
            )
+
+
+expectResultWithin : FloatingPointTolerance -> Float -> Result String Float -> Expectation
+expectResultWithin precision target result =
+    case result of
+        Ok float ->
+            float |> Expect.within precision target
+
+        Err err ->
+            Expect.fail err
 
 
 createServerRequest : StaticDb.Db -> String -> Encode.Value -> String -> Request


### PR DESCRIPTION
## :wrench: Problem

[User story](https://www.notion.so/Abstraire-les-composants-dans-le-code-ecb8ebdfccff4175a2994e0613792466)

Today we have object-specific components, but we need them to be domain-agnostic so we can use the same code and data source format to handle food, object and textile ones.

## :cake: Solution

Move component impacts computation into `Data.Component` module including `Result` to make the calculation domain-agnostic.

## :rotating_light:  Points to watch/comments

As always with code refactoring, ensure the exposed/updated api makes sense and is as much future-proof as possible.

## :desert_island: How to test

Ensure that nothing breaks:
- tests should be green, including added ones
- Object components explorer should work as previously
- Object and véli simulators should work as previously