### PR TITLE
fix: include trims impacts to score without durability.

### DIFF
--- a/src/Data/Textile/Simulator.elm
+++ b/src/Data/Textile/Simulator.elm
@@ -58,7 +58,7 @@ encode v =
         , ( "daysOfWear", v.daysOfWear |> Duration.inDays |> round |> Encode.int )
         , ( "durability", v.durability |> Unit.floatDurabilityFromHolistic |> Encode.float )
         , ( "impacts", Impact.encode v.impacts )
-        , ( "impactsWithoutDurability", Impact.encode (getTotalImpactsWithoutDurability v.lifeCycle) )
+        , ( "impactsWithoutDurability", Impact.encode (getTotalImpactsWithoutDurability v) )
         , ( "inputs", Inputs.encode v.inputs )
         , ( "lifeCycle", LifeCycle.encode v.lifeCycle )
         , ( "transport", Transport.encode v.transport )
@@ -789,17 +789,20 @@ getTotalImpactsWithoutComplements { durability, lifeCycle } =
         |> Impact.divideBy (Unit.floatDurabilityFromHolistic durability)
 
 
-getTotalImpactsWithoutDurability : LifeCycle -> Impacts
-getTotalImpactsWithoutDurability lifeCycle =
+getTotalImpactsWithoutDurability : Simulator -> Impacts
+getTotalImpactsWithoutDurability { lifeCycle, trimsImpacts } =
     let
         complementsImpactsWithoutDurability =
             lifeCycle
                 |> Array.filter .enabled
                 |> LifeCycle.sumComplementsImpacts
     in
-    lifeCycle
-        |> LifeCycle.computeFinalImpacts
-        |> Impact.impactsWithComplements complementsImpactsWithoutDurability
+    Impact.sumImpacts
+        [ lifeCycle
+            |> LifeCycle.computeFinalImpacts
+            |> Impact.impactsWithComplements complementsImpactsWithoutDurability
+        , trimsImpacts
+        ]
 
 
 updateLifeCycle : (LifeCycle -> LifeCycle) -> Simulator -> Simulator

--- a/src/Page/Textile.elm
+++ b/src/Page/Textile.elm
@@ -1204,7 +1204,7 @@ simulatorView session model ({ inputs, impacts } as simulator) =
                         )
                 , productMass = inputs.mass
                 , totalImpacts = impacts
-                , totalImpactsWithoutDurability = Just <| Simulator.getTotalImpactsWithoutDurability simulator.lifeCycle
+                , totalImpactsWithoutDurability = Just <| Simulator.getTotalImpactsWithoutDurability simulator
 
                 -- Impacts tabs
                 , impactTabsConfig =


### PR DESCRIPTION
[Notion card](https://www.notion.so/Impacts-accessoires-non-inclus-dans-le-score-hors-durabilit-7b4e7f70c11f4d51a4c25635d235dfd8)