### PR TITLE
feat(textile,ui): apply default trims on product category change

### DIFF
--- a/public/data/textile/products.json
+++ b/public/data/textile/products.json
@@ -21,6 +21,7 @@
     },
     "name": "Chemise",
     "surfaceMass": 200,
+    "trims": [{ "id": "d56bb0d5-7999-4b8b-b076-94d79099b56a", "quantity": 10 }],
     "use": {
       "daysOfWear": 40,
       "defaultNbCycles": 20,
@@ -55,6 +56,10 @@
     },
     "name": "Jean",
     "surfaceMass": 250,
+    "trims": [
+      { "id": "0c903fc7-279b-4375-8cfa-ca8133b8e973", "quantity": 1 },
+      { "id": "0e8ea799-9b06-490c-a925-37564746c454", "quantity": 1 }
+    ],
     "use": {
       "daysOfWear": 70,
       "defaultNbCycles": 23,
@@ -89,6 +94,10 @@
     },
     "name": "Jupe / Robe",
     "surfaceMass": 200,
+    "trims": [
+      { "id": "0e8ea799-9b06-490c-a925-37564746c454", "quantity": 1 },
+      { "id": "d56bb0d5-7999-4b8b-b076-94d79099b56a", "quantity": 1 }
+    ],
     "use": {
       "daysOfWear": 70,
       "defaultNbCycles": 23,
@@ -123,6 +132,10 @@
     },
     "name": "Manteau / Veste",
     "surfaceMass": 450,
+    "trims": [
+      { "id": "d56bb0d5-7999-4b8b-b076-94d79099b56a", "quantity": 3 },
+      { "id": "86b877ff-0d59-482f-bb34-3ff306b07496", "quantity": 1 }
+    ],
     "use": {
       "daysOfWear": 100,
       "defaultNbCycles": 5,
@@ -157,6 +170,10 @@
     },
     "name": "Pantalon / Short",
     "surfaceMass": 250,
+    "trims": [
+      { "id": "0c903fc7-279b-4375-8cfa-ca8133b8e973", "quantity": 1 },
+      { "id": "0e8ea799-9b06-490c-a925-37564746c454", "quantity": 1 }
+    ],
     "use": {
       "daysOfWear": 70,
       "defaultNbCycles": 23,
@@ -191,6 +208,7 @@
     },
     "name": "Pull",
     "surfaceMass": 250,
+    "trims": [],
     "use": {
       "daysOfWear": 85,
       "defaultNbCycles": 17,
@@ -225,6 +243,7 @@
     },
     "name": "T-shirt / Polo",
     "surfaceMass": 200,
+    "trims": [],
     "use": {
       "daysOfWear": 45,
       "defaultNbCycles": 45,
@@ -259,6 +278,7 @@
     },
     "name": "Chaussettes",
     "surfaceMass": 250,
+    "trims": [],
     "use": {
       "daysOfWear": 50,
       "defaultNbCycles": 25,
@@ -293,6 +313,7 @@
     },
     "name": "Caleçon (tissé)",
     "surfaceMass": 180,
+    "trims": [],
     "use": {
       "daysOfWear": 60,
       "defaultNbCycles": 60,
@@ -327,6 +348,7 @@
     },
     "name": "Boxer / Slip (tricoté)",
     "surfaceMass": 180,
+    "trims": [],
     "use": {
       "daysOfWear": 60,
       "defaultNbCycles": 60,
@@ -361,6 +383,7 @@
     },
     "name": "Maillot de bain",
     "surfaceMass": 220,
+    "trims": [],
     "use": {
       "daysOfWear": 30,
       "defaultNbCycles": 30,

--- a/src/Data/Textile/Product.elm
+++ b/src/Data/Textile/Product.elm
@@ -10,6 +10,7 @@ module Data.Textile.Product exposing
     , idToString
     )
 
+import Data.Component as Component
 import Data.Process as Process exposing (Process)
 import Data.Split as Split exposing (Split)
 import Data.Textile.DyeingMedium as DyeingMedium exposing (DyeingMedium)
@@ -62,6 +63,7 @@ type alias Product =
     , making : MakingOptions
     , name : String
     , surfaceMass : Unit.SurfaceMass
+    , trims : List Component.Item
     , use : UseOptions
     , yarnSize : Unit.YarnSize
     }
@@ -133,6 +135,7 @@ decode processes =
         |> Pipe.required "making" decodeMakingOptions
         |> Pipe.required "name" Decode.string
         |> Pipe.required "surfaceMass" Unit.decodeSurfaceMass
