### PR TITLE
feat: render component transforms

### DIFF
--- a/public/data/object/components.json
+++ b/public/data/object/components.json
@@ -68,7 +68,7 @@
   {
     "elements": [
       {
-        "amount": 1.1741,
+        "amount": 1.05761,
         "material": "62a4d6fb-3276-4ba5-93a3-889ecd3bff84",
         "transforms": [
           "9c478d79-ff6b-45e1-9396-c3bd897faa1d",
@@ -76,7 +76,7 @@
         ]
       },
       {
-        "amount": 1.1741,
+        "amount": 1.05761,
         "material": "9dba0e95-0c35-4f8b-9267-62ddf47d4984",
         "transforms": [
           "9c478d79-ff6b-45e1-9396-c3bd897faa1d",

--- a/public/data/object/components.json
+++ b/public/data/object/components.json
@@ -64,5 +64,27 @@
     ],
     "id": "190276e9-5b90-42d6-8fbd-bc7ddfd4c960",
     "name": "Cadre plastique"
+  },
+  {
+    "elements": [
+      {
+        "amount": 1.067,
+        "material": "62a4d6fb-3276-4ba5-93a3-889ecd3bff84",
+        "transforms": [
+          "f9686809-f55e-4b96-b1f0-3298959de7d0",
+          "da9d1c32-a166-41ab-bac6-f67aff0cf44a"
+        ]
+      },
+      {
+        "amount": 1.067,
+        "material": "9dba0e95-0c35-4f8b-9267-62ddf47d4984",
+        "transforms": [
+          "f9686809-f55e-4b96-b1f0-3298959de7d0",
+          "ae9cbbad-7982-4f3c-9220-edf27946d347"
+        ]
+      }
+    ],
+    "id": "8ca2ca05-8aec-4121-acaa-7cdcc03150a9",
+    "name": "Tissu pour canapé"
   }
 ]

--- a/public/data/object/components.json
+++ b/public/data/object/components.json
@@ -68,7 +68,7 @@
   {
     "elements": [
       {
-        "amount": 1.0575,
+        "amount": 1.174,
         "material": "62a4d6fb-3276-4ba5-93a3-889ecd3bff84",
         "transforms": [
           "9c478d79-ff6b-45e1-9396-c3bd897faa1d",
@@ -76,7 +76,7 @@
         ]
       },
       {
-        "amount": 1.0575,
+        "amount": 1.174,
         "material": "9dba0e95-0c35-4f8b-9267-62ddf47d4984",
         "transforms": [
           "9c478d79-ff6b-45e1-9396-c3bd897faa1d",

--- a/public/data/object/components.json
+++ b/public/data/object/components.json
@@ -68,7 +68,7 @@
   {
     "elements": [
       {
-        "amount": 1.067,
+        "amount": 1.0575,
         "material": "62a4d6fb-3276-4ba5-93a3-889ecd3bff84",
         "transforms": [
           "9c478d79-ff6b-45e1-9396-c3bd897faa1d",
@@ -76,7 +76,7 @@
         ]
       },
       {
-        "amount": 1.067,
+        "amount": 1.0575,
         "material": "9dba0e95-0c35-4f8b-9267-62ddf47d4984",
         "transforms": [
           "9c478d79-ff6b-45e1-9396-c3bd897faa1d",

--- a/public/data/object/components.json
+++ b/public/data/object/components.json
@@ -71,7 +71,7 @@
         "amount": 1.067,
         "material": "62a4d6fb-3276-4ba5-93a3-889ecd3bff84",
         "transforms": [
-          "f9686809-f55e-4b96-b1f0-3298959de7d0",
+          "9c478d79-ff6b-45e1-9396-c3bd897faa1d",
           "da9d1c32-a166-41ab-bac6-f67aff0cf44a"
         ]
       },
@@ -79,7 +79,7 @@
         "amount": 1.067,
         "material": "9dba0e95-0c35-4f8b-9267-62ddf47d4984",
         "transforms": [
-          "f9686809-f55e-4b96-b1f0-3298959de7d0",
+          "9c478d79-ff6b-45e1-9396-c3bd897faa1d",
           "ae9cbbad-7982-4f3c-9220-edf27946d347"
         ]
       }

--- a/public/data/object/components.json
+++ b/public/data/object/components.json
@@ -68,7 +68,7 @@
   {
     "elements": [
       {
-        "amount": 1.174,
+        "amount": 1.1741,
         "material": "62a4d6fb-3276-4ba5-93a3-889ecd3bff84",
         "transforms": [
           "9c478d79-ff6b-45e1-9396-c3bd897faa1d",
@@ -76,7 +76,7 @@
         ]
       },
       {
-        "amount": 1.174,
+        "amount": 1.1741,
         "material": "9dba0e95-0c35-4f8b-9267-62ddf47d4984",
         "transforms": [
           "9c478d79-ff6b-45e1-9396-c3bd897faa1d",

--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -169,7 +169,13 @@ applyTransforms allProcesses transforms (Results materialResults) =
                             in
                             Results
                                 { impacts = Impact.sumImpacts [ transformImpacts, impacts ]
-                                , items = Results { impacts = transformImpacts, items = [], mass = Quantity.negate wastedMass } :: items
+                                , items =
+                                    Results
+                                        { impacts = transformImpacts
+                                        , items = []
+                                        , mass = Quantity.negate wastedMass
+                                        }
+                                        :: items
                                 , mass = outputMass
                                 }
                         )

--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -254,15 +254,13 @@ computeMaterialResults amount process =
                 |> Impact.multiplyBy (amountToFloat amount)
 
         mass =
-            (if process.unit == "kg" then
-                amountToFloat amount
+            Mass.kilograms <|
+                if process.unit == "kg" then
+                    amountToFloat amount
 
-             else
-                -- apply density
-                amountToFloat amount * process.density
-            )
-                |> Mass.kilograms
-                |> Quantity.multiplyBy (1 - Split.toFloat process.waste)
+                else
+                    -- apply density
+                    amountToFloat amount * process.density
     in
     -- global result
     Results

--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -254,13 +254,15 @@ computeMaterialResults amount process =
                 |> Impact.multiplyBy (amountToFloat amount)
 
         mass =
-            Mass.kilograms <|
-                if process.unit == "kg" then
-                    amountToFloat amount
+            (if process.unit == "kg" then
+                amountToFloat amount
 
-                else
-                    -- apply density
-                    amountToFloat amount * process.density
+             else
+                -- apply density
+                amountToFloat amount * process.density
+            )
+                |> Mass.kilograms
+                |> Quantity.multiplyBy (1 - Split.toFloat process.waste)
     in
     -- global result
     Results

--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -164,7 +164,7 @@ applyTransforms allProcesses transforms materialResults =
                                     , elec.impacts
                                         |> Impact.multiplyBy (Energy.inKilowattHours transform.elec)
                                     , heat.impacts
-                                        |> Impact.multiplyBy (Energy.inKilowattHours transform.heat)
+                                        |> Impact.multiplyBy (Energy.inMegajoules transform.heat)
                                     ]
                                         |> Impact.sumImpacts
                                         |> Impact.multiplyBy (Mass.inKilograms mass)

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -128,6 +128,16 @@ componentView config ( quantity, component, expandedElements ) itemResults =
         ]
 
 
+debugResults : Component.Results -> Html msg
+debugResults results =
+    pre [ class "p-2 bg-light" ]
+        [ results
+            |> Component.encodeResults (Just Definition.Ecs)
+            |> Encode.encode 2
+            |> text
+        ]
+
+
 editorView : Config db msg -> Html msg
 editorView ({ db, items, results, scope, title } as config) =
     div [ class "card shadow-sm mb-3" ]
@@ -182,16 +192,6 @@ editorView ({ db, items, results, scope, title } as config) =
         ]
 
 
-debugResults : Component.Results -> Html msg
-debugResults results =
-    pre [ class "p-2 bg-light" ]
-        [ results
-            |> Component.encodeResults (Just Definition.Ecs)
-            |> Encode.encode 2
-            |> text
-        ]
-
-
 elementView : Definition -> ExpandedElement -> Component.Results -> Html msg
 elementView selectedImpact { amount, material, transforms } elementResults =
     let
@@ -218,7 +218,9 @@ elementView selectedImpact { amount, material, transforms } elementResults =
                 , td [ class "text-end text-nowrap" ]
                     [ Format.amount material amount ]
                 , td [ class "align-middle text-truncate w-100" ]
-                    [ text <| Process.getDisplayName material ]
+                    [ text <| Process.getDisplayName material
+                    , debugResults materialResults
+                    ]
                 , td [ class "align-middle text-end text-nowrap" ]
                     [ Format.density material ]
                 , td [ class "text-end align-middle text-nowrap" ]
@@ -230,33 +232,30 @@ elementView selectedImpact { amount, material, transforms } elementResults =
                 , td [ class "pe-3 align-middle text-nowrap" ]
                     []
                 ]
-            :: tr []
-                [ td [ colspan 7 ]
-                    [ debugResults materialResults
-                    ]
-                ]
-            :: (transforms
-                    |> List.map
-                        (\transform ->
-                            tr [ class "fs-7" ]
-                                [ td [] []
-                                , td [ class "text-end text-nowrap" ]
-                                    [ text "-" ]
-                                , td [ class "align-middle text-truncate w-100" ]
-                                    [ text <| Process.getDisplayName transform ]
-                                , td [ class "align-middle text-end text-nowrap" ]
-                                    [ Format.density transform ]
-                                , td [ class "text-end align-middle text-nowrap" ]
-                                    [ Format.kg <| Component.extractMass elementResults ]
-                                , td [ class "text-end align-middle text-nowrap" ]
-                                    [ Component.extractImpacts elementResults
-                                        |> Format.formatImpact selectedImpact
-                                    ]
-                                , td [ class "pe-3 align-middle text-nowrap" ]
-                                    []
-                                ]
-                        )
-               )
+            :: List.map2
+                (\transformResult transform ->
+                    tr [ class "fs-7" ]
+                        [ td [] []
+                        , td [ class "text-end text-nowrap" ]
+                            [ text "-" ]
+                        , td [ class "align-middle text-truncate w-100" ]
+                            [ text <| Process.getDisplayName transform
+                            , debugResults transformResult
+                            ]
+                        , td [ class "align-middle text-end text-nowrap" ]
+                            [ Format.density transform ]
+                        , td [ class "text-end align-middle text-nowrap" ]
+                            [ Format.kg <| Component.extractMass transformResult ]
+                        , td [ class "text-end align-middle text-nowrap" ]
+                            [ Component.extractImpacts transformResult
+                                |> Format.formatImpact selectedImpact
+                            ]
+                        , td [ class "pe-3 align-middle text-nowrap" ]
+                            []
+                        ]
+                )
+                transformResults
+                transforms
         )
 
 

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -235,7 +235,8 @@ elementView selectedImpact { amount, material, transforms } elementResults =
                     , viewDebug materialResults
                     ]
                 , td [ class "align-middle text-end text-nowrap" ]
-                    [ formatWaste material.waste ]
+                    -- Note: waste is never taken into account at ther material step
+                    []
                 , td [ class "text-end align-middle text-nowrap" ]
                     [ Format.kg <| Component.extractMass materialResults ]
                 , td [ class "text-end align-middle text-nowrap" ]

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -37,6 +37,11 @@ type alias Config db msg =
     }
 
 
+debug : Bool
+debug =
+    False
+
+
 addButton : Config db msg -> Html msg
 addButton { addLabel, db, items, openSelectModal, scope } =
     let
@@ -128,14 +133,18 @@ componentView config ( quantity, component, expandedElements ) itemResults =
         ]
 
 
-debugResults : Component.Results -> Html msg
-debugResults results =
-    pre [ class "p-2 bg-light" ]
-        [ results
-            |> Component.encodeResults (Just Definition.Ecs)
-            |> Encode.encode 2
-            |> text
-        ]
+viewDebug : Component.Results -> Html msg
+viewDebug results =
+    if debug then
+        pre [ class "p-2 bg-light" ]
+            [ results
+                |> Component.encodeResults (Just Definition.Ecs)
+                |> Encode.encode 2
+                |> text
+            ]
+
+    else
+        text ""
 
 
 editorView : Config db msg -> Html msg
@@ -188,7 +197,7 @@ editorView ({ db, items, results, scope, title } as config) =
                             )
                         ]
         , addButton config
