### PR TITLE
fix(api): improve API docs and JSON data validation

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -648,6 +648,33 @@ components:
       - materials
       - product
       properties:
+        mass:
+          type: number
+          description: Masse du produit fini, en kilogrammes
+          minimum: 0.01
+          example: 0.17
+        product:
+          type: string
+          description: |
+            Identifiant du produit (liste disponible sur le point d'entrée `/textile/products`)
+          enum:
+          - calecon
+          - chaussettes
+          - chemise
+          - jean
+          - jupe
+          - maillot
+          - manteau
+          - pantalon
+          - pull
+          - slip
+          - tshirt
+        materials:
+          type: array
+          description: Liste des matières composant le vêtement
+          items:
+            "$ref": "#/components/schemas/TextileQueryMaterial"
+          minItems: 1
         airTransportRatio:
           type: number
           description: |
@@ -788,17 +815,6 @@ components:
             **⚠️ Sur les produits tricotés en "integral / whole garment", ce paramètre n'a aucun impact (valeur fixe: 0).**
           minimum: 0
           maximum: 0.4
-        materials:
-          type: array
-          description: Liste des matières composant le vêtement
-          items:
-            "$ref": "#/components/schemas/TextileQueryMaterial"
-          minItems: 1
-        mass:
-          type: number
-          description: Masse du produit fini, en kilogrammes
-          minimum: 0.01
-          example: 0.17
         numberOfReferences:
           description: |
             Nombre de références au catalogue de la marque.
@@ -837,18 +853,6 @@ components:
               type: number
               description: |
                 Pourcentage de surface teinte, exprimé entre `0` et `1`
-        product:
-          type: string
-          description: |
-            Identifiant du produit (liste disponible sur le point d'entrée `/textile/products`)
-          enum:
-          - chemise
-          - jean
-          - jupe
-          - manteau
-          - pantalon
-          - pull
-          - tshirt
         surfaceMass:
           type: number
           description: |

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -644,7 +644,9 @@ components:
       type: object
       additionalProperties: false
       required:
+      - mass
       - materials
+      - product
       properties:
         airTransportRatio:
           type: number

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.4.7",
         "express": "^4.21.2",
+        "express-body-parser-error-handler": "^1.0.9",
         "express-rate-limit": "^7.5.0",
         "helmet": "^8.1.0",
         "js-yaml": "^4.1.0",
@@ -4387,6 +4388,16 @@
         "@babel/types": "^7.20.7"
       }
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.5",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
+      "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/cacheable-request": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
@@ -4409,6 +4420,30 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/express": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
+      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.19.6",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
+      "integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -4424,6 +4459,12 @@
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
       "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
+      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
       "license": "MIT"
     },
     "node_modules/@types/istanbul-lib-coverage": {
@@ -4470,6 +4511,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "license": "MIT"
+    },
     "node_modules/@types/mysql": {
       "version": "2.15.26",
       "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.26.tgz",
@@ -4508,6 +4555,18 @@
         "@types/pg": "*"
       }
     },
+    "node_modules/@types/qs": {
+      "version": "6.9.18",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.18.tgz",
+      "integrity": "sha512-kK7dgTYDyGqS+e2Q4aK9X3D7q234CIZ1Bv0q/7Z5IwRDoADNU81xXJK/YVyLbLTZCoIwUoDoffFeF+p/eIklAA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/responselike": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
@@ -4516,6 +4575,27 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/send": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
+      "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.7",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.7.tgz",
+      "integrity": "sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "*"
       }
     },
     "node_modules/@types/shimmer": {
@@ -6625,6 +6705,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-body-parser-error-handler": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/express-body-parser-error-handler/-/express-body-parser-error-handler-1.0.9.tgz",
+      "integrity": "sha512-3+g4eRSx4ShaYfubqpm8efWoBY6A5fgk/oNV4qZ8peH9EWMuPCS1fCOnlnDgCjCwd1wtll/WHYMy6PnLMtEcZA==",
+      "license": "ISC",
+      "dependencies": {
+        "@types/express": "^4.17.15"
       }
     },
     "node_modules/express-rate-limit": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
+    "express-body-parser-error-handler": "^1.0.9",
     "express-rate-limit": "^7.5.0",
     "helmet": "^8.1.0",
     "js-yaml": "^4.1.0",

--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@ const { monitorExpressApp } = require("./lib/instrument");
 const fs = require("fs");
 const path = require("path");
 const bodyParser = require("body-parser");
+const bodyParserErrorHandler = require("express-body-parser-error-handler");
 const cors = require("cors");
 const yaml = require("js-yaml");
 const helmet = require("helmet");
