### PR TITLE
fix: default to empty string on BACKEND_API_URL not set

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ const storeKey = "store";
 
 const app = Elm.Main.init({
   flags: {
-    backendApiUrl: process.env.BACKEND_API_URL,
+    backendApiUrl: process.env.BACKEND_API_URL || "",
     clientUrl: location.origin + location.pathname,
     enabledSections: {
       food: process.env.ENABLE_FOOD_SECTION === "True",


### PR DESCRIPTION
should fix #1051

![image](https://github.com/user-attachments/assets/0a4d1fc3-3a19-49e7-8f59-cc12746d01cb)

@vjousse dunno how to check that it actually fixes version switching WPOD, and how to patch generated versions :/