-        , debugResults results
+        , viewDebug results
         ]
 
 
@@ -209,7 +218,7 @@ elementView selectedImpact { amount, material, transforms } elementResults =
             , th [ class "text-end", scope "col" ] [ text "Quantité" ]
             , th [ scope "col" ] [ text "Procédé" ]
             , th [ scope "col" ] [ text "Densité" ]
-            , th [ scope "col" ] [ text "Masse" ]
+            , th [ class "text-truncate", scope "col", Attr.title "Masse sortante" ] [ text "Masse" ]
             , th [ scope "col" ] [ text "Impact" ]
             , th [ scope "col" ] [ text "" ]
             ]
@@ -219,7 +228,7 @@ elementView selectedImpact { amount, material, transforms } elementResults =
                     [ Format.amount material amount ]
                 , td [ class "align-middle text-truncate w-100" ]
                     [ text <| Process.getDisplayName material
-                    , debugResults materialResults
+                    , viewDebug materialResults
                     ]
                 , td [ class "align-middle text-end text-nowrap" ]
                     [ Format.density material ]
@@ -240,7 +249,7 @@ elementView selectedImpact { amount, material, transforms } elementResults =
                             [ text "-" ]
                         , td [ class "align-middle text-truncate w-100" ]
                             [ text <| Process.getDisplayName transform
-                            , debugResults transformResult
+                            , viewDebug transformResult
                             ]
                         , td [ class "align-middle text-end text-nowrap" ]
                             [ Format.density transform ]

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -234,7 +234,7 @@ elementView selectedImpact { amount, material, transforms } elementResults =
                 , td [ class "align-middle text-end text-nowrap" ]
                     [ formatWaste material.waste ]
                 , td [ class "text-end align-middle text-nowrap" ]
