### PR TITLE
fix: remove the sourceId from the explorer

### DIFF
--- a/src/Page/Explore/FoodIngredients.elm
+++ b/src/Page/Explore/FoodIngredients.elm
@@ -7,7 +7,6 @@ import Data.Food.Ingredient as Ingredient exposing (Ingredient)
 import Data.Food.Ingredient.Category as IngredientCategory
 import Data.Food.Origin as Origin
 import Data.Gitbook as Gitbook
-import Data.Process as Process
 import Data.Scope exposing (Scope)
 import Data.Split as Split
 import Data.Unit as Unit

--- a/src/Page/Explore/FoodIngredients.elm
+++ b/src/Page/Explore/FoodIngredients.elm
@@ -82,10 +82,7 @@ table _ { detailed, scope } =
           , toCell =
                 \{ default } ->
                     div []
-                        [ default.sourceId
-                            |> Maybe.map (Process.sourceIdToString >> text >> List.singleton >> code [])
-                            |> Maybe.withDefault (text "")
-                        , div [ class "cursor-help", title default.name ]
+                        [ div [ class "cursor-help", title default.name ]
                             [ text default.name ]
                         , em [ class "cursor-help", title default.comment ]
                             [ text default.comment ]

--- a/src/Page/Explore/Processes.elm
+++ b/src/Page/Explore/Processes.elm
@@ -51,10 +51,6 @@ baseColumns detailed scope =
       , toValue = Table.StringValue <| .source
       , toCell = .source >> text
       }
-    , { label = "Identifiant dans la source"
-      , toValue = Table.StringValue <| .sourceId >> Maybe.map Process.sourceIdToString >> Maybe.withDefault ""
-      , toCell = .sourceId >> Maybe.map (Process.sourceIdToString >> text >> List.singleton >> code []) >> Maybe.withDefault (text "")
-      }
     , { label = "Catégories"
       , toValue =
             Table.StringValue <|


### PR DESCRIPTION
## :wrench: Problem

source Identifier has no sense outside of a SimaPro instance. The agb 3.1.1  AGRIBALU identifiers will be lost when moving to agb 3.2.
See :
https://www.notion.so/Agribalyse-3-2-library-dans-SimaPro-1a4b056852fc80909005dcca6b97979a
https://www.notion.so/Identifiants-de-proc-d-s-1a5b056852fc80c19eb8debdb1ece392

## :cake: Solution

Remove these identifiers from the explorer.

## :desert_island: How to test

Check that there are no MTE or AGRIBALU in the explorer
