### PR TITLE
feat: show heat, elec, waste, density in process explorer.

### DIFF
--- a/src/Page/Explore/Processes.elm
+++ b/src/Page/Explore/Processes.elm
@@ -75,7 +75,7 @@ baseColumns detailed scope =
       , toValue = Table.StringValue <| .unit
       , toCell = .unit >> text
       }
-    , { label = "Electricité"
+    , { label = "Électricité"
       , toValue = Table.FloatValue <| .elec >> Energy.inKilowattHours
       , toCell = .elec >> Format.kilowattHours
       }

--- a/src/Page/Explore/Processes.elm
+++ b/src/Page/Explore/Processes.elm
@@ -7,7 +7,9 @@ import Data.Process as Process exposing (Process)
 import Data.Process.Category as ProcessCategory
 import Data.Scope exposing (Scope)
 import Data.Session as Session exposing (Session)
+import Data.Split as Split
 import Data.Unit as Unit
+import Energy
 import Html exposing (..)
 import Page.Explore.Table as Table exposing (Column, Table)
 import Route
@@ -72,6 +74,22 @@ baseColumns detailed scope =
     , { label = "Unité"
       , toValue = Table.StringValue <| .unit
       , toCell = .unit >> text
+      }
+    , { label = "Electricité"
+      , toValue = Table.FloatValue <| .elec >> Energy.inKilowattHours
+      , toCell = .elec >> Format.kilowattHours
+      }
+    , { label = "Chaleur"
+      , toValue = Table.FloatValue <| .heat >> Energy.inMegajoules
+      , toCell = .heat >> Format.megajoules
+      }
+    , { label = "Pertes"
+      , toValue = Table.FloatValue <| .waste >> Split.toPercent
+      , toCell = .waste >> Format.splitAsPercentage 2
+      }
+    , { label = "Densité"
+      , toValue = Table.FloatValue .density
+      , toCell = Format.density
       }
     , { label = "Commentaire"
       , toValue = Table.StringValue .comment


### PR DESCRIPTION
## :wrench: Problem

Process explorers don't currently show waste, density, elec and heat fields.

## :cake: Solution

Show them.

## :desert_island: How to test

Check that these fields are added as columns in process explorer tables and as rows in process explorer details modals.