-                    [ Format.amount material amount ]
+                    [ Format.kg <| Component.extractMass materialResults ]
                 , td [ class "text-end align-middle text-nowrap" ]
                     [ Component.extractImpacts materialResults
                         |> Format.formatImpact selectedImpact

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -81,53 +81,56 @@ componentView config ( quantity, component, expandedElements ) itemResults =
                 |> not
     in
     List.concat
-        [ [ tr []
-                [ th [ class "ps-3 align-middle", scope "col" ]
-                    [ if config.allowExpandDetails then
-                        button
-                            [ class "btn btn-link text-dark text-decoration-none font-monospace fs-5  p-0 m-0"
-                            , onClick <|
-                                config.setDetailed <|
-                                    if collapsed && not (List.member component.id config.detailed) then
-                                        LE.unique <| component.id :: config.detailed
+        [ [ tbody []
+                [ tr []
+                    [ th [ class "ps-3 align-middle", scope "col" ]
+                        [ if config.allowExpandDetails then
+                            button
+                                [ class "btn btn-link text-dark text-decoration-none font-monospace fs-5  p-0 m-0"
+                                , onClick <|
+                                    config.setDetailed <|
+                                        if collapsed && not (List.member component.id config.detailed) then
+                                            LE.unique <| component.id :: config.detailed
 
-                                    else
-                                        List.filter ((/=) component.id) config.detailed
-                            ]
-                            [ if collapsed then
-                                text "▶"
+                                        else
+                                            List.filter ((/=) component.id) config.detailed
+                                ]
+                                [ if collapsed then
+                                    text "▶"
 
-                              else
-                                text "▼"
-                            ]
+                                  else
+                                    text "▼"
+                                ]
 
-                      else
-                        text ""
-                    ]
-                , td [ class "ps-0 align-middle" ]
-                    [ quantity |> quantityInput config component.id ]
-                , td [ class "align-middle text-truncate w-100 fw-bold", colspan 2 ]
-                    [ text component.name ]
-                , td [ class "text-end align-middle text-nowrap" ]
-                    [ Component.extractMass itemResults
-                        |> Format.kg
-                    ]
-                , td [ class "text-end align-middle text-nowrap" ]
-                    [ Component.extractImpacts itemResults
-                        |> Format.formatImpact config.impact
-                    ]
-                , td [ class "pe-3 align-middle text-nowrap" ]
-                    [ button
-                        [ class "btn btn-outline-secondary"
-                        , onClick (config.removeItem component.id)
+                          else
+                            text ""
                         ]
-                        [ Icon.trash ]
+                    , td [ class "ps-0 align-middle" ]
+                        [ quantity |> quantityInput config component.id ]
+                    , td [ class "align-middle text-truncate w-100 fw-bold", colspan 2 ]
+                        [ text component.name ]
+                    , td [ class "text-end align-middle text-nowrap" ]
+                        [ Component.extractMass itemResults
+                            |> Format.kg
+                        ]
+                    , td [ class "text-end align-middle text-nowrap" ]
+                        [ Component.extractImpacts itemResults
+                            |> Format.formatImpact config.impact
+                        ]
+                    , td [ class "pe-3 align-middle text-nowrap" ]
+                        [ button
+                            [ class "btn btn-outline-secondary"
+                            , onClick (config.removeItem component.id)
+                            ]
+                            [ Icon.trash ]
+                        ]
                     ]
                 ]
           ]
         , if not collapsed then
-            Component.extractItems itemResults
-                |> List.map2 (elementView config.impact) expandedElements
+            List.map2 (elementView config.impact)
+                expandedElements
+                (Component.extractItems itemResults)
 
           else
             []

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -7,6 +7,7 @@ import Data.Dataset as Dataset
 import Data.Impact.Definition as Definition exposing (Definition)
 import Data.Process as Process
 import Data.Scope as Scope exposing (Scope)
+import Data.Split as Split exposing (Split)
 import Html exposing (..)
 import Html.Attributes as Attr exposing (..)
 import Html.Events exposing (..)
@@ -217,7 +218,7 @@ elementView selectedImpact { amount, material, transforms } elementResults =
             [ th [] []
             , th [ class "text-end", scope "col" ] [ text "Quantité" ]
             , th [ scope "col" ] [ text "Procédé" ]
-            , th [ scope "col" ] [ text "Densité" ]
+            , th [ scope "col" ] [ text "Pertes" ]
             , th [ class "text-truncate", scope "col", Attr.title "Masse sortante" ] [ text "Masse" ]
             , th [ scope "col" ] [ text "Impact" ]
             , th [ scope "col" ] [ text "" ]
@@ -231,7 +232,7 @@ elementView selectedImpact { amount, material, transforms } elementResults =
                     , viewDebug materialResults
                     ]
                 , td [ class "align-middle text-end text-nowrap" ]
-                    [ Format.density material ]
+                    [ formatWaste material.waste ]
                 , td [ class "text-end align-middle text-nowrap" ]
                     [ Format.amount material amount ]
                 , td [ class "text-end align-middle text-nowrap" ]
@@ -252,7 +253,7 @@ elementView selectedImpact { amount, material, transforms } elementResults =
                             , viewDebug transformResult
                             ]
                         , td [ class "align-middle text-end text-nowrap" ]
-                            [ Format.density transform ]
+                            [ formatWaste transform.waste ]
                         , td [ class "text-end align-middle text-nowrap" ]
                             [ Format.kg <| Component.extractMass transformResult ]
                         , td [ class "text-end align-middle text-nowrap" ]
@@ -299,3 +300,12 @@ quantityInput config id quantity =
             ]
             []
         ]
+
+
+formatWaste : Split -> Html msg
+formatWaste waste =
+    if Split.toPercent waste == 0 then
+        text ""
+
+    else
+        Format.splitAsPercentage 3 waste

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -4,12 +4,13 @@ import Autocomplete exposing (Autocomplete)
 import Data.AutocompleteSelector as AutocompleteSelector
 import Data.Component as Component exposing (Component, ExpandedElement, Item)
 import Data.Dataset as Dataset
-import Data.Impact.Definition exposing (Definition)
+import Data.Impact.Definition as Definition exposing (Definition)
 import Data.Process as Process
 import Data.Scope as Scope exposing (Scope)
 import Html exposing (..)
 import Html.Attributes as Attr exposing (..)
 import Html.Events exposing (..)
+import Json.Encode as Encode
 import List.Extra as LE
 import Route
 import Views.Alert as Alert
@@ -177,6 +178,17 @@ editorView ({ db, items, results, scope, title } as config) =
                             )
                         ]
         , addButton config
+        , debugResults results
+        ]
+
+
+debugResults : Component.Results -> Html msg
+debugResults results =
+    pre [ class "p-2 bg-light" ]
+        [ results
+            |> Component.encodeResults (Just Definition.Ecs)
+            |> Encode.encode 2
+            |> text
         ]
 
 
@@ -217,6 +229,11 @@ elementView selectedImpact { amount, material, transforms } elementResults =
                     ]
                 , td [ class "pe-3 align-middle text-nowrap" ]
                     []
