### PR TITLE
add desync and github workflow

### DIFF
--- a/.github/workflows/review_app.yml
+++ b/.github/workflows/review_app.yml
@@ -1,9 +1,11 @@
 name: Deploy Review App
 
 on:
-  workflow_run:
-    workflows: ["Node.js CI"]
-    types: [completed]
+  push:
+    branches: [ master, staging ]
+  pull_request:
+    branches: [ master, staging ]
+  workflow_dispatch:
 
 jobs:
   deploy-review-app:

--- a/.github/workflows/review_app.yml
+++ b/.github/workflows/review_app.yml
@@ -9,9 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/scalingo-cli
       - env:
           SCALINGO_API_TOKEN: ${{ secrets.SCALINGO_API_TOKEN }}
           SCALINGO_APP: ecobalyse
-          SCALINGO_REGION: ${{ secrets.SCALINGO_REGION }}
-        run: scalingo --app $SCALINGO_APP review-app create
+        run: |
+          curl -H "Accept: application/json" \
+               -H "Content-Type: application/json" \
+               -H "Authorization: Bearer $SCALINGO_API_TOKEN" \
+               -X POST https://api.osc-fr1.scalingo.com/v1/apps/$SCALINGO_APP/scm_repo_link/manual_review_app \
+               -d "{\"pull_request_id\": ${{ github.event.pull_request.number }}}"

--- a/.github/workflows/review_app.yml
+++ b/.github/workflows/review_app.yml
@@ -3,37 +3,17 @@ name: Deploy Review App
 on:
   workflow_run:
     workflows: ["Node.js CI"]
-    types:
-      - completed
+    types: [completed]
 
 jobs:
   deploy-review-app:
-    name: Deploy Review App
     runs-on: ubuntu-latest
-    # We want this to run if Node.js CI passes, regardless of ecobalyse-data-sync
     if: github.event.workflow_run.conclusion == 'success'
-
     steps:
       - uses: actions/checkout@v4
-
-      - name: Install Scalingo CLI
-        uses: ./.github/actions/scalingo-cli
-
-      - name: Add scalingo to known hosts
-        run: echo "KNOWN_HOSTS=$(ssh-keyscan -H ssh.osc-fr1.scalingo.com)" >> $GITHUB_ENV
-
-      - name: Install SSH key
-        uses: shimataro/ssh-key-action@v2
-        with:
-          key: ${{ secrets.PRIVATE_SSH_KEY }}
-          name: id_rsa
-          known_hosts: ${{ env.KNOWN_HOSTS }}
-          if_key_exists: fail
-
-      - name: Deploy Review App
-        env:
+      - uses: ./.github/actions/scalingo-cli
+      - env:
           SCALINGO_API_TOKEN: ${{ secrets.SCALINGO_API_TOKEN }}
           SCALINGO_APP: ecobalyse
           SCALINGO_REGION: ${{ secrets.SCALINGO_REGION }}
-        run: |
-          scalingo --app $SCALINGO_APP review-app create
+        run: scalingo --app $SCALINGO_APP review-app create

--- a/.github/workflows/review_app.yml
+++ b/.github/workflows/review_app.yml
@@ -1,0 +1,39 @@
+name: Deploy Review App
+
+on:
+  workflow_run:
+    workflows: ["Node.js CI"]
+    types:
+      - completed
+
+jobs:
+  deploy-review-app:
+    name: Deploy Review App
+    runs-on: ubuntu-latest
+    # We want this to run if Node.js CI passes, regardless of ecobalyse-data-sync
+    if: github.event.workflow_run.conclusion == 'success'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Scalingo CLI
+        uses: ./.github/actions/scalingo-cli
+
+      - name: Add scalingo to known hosts
+        run: echo "KNOWN_HOSTS=$(ssh-keyscan -H ssh.osc-fr1.scalingo.com)" >> $GITHUB_ENV
+
+      - name: Install SSH key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.PRIVATE_SSH_KEY }}
+          name: id_rsa
+          known_hosts: ${{ env.KNOWN_HOSTS }}
+          if_key_exists: fail
+
+      - name: Deploy Review App
+        env:
+          SCALINGO_API_TOKEN: ${{ secrets.SCALINGO_API_TOKEN }}
+          SCALINGO_APP: ecobalyse
+          SCALINGO_REGION: ${{ secrets.SCALINGO_REGION }}
+        run: |
+          scalingo --app $SCALINGO_APP review-app create

--- a/.github/workflows/review_app.yml
+++ b/.github/workflows/review_app.yml
@@ -1,16 +1,12 @@
 name: Deploy Review App
 
 on:
-  push:
-    branches: [ master, staging ]
   pull_request:
-    branches: [ master, staging ]
-  workflow_dispatch:
+    types: [opened, synchronize, reopened]
 
 jobs:
   deploy-review-app:
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success'
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/scalingo-cli

--- a/public/data/food/processes.json
+++ b/public/data/food/processes.json
@@ -4,7 +4,7 @@
     "comment": "",
     "density": 0,
     "displayName": "Oeuf Bleu-Blanc-Cœur FR Conv.",
-    "elec_MJ": 0,
+    "elec_MJ": 4,
     "heat_MJ": 0,
     "id": "7ef7399a-1d56-4947-b773-9f6438a50fda",
     "impacts": {


### PR DESCRIPTION
## :wrench: Problem

Currently, review apps on Scalingo are only deployed when our GitHub CI is successful. This means that even if we want to test a PR with failing tests, we can't easily do so through a review app. For example, in PR #928, we had to manually deploy the review app despite wanting to test the changes.

## :cake: Solution

Created a new GitHub workflow that deploys review apps independently of CI status. This workflow:
- Utilizes Scalingo CLI to create review apps

## :rotating_light: Points to watch/comments


## :desert_island: How to test

1. Create a new PR from this one with a failing test 
2. Verify that despite the CI failure:
   - The "Deploy Review App" workflow runs successfully
3. Fix the test in a new commit
4. Verify that a new review app deployment is triggered automatically