+        |> Pipe.required "trims" (Decode.list Component.decodeItem)
         |> Pipe.required "use" (decodeUseOptions processes)
         |> Pipe.required "yarnSize" Unit.decodeYarnSize
 
@@ -176,6 +179,7 @@ encode v =
         , ( "name", Encode.string v.name )
         , ( "fabric", Fabric.encode v.fabric )
         , ( "making", encodeMakingOptions v.making )
+        , ( "trims", Encode.list Component.encodeItem v.trims )
         , ( "use", encodeUseOptions v.use )
         , ( "endOfLife", encodeEndOfLifeOptions v.endOfLife )
         ]

--- a/src/Data/Textile/Query.elm
+++ b/src/Data/Textile/Query.elm
@@ -266,8 +266,8 @@ handleUpcycling query =
         query
 
 
-isAdvancedQuery : Query -> Bool
-isAdvancedQuery query =
+isAdvancedQuery : List Product -> Query -> Bool
+isAdvancedQuery products query =
     List.any identity
         [ query.dyeingMedium /= Nothing
         , query.fabricProcess /= Nothing
@@ -277,6 +277,10 @@ isAdvancedQuery query =
         , query.materials |> List.any (.spinning >> (/=) Nothing)
         , query.physicalDurability /= Nothing
         , query.surfaceMass /= Nothing
+        , products
+            |> Product.findById query.product
+            |> Result.map (.trims >> (/=) query.trims)
+            |> Result.withDefault False
         , not query.upcycled && List.length query.disabledSteps > 0
         , query.yarnSize /= Nothing
         ]
@@ -284,8 +288,8 @@ isAdvancedQuery query =
 
 {-| Resets a query to use only regulatory-level fields.
 -}
-regulatory : Query -> Query
-regulatory query =
+regulatory : List Product -> Query -> Query
+regulatory products query =
     { query
         | disabledSteps = []
         , dyeingMedium = Nothing
@@ -296,6 +300,11 @@ regulatory query =
         , materials = query.materials |> List.map (\m -> { m | spinning = Nothing })
         , physicalDurability = Nothing
         , surfaceMass = Nothing
+        , trims =
+            products
+                |> Product.findById query.product
+                |> Result.map .trims
+                |> Result.withDefault []
         , yarnSize = Nothing
     }
 
@@ -365,6 +374,7 @@ updateProduct product query =
             , printing = Nothing
             , product = product.id
             , surfaceMass = Nothing
+            , trims = product.trims
             , yarnSize = Nothing
         }
 

--- a/src/Page/Textile.elm
+++ b/src/Page/Textile.elm
@@ -184,7 +184,7 @@ init trigram maybeUrlQuery session =
       , impact = Definition.get trigram session.db.definitions
       , modal = NoModal
       , activeTab =
-            if Query.isAdvancedQuery initialQuery then
+            if Query.isAdvancedQuery session.db.textile.products initialQuery then
                 ExploratoryTab
 
             else
@@ -238,7 +238,7 @@ initFromExample session uuid =
       , impact = Definition.get Definition.Ecs session.db.definitions
       , modal = NoModal
       , activeTab =
-            if Query.isAdvancedQuery exampleQuery then
+            if Query.isAdvancedQuery session.db.textile.products exampleQuery then
                 ExploratoryTab
 
             else
@@ -310,7 +310,7 @@ update ({ queries, navKey } as session) msg model =
 
         ( ConfirmSwitchToRegulatory, _ ) ->
             ( { model | modal = NoModal, activeTab = RegulatoryTab }, session, Cmd.none )
-                |> updateQuery (Query.regulatory query)
+                |> updateQuery (Query.regulatory session.db.textile.products query)
 
         ( CopyToClipBoard shareableLink, _ ) ->
             ( model, session, Ports.copyToClipboard shareableLink )
@@ -539,7 +539,7 @@ update ({ queries, navKey } as session) msg model =
             )
 
         ( SwitchTab RegulatoryTab, _ ) ->
-            if Query.isAdvancedQuery query then
+            if Query.isAdvancedQuery session.db.textile.products query then
                 ( { model | modal = ConfirmSwitchToRegulatoryModal }, session, Cmd.none )
 
             else


### PR DESCRIPTION
See [Notion card](https://www.notion.so/Les-cat-gories-en-textile-doivent-avoir-les-trims-par-d-fauts-eb163196faa841da941283c831e1c42f) which exhaustively describes the use case and expectations.