+                ]
+            :: tr []
+                [ td [ colspan 7 ]
+                    [ debugResults materialResults
+                    ]
                 ]
             :: (transforms
                     |> List.map

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -242,12 +242,13 @@ elementView selectedImpact { amount, material, transforms } elementResults =
                 , td [ class "pe-3 align-middle text-nowrap" ]
                     []
                 ]
-            :: List.map2
-                (\transformResult transform ->
+            :: List.map3
+                (\transform transformResult previousResult ->
                     tr [ class "fs-7" ]
                         [ td [] []
                         , td [ class "text-end text-nowrap" ]
-                            [ text "-" ]
+                            [ Format.kg <| Component.extractMass previousResult
+                            ]
                         , td [ class "align-middle text-truncate w-100" ]
                             [ text <| Process.getDisplayName transform
                             , viewDebug transformResult
@@ -264,8 +265,9 @@ elementView selectedImpact { amount, material, transforms } elementResults =
                             []
                         ]
                 )
-                transformResults
                 transforms
+                transformResults
+                (Component.extractItems elementResults)
         )
 
 

--- a/tests/Data/ComponentTest.elm
+++ b/tests/Data/ComponentTest.elm
@@ -93,7 +93,7 @@ suite =
                                         |> Impact.insertWithoutAggregateComputation Definition.Ecs (Unit.impact 10)
                               }
                             ]
