### PR TITLE
fix: improve e2e tests reliability wrt notifications

### DIFF
--- a/e2e/lib.js
+++ b/e2e/lib.js
@@ -13,6 +13,8 @@ export async function deleteAllEmails() {
 
 export async function expectNotification(page, message) {
   await expect(page.locator(".ToastTray").getByText(message)).toBeVisible();
+  // immediately close the notification to avoid unwanted accumulation
+  await page.locator(".ToastTray").locator("button", { name: "Fermer" }).nth(0).click();
 }
 
 export function extractUrlsFromText(text) {

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -48,7 +48,7 @@ export default defineConfig({
       name: "chromium",
       use: {
         ...devices["Desktop Chrome"],
-        viewport: { width: 2560, height: 1440 },
+        viewport: { width: 1920, height: 1080 },
       },
     },
   ],


### PR DESCRIPTION
Immediately close a notification as soon as a test assertion has been made about it, to avoid intermittent e2e test failures.