### PR TITLE
chore: update ingredient name in score history

### DIFF
--- a/bin/score_history/score_history.py
+++ b/bin/score_history/score_history.py
@@ -5,7 +5,6 @@ import logging
 import os
 import pathlib
 import sys
-import uuid
 from contextlib import contextmanager
 from datetime import datetime
 from enum import StrEnum
@@ -544,8 +543,8 @@ def add_all_ingredients_as_examples(examples_input):
     for ingredient in visible_ingredients:
         ingredient_id = ingredient["id"]
         new_example = {
-            "id": str(uuid.uuid5(uuid.NAMESPACE_DNS, ingredient_id)),
-            "name": f"{ingredient_id}",
+            "id": ingredient_id,
+            "name": f"{ingredient['alias']}",
             "category": "raw_ingredient",
             "query": {"ingredients": [{"id": ingredient_id, "mass": 1000}]},
         }


### PR DESCRIPTION
## :wrench: Problem

We change the ingredients datamodel without updating score_history.py

For food, the product_name being registered right now is the id `ebb1d5ac-83e9-4295-9067-01e4bc5e43d1` instead of the alias `chinese-cabbage-ue`

## :cake: Solution

Replace the id by the alias

## :rotating_light:  Points to watch/comments


## :desert_island: How to test

- scores are kept in score_history table only if there is a change of score so this PR won't trigger a score_history table insertion
- for the next score change,  In https://superset.ecobalyse.fr/sqllab, for new records food.product_name should be an alias and not an uuid.

