### PR TITLE
chore: add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,51 @@
+name: Bug Report/Rapport de bug
+description: |
+  File a bug report/Remonter un bug
+
+  Note:
+  - For feature requests and support questions, please use [Mattermost](https://chat.ecobalyse.fr/)
+  - Pour suggérer des fonctionnalités ou obtenir de l'aide, veuillez utiliser [Mattermost](https://chat.ecobalyse.fr/)
+labels: ["bug"]
+projects: ["MTES-MCT/53"]
+body:
+- type: textarea
+  attributes:
+    label: Current Behavior/Comportement actuel
+    description: A concise description of what you're experiencing/Une brève description du comportement problématique observé
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Expected Behavior/Comportement attendu
+    description: A concise description of what you expected to happen/Une brève description du comportement normal attendu
+  validations:
+    required: false
+- type: input
+  attributes:
+    label: URL/Adresse
+    description: URL where the bug occurs/Adresse à laquelle le bug apparait
+    placeholder: "https://"
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Steps To Reproduce/Étapes de reproduction
+    description: Steps to reproduce the behavior/Étapes permettant de reproduirele problème
+    placeholder: |
+      1. In this environment/Dans cet environnement…
+      1. With this config/Dans cette configuration…
+      1. Run/Exécuter…
+      1. See error/Erreur obtenue…
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Environment/Environnement
+    description: |
+      Examples/Exemples:
+        - Safari/iOS 18.2
+        - Firefox/Windows 11
+        - cURL/API v4.0.0
+    render: markdown
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,7 +1,7 @@
 ---
 name: Task
 about: A technical task
-title: "A short description of the task"
+title: A short summary of the problem the task should solve
 ---
 
 ## :wrench: Problem

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,20 @@
+---
+name: Task
+about: A technical task
+title: "A short description of the task"
+---
+
+## :wrench: Problem
+<!-- Describe the problem you're trying to solve, the reason why you are creating this task. -->
+
+## :cake: Solution
+<!-- Optionally, explain the functional or technical solution that should be implemented to solve the problem. Otherwise leave this section blank so it can be discussed in the comment section. -->
+
+## :rotating_light:  Points to watch/comments
+<!-- If there is anything unusual or some clarifications needed for the implementer to better understand the requirements or the constraints, mention it here. -->
+
+## :desert_island: How to test
+<!-- What should someone do to validate that the proposed solution and implementation is working as expected and properly addresses the needs. Don't hesitate to be too verbose and to explain in details, using bullet points for example, the steps to follow to test the expected behavior. -->
+
+- [ ] Example expectation
+- [ ] Another example expectation


### PR DESCRIPTION
## :wrench: Problem

We want to explore switching to Github Project.

## :cake: Solution

Introduce an issue template to use Github project for managing the project backlog.

## :desert_island: How to test

Once merged, creating a new issue should use this new template
