### PR TITLE
chore: deprecate textile simulator API GET endpoints.

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -77,6 +77,7 @@ paths:
                 $ref: "#/components/schemas/ProductListResponse"
   /textile/simulator:
     get:
+      deprecated: true
       tags:
         - Textile
       summary: Calcul des impacts environnementaux d'un produit textile
@@ -150,6 +151,7 @@ paths:
                 $ref: "#/components/schemas/InvalidParametersError"
   /textile/simulator/{impact}:
     get:
+      deprecated: true
       tags:
         - Textile
       summary: Calcul d'un impact environnemental spécifique d'un produit textile
@@ -226,6 +228,7 @@ paths:
                 $ref: "#/components/schemas/InvalidParametersError"
   /textile/simulator/detailed:
     get:
+      deprecated: true
       tags:
         - Textile
       summary: Calcul exhaustif des impacts environnementaux d'un produit textile

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -363,6 +363,7 @@ paths:
                 $ref: "#/components/schemas/PackagingListResponse"
   /food:
     get:
+      deprecated: true
       tags:
         - Alimentaire
       summary: Calcul des impacts environnementaux d'une recette alimentaire

--- a/src/Page/Api.elm
+++ b/src/Page/Api.elm
@@ -55,14 +55,24 @@ getApiServerUrl { clientUrl } =
 
 changelog : List News
 changelog =
-    [  { date = "26 février 2025"
+    [ { date = "26 février 2025"
       , level = "major"
-      , domains = [ "Textile" ]
-      , md = """Standardisation des noms de champs dans les réponses API :
+      , domains = [ "Alimentaire", "Textile" ]
+      , md = """Les points d'entrée utilisant les paramètres passés en query string pour effectuer des calculs
+      sont dépréciés, leur équivalent `POST`/`JSON` leur étant désormais préférés\u{00A0}:
+- `GET /food` est déprécié
+- `GET /textile/simulator` est déprécié
+- `GET /textile/simulator/{impact}` est déprécié
+- `GET /textile/simulator/detailed` est déprécié
+
+                **Note: ces points d'entrée seront supprimés dans la prochaine version majeure de l'application.**
+
+                D'autre part et par souci de cohérence et de consistance, certains noms de champs utilisent
+                désormais le `camelCase` dans les réponses API\u{00A0}:
 - `elec_kWh` devient `elecKWh`
 - `heat_MJ` devient `heatMJ`"""
-      },
-      { date = "17 février 2025"
+      }
+    , { date = "17 février 2025"
       , level = "major"
       , domains = [ "Textile" ]
       , md = """Le paramètre `dyeingMedium`, qui permettait de sélectionner le support de teinture,


### PR DESCRIPTION
## :wrench: Problem

Query-string based API endpoints have been complicated to maintain over time and don't provide much value over their much simpler POST+JSON equivalent. We should deprecate these redundant GET endpoints.

Note: We'll remove them completely in the following major version to clear redundancy and clean a bunch of tech debt along the way (work has been started in #951).

## :cake: Solution

Deprecate these API endpoints which already have a POST+JSON equivalent:

- `GET /food`
- `GET /textile/simulator`
- `GET /textile/simulator/{impact}`
- `GET /textile/simulator/detailed`

These will be removed in 5.0.0.

## :desert_island: How to test

Endpoints should keep working, only the documentation should denote them as deprecated:

![image](https://github.com/user-attachments/assets/908b823e-7f72-488f-a6ee-588b193292b2)

