### PR TITLE
refactor: generalize uuid parsing result errors

### DIFF
--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -659,11 +659,8 @@ findById id =
 
 
 idFromString : String -> Result String Id
-idFromString str =
-    str
-        |> Uuid.fromString
-        |> Result.fromMaybe ("Identifiant invalide: " ++ str)
-        |> Result.map Id
+idFromString =
+    Uuid.fromString >> Result.map Id
 
 
 idToString : Id -> String

--- a/src/Data/Dataset.elm
+++ b/src/Data/Dataset.elm
@@ -247,22 +247,22 @@ setIdFromString idString dataset =
             Countries (Just (Country.codeFromString idString))
 
         FoodExamples _ ->
-            FoodExamples (Uuid.fromString idString)
+            FoodExamples (idString |> Uuid.fromString |> Result.toMaybe)
 
         FoodIngredients _ ->
-            FoodIngredients (Ingredient.idFromString idString)
+            FoodIngredients (idString |> Ingredient.idFromString |> Result.toMaybe)
 
         Impacts _ ->
             Impacts (Definition.toTrigram idString |> Result.toMaybe)
 
         ObjectExamples _ ->
-            ObjectExamples (Uuid.fromString idString)
+            ObjectExamples (idString |> Uuid.fromString |> Result.toMaybe)
 
         Processes scope _ ->
             Processes scope (Process.idFromString idString |> Result.toMaybe)
 
         TextileExamples _ ->
-            TextileExamples (Uuid.fromString idString)
+            TextileExamples (idString |> Uuid.fromString |> Result.toMaybe)
 
         TextileMaterials _ ->
             TextileMaterials (Just (Material.Id idString))

--- a/src/Data/Example.elm
+++ b/src/Data/Example.elm
@@ -69,7 +69,7 @@ forScope scope =
 
 parseUuid : Parser (Uuid -> a) a
 parseUuid =
-    Parser.custom "EXAMPLE" Uuid.fromString
+    Parser.custom "EXAMPLE" (Uuid.fromString >> Result.toMaybe)
 
 
 toCategory : List (Example query) -> query -> String

--- a/src/Data/Food/Ingredient.elm
+++ b/src/Data/Food/Ingredient.elm
@@ -112,9 +112,9 @@ encodePlaneTransport planeTransport =
             Nothing
 
 
-idFromString : String -> Maybe Id
-idFromString str =
-    Uuid.fromString str |> Maybe.map Id
+idFromString : String -> Result String Id
+idFromString =
+    Uuid.fromString >> Result.map Id
 
 
 idToString : Id -> String

--- a/src/Data/Process.elm
+++ b/src/Data/Process.elm
@@ -147,11 +147,8 @@ encodeSourceId =
 
 
 idFromString : String -> Result String Id
-idFromString str =
-    str
-        |> Uuid.fromString
-        |> Result.fromMaybe ("Identifiant invalide : " ++ str)
-        |> Result.map Id
+idFromString =
+    Uuid.fromString >> Result.map Id
 
 
 idToString : Id -> String

--- a/src/Data/Uuid.elm
+++ b/src/Data/Uuid.elm
@@ -25,9 +25,10 @@ encoder =
     Uuid.encode
 
 
-fromString : String -> Maybe Uuid
+fromString : String -> Result String Uuid
 fromString =
     Uuid.fromString
+        >> Result.fromMaybe "UUIDinvalide"
 
 
 toString : Uuid -> String

--- a/tests/Data/Food/RecipeTest.elm
+++ b/tests/Data/Food/RecipeTest.elm
@@ -36,7 +36,7 @@ suite =
                   )
                 )
             of
-                ( Ok royalPizza, ( Just eggId, Just mangoId, Just wheatId ) ) ->
+                ( Ok royalPizza, ( Ok eggId, Ok mangoId, Ok wheatId ) ) ->
                     [ let
                         testComputedComplements complements =
                             Recipe.computeIngredientComplementsImpacts complements (Mass.kilograms 2)


### PR DESCRIPTION
This improves the way we express UUID parsing errors, making them more consistent across the codebase.