### PR TITLE
feat: allow expanding trim details.

### DIFF
--- a/src/Page/Textile.elm
+++ b/src/Page/Textile.elm
@@ -1015,7 +1015,7 @@ simulatorFormView session model ({ inputs } as simulator) =
         ]
     , TrimView.editorView
         { addLabel = "Ajouter un accessoire"
-        , allowExpandDetails = False
+        , allowExpandDetails = True
         , db = session.db.textile
         , detailed = model.detailedTrims
         , impact = model.impact


### PR DESCRIPTION
## :wrench: Problem

Users want trim impact and amount details, as we have in the Object simulator.

## :cake: Solution

Allow expanding textile trim details as we allow it for object components.

## :desert_island: How to test

Check that trim details are expanded and collapsed when clicking the black arrow next to a trim row.