### PR TITLE
fix: memory leak in node 20.16 and 20.17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "uuid": "^11.0.5"
       },
       "engines": {
-        "node": "20.17"
+        "node": "20.18"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "private": true,
   "engines": {
-    "node": "20.17"
+    "node": "20.18"
   },
   "browserslist": [
     "last 2 versions",


### PR DESCRIPTION
## :wrench: Problem

We get a daily application crash with the following log:

```
2025-03-06 01:20:27.700694367 +0000 UTC [web-1] <--- JS stacktrace --->
2025-03-06 01:20:27.700703803 +0000 UTC [web-1] FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
2025-03-06 01:20:27.700706909 +0000 UTC [web-1] ----- Native stack trace -----
2025-03-06 01:20:27.701695609 +0000 UTC [web-1] 1: 0xb86ecf node::OOMErrorHandler(char const*, v8::OOMDetails const&) [node]
2025-03-06 01:20:27.702335043 +0000 UTC [web-1] 2: 0xef74d0 v8::Utils::ReportOOMFailure(v8::internal::Isolate*, char const*, v8::OOMDetails const&) [node]
2025-03-06 01:20:27.702951980 +0000 UTC [web-1] 3: 0xef77b7 v8::internal::V8::FatalProcessOutOfMemory(v8::internal::Isolate*, char const*, v8::OOMDetails const&) [node]
2025-03-06 01:20:27.703647253 +0000 UTC [web-1] 4: 0x1109355 [node]
2025-03-06 01:20:27.704443782 +0000 UTC [web-1] 5: 0x11098e4 v8::internal::Heap::RecomputeLimits(v8::internal::GarbageCollector) [node]
2025-03-06 01:20:27.705220117 +0000 UTC [web-1] 6: 0x11207d4 v8::internal::Heap::PerformGarbageCollection(v8::internal::GarbageCollector, v8::internal::GarbageCollectionReason, char const*) [node]
2025-03-06 01:20:27.705917365 +0000 UTC [web-1] 7: 0x1120fec v8::internal::Heap::CollectGarbage(v8::internal::AllocationSpace, v8::internal::GarbageCollectionReason, v8::GCCallbackFlags) [node]
2025-03-06 01:20:27.706609541 +0000 UTC [web-1] 8: 0x10f72f1 v8::internal::HeapAllocator::AllocateRawWithLightRetrySlowPath(int, v8::internal::AllocationType, v8::internal::AllocationOrigin, v8::internal::AllocationAlignment) [node]
2025-03-06 01:20:27.707298498 +0000 UTC [web-1] 9: 0x10f8485 v8::internal::HeapAllocator::AllocateRawWithRetryOrFailSlowPath(int, v8::internal::AllocationType, v8::internal::AllocationOrigin, v8::internal::AllocationAlignment) [node]
2025-03-06 01:20:27.708073133 +0000 UTC [web-1] 10: 0x10d5ad6 v8::internal::Factory::NewFillerObject(int, v8::internal::AllocationAlignment, v8::internal::AllocationType, v8::internal::AllocationOrigin) [node]
2025-03-06 01:20:27.708921213 +0000 UTC [web-1] 11: 0x1531906 v8::internal::Runtime_AllocateInYoungGeneration(int, unsigned long*, v8::internal::Isolate*) [node]
2025-03-06 01:20:27.709741637 +0000 UTC [web-1] 12: 0x196aef6 [node]
2025-03-06 01:20:27.966519839 +0000 UTC [web-1] Aborted (core dumped) 
```

We're currently running node v20.17.
Apparently there is a memory leak on node 20.16 and 20.17 which is fixed in 20.18:
https://github.com/nodejs/node/issues/54274

## :cake: Solution

Upgrade to node 20.18

## :desert_island: How to test

Wait 2 or 3 days to see if there are other crashes.