### PR TITLE
feat(textile,ui): add link to product category explorer

### DIFF
--- a/src/Page/Textile.elm
+++ b/src/Page/Textile.elm
@@ -712,8 +712,17 @@ productCategoryField { products } query =
                 |> AutocompleteSelector.init .name
     in
     div [ class "d-flex flex-column" ]
-        [ label [ for "selector-product", class "form-label text-truncate" ]
-            [ text "Catégorie" ]
+        [ div [ class "d-flex justify-content-between align-items-center" ]
+            [ label [ for "selector-product", class "form-label text-truncate" ]
+                [ text "Catégorie de produit" ]
+            , Button.smallPillLink
+                [ class "text-primary"
+                , Route.href <| Route.Explore Scope.Textile (Dataset.TextileProducts Nothing)
+                , title "Explorer les catégories de produit"
+                , target "_blank"
+                ]
+                [ Icon.question ]
+            ]
         , button
             [ id "selector-product"
             , class "form-select ElementSelector text-start w-auto"


### PR DESCRIPTION
This patch adds a link to the product category explorer for the product category field in the textile simulator UI:

![image](https://github.com/user-attachments/assets/9170d4ff-8414-4309-b124-8747a1b3b9c8)

Context feedback: https://mattermost.incubateur.net/fabnum-mte/pl/nwa71e6hx3875cazg1n98dsquo