### PR TITLE
chore: reduce sentry tracesSampleRate

### DIFF
--- a/lib/instrument.js
+++ b/lib/instrument.js
@@ -9,8 +9,8 @@ if (shouldInitSentry) {
   Sentry.init({
     dsn: SENTRY_DSN,
     integrations: [nodeProfilingIntegration()],
-    tracesSampleRate: 1.0,
-    profilesSampleRate: 1.0,
+    tracesSampleRate: 0.1,
+    profilesSampleRate: 0.1,
     // IS_REVIEW_APP is set by `scalingo.json` only on review apps
     environment: IS_REVIEW_APP ? "review-app" : NODE_ENV,
   });


### PR DESCRIPTION
reduce sentry tracesSampleRate (800k events/day)

## :wrench: Problem

> Sentry client generates too much data on our shared instance

## :cake: Solution

> reduce tracesSampleRate

> https://docs.sentry.io/platforms/javascript/configuration/sampling/