### PR TITLE
fix: values of textile volume

### DIFF
--- a/public/data/textile/products.json
+++ b/public/data/textile/products.json
@@ -268,7 +268,7 @@
       "traceability": false
     },
     "endOfLife": {
-      "volume": 0.002
+      "volume": 0.0006
     },
     "fabric": "knitting-fully-fashioned",
     "id": "chaussettes",
@@ -303,7 +303,7 @@
       "traceability": false
     },
     "endOfLife": {
-      "volume": 0.002
+      "volume": 0.0006
     },
     "fabric": "weaving",
     "id": "calecon",
@@ -338,7 +338,7 @@
       "traceability": false
     },
     "endOfLife": {
-      "volume": 0.002
+      "volume": 0.0006
     },
     "fabric": "knitting-mix",
     "id": "slip",
@@ -373,7 +373,7 @@
       "traceability": false
     },
     "endOfLife": {
-      "volume": 0.004
+      "volume": 0.0006
     },
     "fabric": "knitting-mix",
     "id": "maillot-de-bain",


### PR DESCRIPTION
## :wrench: Problem

As pointed in [this issue](https://github.com/MTES-MCT/ecobalyse/issues/924), there is a discrepancy between the `endOfLife.volume` values and the documentation in [Ecobalyse GitBook - Textile Life Cycle](https://fabrique-numerique.gitbook.io/ecobalyse/textile/cycle-de-vie-des-produits-textiles/etape-7-fin-de-vie).  

If we compare it to the table named **"Table 40: Default Representative Product Volumes"**, we observe four differences:  

- **Chaussette**: `0.002` instead of `0.0006`  
- **Caleçon**: `0.002` instead of `0.0006`  
- **Slip**: `0.002` instead of `0.0006`  
- **Maillot de bain**: `0.004` instead of `0.0006`  

## :cake: Solution

Change the values to the right ones


## :rotating_light:  Points to watch/comments

Impacts may slightly change

## :desert_island: How to test

- [ ] PO validation
