### PR TITLE
fix: Warn on session data decoding error.

### DIFF
--- a/src/Data/Session.elm
+++ b/src/Data/Session.elm
@@ -296,9 +296,7 @@ decodeRawStore : String -> Session -> Session
 decodeRawStore rawStore session =
     case Decode.decodeString decodeStore rawStore of
         Err error ->
-            session
-                |> notifyStoreDecodingError error
-                |> updateStore (always defaultStore)
+            session |> notifyStoreDecodingError error
 
         Ok store ->
             { session | store = store }

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -88,6 +88,7 @@ type Msg
     | OpenMobileNavigation
     | ReleasesReceived (WebData (List Github.Release))
     | ReloadPage
+    | ResetSessionStore
     | StatsMsg Stats.Msg
     | StoreChanged String
     | SwitchVersion String
@@ -356,6 +357,16 @@ update rawMsg ({ state } as model) =
                     , Cmd.none
                     )
 
+                ( ResetSessionStore, currentPage ) ->
+                    let
+                        newSession =
+                            { session | notifications = [], store = Session.defaultStore }
+                                |> Session.notifyInfo "Session" "La session a été réinitialisée."
+                    in
+                    ( { model | state = currentPage |> Loaded newSession }
+                    , newSession.store |> Session.serializeStore |> Ports.saveStore
+                    )
+
                 -- Version switch
                 ( SwitchVersion version, _ ) ->
                     ( model
@@ -476,6 +487,7 @@ view { mobileNavigationOpened, state } =
                         LoadUrl
                         ReloadPage
                         CloseNotification
+                        ResetSessionStore
                         SwitchVersion
 
                 mapMsg msg ( title, content ) =

--- a/src/Views/Alert.elm
+++ b/src/Views/Alert.elm
@@ -26,6 +26,7 @@ type Level
     = Danger
     | Info
     | Success
+    | Warning
 
 
 icon : Level -> Html msg
@@ -39,6 +40,9 @@ icon level =
 
         Success ->
             span [ class "me-1" ] [ Icon.checkCircle ]
+
+        Warning ->
+            span [ class "me-1" ] [ Icon.warning ]
 
 
 httpError : Http.Error -> Html msg
@@ -125,3 +129,6 @@ levelToClass level =
 
         Success ->
             "success"
+
+        Warning ->
+            "warning"

--- a/src/Views/Page.elm
+++ b/src/Views/Page.elm
@@ -15,6 +15,7 @@ import Data.Session as Session exposing (Session)
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (..)
+import Json.Decode as Decode
 import RemoteData
 import Request.Version as Version exposing (Version(..))
 import Route
@@ -22,6 +23,7 @@ import Views.Alert as Alert
 import Views.Container as Container
 import Views.Icon as Icon
 import Views.Link as Link
+import Views.Markdown as Markdown
 import Views.Spinner as Spinner
 
 
@@ -454,6 +456,23 @@ notificationView { closeNotification } notification =
                 , title = Just title
                 , close = Just (closeNotification notification)
                 , content = [ text message ]
+                }
+
+        Session.StoreDecodingError decodeError ->
+            Alert.simple
+                { level = Alert.Danger
+                , title = Just "Erreur de récupération de session"
+                , close = Nothing
+                , content =
+                    [ Markdown.simple []
+                        """Votre précédente session n'a pas pu être récupérée, elle a donc été réinitialisée.
+                           Vous aurez peut-être besoin de vous [réauthentifier](/#/auth/) sur la plateforme.
+                        """
+                    , details []
+                        [ summary [] [ text "Afficher les détails technique de l'erreur" ]
+                        , pre [] [ text <| Decode.errorToString decodeError ]
+                        ]
+                    ]
                 }
 
 

--- a/src/Views/Page.elm
+++ b/src/Views/Page.elm
@@ -23,7 +23,6 @@ import Views.Alert as Alert
 import Views.Container as Container
 import Views.Icon as Icon
 import Views.Link as Link
