### PR TITLE
fix: properly decode json processes on login

### DIFF
--- a/src/Request/Auth.elm
+++ b/src/Request/Auth.elm
@@ -63,7 +63,7 @@ processes : (Result Http.Error String -> msg) -> String -> Cmd msg
 processes event token =
     Http.request
         { body = Http.emptyBody
-        , expect = Http.expectJson event Decode.string
+        , expect = Http.expectString event
         , headers = [ Http.header "token" token ]
         , method = "GET"
         , timeout = Nothing


### PR DESCRIPTION
Fixes #1084 

How to test on the review app:
- [ ] Log in and you shouldn't get a JSON decode error
- [ ] Refresh the page in the browser : you shouldn't get a JSON decode error
- [ ] When authenticated, you should have access to detailed impacts