-                            |> Expect.within (Expect.Absolute 1) 198
+                            |> Expect.within (Expect.Absolute 1) 391
                         )
                     , asTest "should add impacts when multiple transforms are passed (no elec, no heat)"
                         (getTestEcsImpact
@@ -107,7 +107,7 @@ suite =
                             [ fading |> setProcessEcsImpact (Unit.impact 10)
                             , fading |> setProcessEcsImpact (Unit.impact 20)
                             ]
-                            |> Expect.within (Expect.Absolute 1) 406
+                            |> Expect.within (Expect.Absolute 1) 793
                         )
                     ]
                 , let
@@ -170,7 +170,7 @@ suite =
                                 |> Component.extractImpacts
                                 |> Impact.getImpact Definition.Ecs
                                 |> Unit.impactToFloat
-                                |> Expect.within (Expect.Absolute 1) 402
+                                |> Expect.within (Expect.Absolute 1) 692
                             )
                         , asTest "should handle impacts+waste when applying transforms: mass"
                             (withElecAndHeat
@@ -208,7 +208,7 @@ suite =
                                         )
                                     )
                                 |> Result.withDefault ( 0, 0 )
-                                |> Expect.equal ( 1830, 0.93747 )
+                                |> Expect.equal ( 2012, 0.93747 )
 
                         Err err ->
                             Expect.fail err

