### PR TITLE
feat(food): add transport cooling column to ingredients explorer.

### DIFF
--- a/src/Data/Food/Ingredient.elm
+++ b/src/Data/Food/Ingredient.elm
@@ -13,6 +13,7 @@ module Data.Food.Ingredient exposing
     , getDefaultOriginTransport
     , idFromString
     , idToString
+    , transportCoolingToString
     )
 
 import Data.Food.EcosystemicServices as EcosystemicServices exposing (EcosystemicServices)
@@ -215,3 +216,16 @@ linkProcess processes =
                             |> Result.fromMaybe ("Procédé introuvable par code : " ++ processCode)
                    )
             )
+
+
+transportCoolingToString : TransportCooling -> String
+transportCoolingToString v =
+    case v of
+        AlwaysCool ->
+            "Toujours réfrigéré"
+
+        CoolOnceTransformed ->
+            "Réfrigéré après transformation"
+
+        NoCooling ->
+            "Non régrigéré"

--- a/src/Page/Explore/FoodIngredients.elm
+++ b/src/Page/Explore/FoodIngredients.elm
@@ -76,6 +76,10 @@ table _ { detailed, scope } =
                             [ Icon.question ]
                         ]
           }
+        , { label = "Transport réfrigéré"
+          , toValue = Table.StringValue <| .transportCooling >> Ingredient.transportCoolingToString
+          , toCell = .transportCooling >> Ingredient.transportCoolingToString >> text
+          }
         , { label = "Procédé"
           , toValue = Table.StringValue <| .default >> .name
           , toCell =


### PR DESCRIPTION
## :wrench: Problem

Ingredient transport cooling information was not displayed in the ingredients explorer. [context](https://mattermost.incubateur.net/fabnum-mte/pl/n1rho7xrpjrdzbcbcxse8nkgso)

## :cake: Solution

Display it.

## :desert_island: How to test

Check that the column renders the appropriate transport cooling information.