### PR TITLE
chore: enable all verticals in review apps

### DIFF
--- a/scalingo.json
+++ b/scalingo.json
@@ -1,5 +1,14 @@
 {
   "env": {
+    "ENABLE_FOOD_SECTION": {
+      "value": "True"
+    },
+    "ENABLE_OBJECTS_SECTION": {
+      "value": "True"
+    },
+    "ENABLE_VELI_SECTION": {
+      "value": "True"
+    },
     "IS_REVIEW_APP": {
       "value": "true"
     }


### PR DESCRIPTION
## :wrench: Problem

Currently food, objects and veli are disabled by default in review apps. This make reviewing changes in these vertical more difficult.

## :cake: Solution

Use `scalingo.json` to set 
`
    "ENABLE_FOOD_SECTION": {
      "value": "True"
    },
    "ENABLE_OBJECTS_SECTION": {
      "value": "True"
    },
    "ENABLE_VELI_SECTION": {
      "value": "True"
    },
`
So that review apps display all verticals, but it doesn't affect production

## :rotating_light:  Points to watch/comments


## :desert_island: How to test

Check that the review app has a food, objects and veli tab