### PR TITLE
feat(data,ui): add trims to more textile examples, render them in explorer

### DIFF
--- a/public/data/textile/components.json
+++ b/public/data/textile/components.json
@@ -1,7 +1,7 @@
 [
   {
     "id": "86b877ff-0d59-482f-bb34-3ff306b07496",
-    "name": "Zip pour veste",
+    "name": "Zip long",
     "processes": [
       {
         "process_id": "8b91651b-9651-46fc-8bc2-37a141494086",
@@ -11,7 +11,7 @@
   },
   {
     "id": "0e8ea799-9b06-490c-a925-37564746c454",
-    "name": "Zip pour jeans",
+    "name": "Zip court",
     "processes": [
       {
         "process_id": "8b91651b-9651-46fc-8bc2-37a141494086",

--- a/public/data/textile/examples.json
+++ b/public/data/textile/examples.json
@@ -353,7 +353,11 @@
       "product": "jupe",
       "marketingDuration": 65,
       "numberOfReferences": 100000,
-      "price": 15
+      "price": 15,
+      "trims": [
+        { "quantity": 1, "id": "0e8ea799-9b06-490c-a925-37564746c454" },
+        { "quantity": 1, "id": "d56bb0d5-7999-4b8b-b076-94d79099b56a" }
+      ]
     }
   },
   {
@@ -372,7 +376,8 @@
       "product": "chemise",
       "marketingDuration": 65,
       "numberOfReferences": 100000,
-      "price": 15
+      "price": 15,
+      "trims": [{ "quantity": 10, "id": "d56bb0d5-7999-4b8b-b076-94d79099b56a" }]
     }
   },
   {
@@ -415,7 +420,11 @@
       "product": "pantalon",
       "marketingDuration": 65,
       "numberOfReferences": 100000,
-      "price": 20
+      "price": 20,
+      "trims": [
+        { "quantity": 1, "id": "0c903fc7-279b-4375-8cfa-ca8133b8e973" },
+        { "quantity": 1, "id": "0e8ea799-9b06-490c-a925-37564746c454" }
+      ]
     }
   },
   {
@@ -434,7 +443,11 @@
       "product": "manteau",
       "marketingDuration": 65,
       "numberOfReferences": 100000,
-      "price": 40
+      "price": 40,
+      "trims": [
+        { "quantity": 1, "id": "86b877ff-0d59-482f-bb34-3ff306b07496" },
+        { "quantity": 3, "id": "d56bb0d5-7999-4b8b-b076-94d79099b56a" }
+      ]
     }
   },
   {

--- a/src/Page/Explore.elm
+++ b/src/Page/Explore.elm
@@ -552,7 +552,7 @@ textileExamplesExplorer db tableConfig tableState maybeId =
     in
     [ scoredExamples
         |> List.sortBy (Tuple.first >> .name)
-        |> Table.viewList OpenDetail tableConfig tableState Scope.Textile (TextileExamples.table max)
+        |> Table.viewList OpenDetail tableConfig tableState Scope.Textile (TextileExamples.table db max)
     , case maybeId of
         Just id ->
             detailsModal
@@ -562,7 +562,7 @@ textileExamplesExplorer db tableConfig tableState maybeId =
 
                     Ok example ->
                         Table.viewDetails Scope.Textile
-                            (TextileExamples.table max)
+                            (TextileExamples.table db max)
                             ( example
                             , { score = getTextileScore db example
                               , per100g = getTextileScorePer100g db example


### PR DESCRIPTION
## :wrench: Problem

More example garments should feature trims ([Notion card](https://www.notion.so/Sc-nario-par-d-faut-pour-les-trims-1d3abd5235cc46b4bf746d090f094fdd)). We should also render them in the textile examples explorer.

## :cake: Solution

Update textile examples with new trims data. Render them in the textile examples exporer.

## :desert_island: How to test

Check that the updated textile examples (see notion card) feature the expected trims. Check the textile examples explorer.