### PR TITLE
feat: add success notification on api token copied.

### DIFF
--- a/src/Page/Auth.elm
+++ b/src/Page/Auth.elm
@@ -128,7 +128,7 @@ update session msg model =
         -- Generic page updates
         CopyToClipboard accessToken ->
             ( model
-            , session
+            , session |> Session.notifyInfo "Copié" "Le jeton d'API a été copié dans le presse-papiers"
             , Ports.copyToClipboard accessToken
             )
 


### PR DESCRIPTION
## :wrench: Problem

From @camcoq-start ([source](https://github.com/MTES-MCT/ecobalyse/issues/1052#issuecomment-2969555702))

There's no visual feedback when a token has been copied to the user's clipboard.

## :cake: Solution

Add a success notification.

## :desert_island: How to test

- [ ] Copy a generated API token: a success notification is shown.