@@ -47,6 +48,16 @@ if (NODE_ENV !== "test" && (!MATOMO_HOST || !MATOMO_SITE_ID || !MATOMO_TOKEN)) {
 
 // Sentry monitoring
 monitorExpressApp(app);
+
+// Middleware
+const jsonErrorHandler = bodyParserErrorHandler({
+  onError: (err, req, res, next) => {
+    res.status(400).send({
+      error: { decoding: `Format JSON invalide : ${err.message}` },
+      documentation: "https://ecobalyse.beta.gouv.fr/#/api",
+    });
+  },
+});
 
 // Web
 
@@ -233,7 +244,7 @@ const respondWithFormattedJSON = (res, status, body) => {
 };
 
 // Note: Text/JSON request body parser (JSON is decoded in Elm)
-api.all(/(.*)/, bodyParser.json(), async (req, res) => {
+api.all(/(.*)/, bodyParser.json(), jsonErrorHandler, async (req, res) => {
   const processes = await getProcesses(req.headers.token);
 
   elmApp.ports.input.send({
@@ -274,33 +285,39 @@ version.get("/:versionNumber/api", checkVersionAndPath, (req, res) => {
   res.status(200).send(openApiContents);
 });
 
-version.all("/:versionNumber/api/*", checkVersionAndPath, bodyParser.json(), async (req, res) => {
-  const versionNumber = req.params.versionNumber;
-  const { processesImpacts, processes } = availableVersions.find(
-    (version) => version.dir === versionNumber,
-  );
-  const versionProcesses = await getProcesses(req.headers.token, processesImpacts, processes);
+version.all(
+  "/:versionNumber/api/*",
+  checkVersionAndPath,
+  bodyParser.json(),
+  jsonErrorHandler,
+  async (req, res) => {
+    const versionNumber = req.params.versionNumber;
+    const { processesImpacts, processes } = availableVersions.find(
+      (version) => version.dir === versionNumber,
+    );
+    const versionProcesses = await getProcesses(req.headers.token, processesImpacts, processes);
 
-  const { Elm } = require(path.join(req.staticDir, "server-app"));
+    const { Elm } = require(path.join(req.staticDir, "server-app"));
 
-  const elmApp = Elm.Server.init();
+    const elmApp = Elm.Server.init();
 
-  elmApp.ports.output.subscribe(({ status, body, jsResponseHandler }) => {
-    return jsResponseHandler({ status, body });
-  });
+    elmApp.ports.output.subscribe(({ status, body, jsResponseHandler }) => {
+      return jsResponseHandler({ status, body });
+    });
 
-  const urlWithoutPrefix = req.url.replace(/\/[^/]+\/api/, "");
+    const urlWithoutPrefix = req.url.replace(/\/[^/]+\/api/, "");
 
-  elmApp.ports.input.send({
-    method: req.method,
-    url: urlWithoutPrefix,
-    body: req.body,
-    processes: versionProcesses,
-    jsResponseHandler: ({ status, body }) => {
-      respondWithFormattedJSON(res, status, body);
-    },
-  });
-});
+    elmApp.ports.input.send({
+      method: req.method,
+      url: urlWithoutPrefix,
+      body: req.body,
+      processes: versionProcesses,
+      jsResponseHandler: ({ status, body }) => {
+        respondWithFormattedJSON(res, status, body);
+      },
+    });
+  },
+);
 
 version.get("/:versionNumber/processes/processes.json", checkVersionAndPath, async (req, res) => {
   const versionNumber = req.params.versionNumber;

--- a/tests/server.spec.js
+++ b/tests/server.spec.js
@@ -44,6 +44,15 @@ describe("API", () => {
         expect(response.body.openapi).toEqual("3.0.1");
         expect(response.body.info.title).toEqual("API Ecobalyse");
       });
+
+      it("should respond with an HTTP 400 error on invalid JSON provided", async () => {
+        const response = await request(app).post("/api/textile/simulator").type("json").send("}{");
+
+        expectStatus(response, 400);
+        expect(response.body).toHaveProperty("error");
+        expect(response.body.error).toHaveProperty("decoding");
+        expect(response.body.error.decoding).toMatch("Format JSON invalide");
+      });
     });
   });
 
@@ -667,7 +676,7 @@ async function expectListResponseContains(path, object) {
 
 function expectStatus(response, expectedCode, type = "application/json") {
   if (response.status === 400 && expectedCode != 400) {
-    expect(response.body).toHaveProperty("errors", "");
+    expect(response.body).toHaveProperty("error", "");
   }
   expect(response.type).toBe(type);
   expect(response.statusCode).toBe(expectedCode);


### PR DESCRIPTION
This patch fixes 4 problems with the API:

- The `openapi.yml` schema didn't declare required schema fields properly ([source](https://chat.ecobalyse.fr/ecobalyse/pl/twdih8ewwtd6bnqarskzpmkq3h))
- The required fields now appears on top of the fields list for convenience
- Several product categories were missing from the schema enum
- Invalid JSON body passed to POST endpoints generated a `text/html` response, possibly breaking clients 