--- a/tests/Data/ComponentTest.elm
+++ b/tests/Data/ComponentTest.elm
@@ -16,17 +16,8 @@ import TestUtils exposing (asTest, suiteWithDb)
 
 getEcsImpact : Component.Results -> Float
 getEcsImpact =
-    Component.extractImpacts >> (Impact.getImpact Definition.Ecs >> Unit.impactToFloat)
-
-
-sampleJsonItems : String
-sampleJsonItems =
-    """
-    [ { "id": "64fa65b3-c2df-4fd0-958b-83965bd6aa08", "quantity": 4 }
-    , { "id": "ad9d7f23-076b-49c5-93a4-ee1cd7b53973", "quantity": 1 }
-    , { "id": "eda5dd7e-52e4-450f-8658-1876efc62bd6", "quantity": 1 }
-    ]
-    """
+    Component.extractImpacts
+        >> (Impact.getImpact Definition.Ecs >> Unit.impactToFloat)
 
 
 suite : Test
@@ -183,7 +174,10 @@ suite =
                 ]
             , describe "compute"
                 [ asTest "should compute results from decoded component items"
-                    (sampleJsonItems
+                    (""" [ { "id": "64fa65b3-c2df-4fd0-958b-83965bd6aa08", "quantity": 4 }
+                         , { "id": "ad9d7f23-076b-49c5-93a4-ee1cd7b53973", "quantity": 1 }
+                         , { "id": "eda5dd7e-52e4-450f-8658-1876efc62bd6", "quantity": 1 }
+                         ]"""
                         |> Decode.decodeString (Decode.list Component.decodeItem)
                         |> Result.mapError Decode.errorToString
                         |> Result.andThen (Component.compute db)

--- a/tests/Data/ComponentTest.elm
+++ b/tests/Data/ComponentTest.elm
@@ -204,13 +204,13 @@ suite =
                                         >> Unit.impactToFloat
                                     )
                                 |> Result.withDefault 0
-                                |> Expect.within (Expect.Absolute 1) 1949
+                                |> Expect.within (Expect.Absolute 1) 2012
                             )
                         , asTest "should compute element mass"
                             (elementResults
                                 |> Result.map (Component.extractMass >> Mass.inKilograms)
                                 |> Result.withDefault 0
-                                |> Expect.within (Expect.Absolute 0.01) 0.78
+                                |> Expect.within (Expect.Absolute 0.01) 0.94
                             )
                         ]
 


### PR DESCRIPTION
## :wrench: Problem

[Notion card](https://www.notion.so/Composants-de-n-proc-d-s-mati-res-et-n-proc-d-s-transformation-b30599ba654c46758f962eabe6b8595c)

We need to render the details of applied transform processes to each component element material.

## :cake: Solution

Render them.

![image](https://github.com/user-attachments/assets/a64d1ef3-d06d-420d-aa2c-9d2ec9feb6b5)
![image](https://github.com/user-attachments/assets/31d5d4ff-3597-4547-aac1-e75701d1e985)

## :rotating_light:  Points to watch/comments

A bug was fixed where energy was applied as kWh instead of MJ for heat consumption in transform process impacts computation (https://github.com/MTES-MCT/ecobalyse/pull/907/commits/8ce0548ffebdbc29f83c0787c80b32e8ae89cc34).

## :desert_island: How to test

Check that the UI conforms to users expectations (see card)