### PR TITLE
fix: allow workflow dispatch for release creation

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1,6 +1,7 @@
 name: Create tag and release
 
 on:
+  workflow_dispatch:
   pull_request:
     types: [closed]
 
@@ -11,8 +12,7 @@ permissions:
 jobs:
   create_tag_and_release:
     # The tag and the release should be created only when the automated PR created by `create_pr_for_changelog` is merged
-    # Or to test it for now, by triggering a workflow dispatch by hand
-    if: (github.event.pull_request.merged == true && startsWith(github.event.pull_request.title, 'chore(release)') && contains(github.event.pull_request.labels.*.name, 'automated') && contains(github.event.pull_request.labels.*.name, 'pending-release'))
+    if: ((github.event.pull_request.merged == true && startsWith(github.event.pull_request.title, 'chore(release)') && contains(github.event.pull_request.labels.*.name, 'automated') && contains(github.event.pull_request.labels.*.name, 'pending-release'))|| github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1,5 +1,8 @@
 name: Create tag and release
 
+env:
+  TRANSCRYPT_KEY: ${{ secrets.TRANSCRYPT_KEY }}
+
 on:
   workflow_dispatch:
   pull_request:


### PR DESCRIPTION
## :wrench: Problem

The current release workflow fails because it’s missing the transcrypt key env variable. See https://github.com/MTES-MCT/ecobalyse/actions/runs/12748629218

## :cake: Solution

Add the env variable and allow the possibility to run the workflow by hand with a dispatch in case of failure.


## :desert_island: How to test

Hard to test as it is only testable when creating a release…

Once it has been approved, I’ll remove the already created tag and restart the release process by hand using the workflow dispatch added here.