-import Views.Markdown as Markdown
 import Views.Spinner as Spinner
 
 
@@ -55,6 +54,7 @@ type alias Config msg =
     , loadUrl : String -> msg
     , reloadPage : msg
     , closeNotification : Session.Notification -> msg
+    , resetSessionStore : msg
     , switchVersion : String -> msg
     , activePage : ActivePage
     }
@@ -438,7 +438,7 @@ notificationListView ({ session } as config) =
 
 
 notificationView : Config msg -> Session.Notification -> Html msg
-notificationView { closeNotification } notification =
+notificationView { closeNotification, resetSessionStore } notification =
     -- TODO:
     -- - absolute positionning
     case notification of
@@ -464,10 +464,8 @@ notificationView { closeNotification } notification =
                 , title = Just "Erreur de récupération de session"
                 , close = Nothing
                 , content =
-                    [ Markdown.simple []
-                        """Votre précédente session n'a pas pu être récupérée, elle a donc été réinitialisée.
-                           Vous aurez peut-être besoin de vous [réauthentifier](/#/auth/) sur la plateforme.
-                        """
+                    [ p [] [ text "Votre précédente session n'a pas pu être récupérée, elle doit donc être réinitialisée." ]
+                    , p [] [ button [ class "btn btn-primary", onClick resetSessionStore ] [ text "D'accord" ] ]
                     , details []
                         [ summary [] [ text "Afficher les détails techniques de l'erreur" ]
                         , pre [] [ text <| Decode.errorToString decodeError ]

--- a/src/Views/Page.elm
+++ b/src/Views/Page.elm
@@ -460,7 +460,7 @@ notificationView { closeNotification } notification =
 
         Session.StoreDecodingError decodeError ->
             Alert.simple
-                { level = Alert.Danger
+                { level = Alert.Warning
                 , title = Just "Erreur de récupération de session"
                 , close = Nothing
                 , content =

--- a/src/Views/Page.elm
+++ b/src/Views/Page.elm
@@ -465,7 +465,7 @@ notificationView { closeNotification, resetSessionStore } notification =
                 , close = Nothing
                 , content =
                     [ p [] [ text "Votre précédente session n'a pas pu être récupérée, elle doit donc être réinitialisée." ]
-                    , p [] [ button [ class "btn btn-primary", onClick resetSessionStore ] [ text "D'accord" ] ]
+                    , p [] [ button [ class "btn btn-primary", onClick resetSessionStore ] [ text "D’accord, réinitialiser la session" ] ]
                     , details []
                         [ summary [] [ text "Afficher les détails techniques de l'erreur" ]
                         , pre [] [ text <| Decode.errorToString decodeError ]

--- a/src/Views/Page.elm
+++ b/src/Views/Page.elm
@@ -469,7 +469,7 @@ notificationView { closeNotification } notification =
                            Vous aurez peut-être besoin de vous [réauthentifier](/#/auth/) sur la plateforme.
                         """
                     , details []
-                        [ summary [] [ text "Afficher les détails technique de l'erreur" ]
+                        [ summary [] [ text "Afficher les détails techniques de l'erreur" ]
                         , pre [] [ text <| Decode.errorToString decodeError ]
                         ]
                     ]


### PR DESCRIPTION
## 🔧 **Problem**

Context: comment from @vjousse (https://github.com/MTES-MCT/ecobalyse/pull/878#issuecomment-2577039188):

> the problem is with the local storage decoding. The `staff` field is missing in my local storage (so I suppose that the Elm json decode is failing), if I add it by hand it works again as expected.

No error message is rendered to users when decoding their serialized session data fails.

## 🍰 Solution

Warn the user that decoding the session has failed, with useful information on how to report the problem:

![image](https://github.com/user-attachments/assets/5cb53ef4-18d8-428b-bd5d-ccd177f86a30)

## 🏝️ **How to test**

Tamper with serialized user session data in localstorage and check that an error message is rendered to the user.