### PR TITLE
fix: 500 error on journal history

### DIFF
--- a/backend/.env.sample
+++ b/backend/.env.sample
@@ -1,4 +1,0 @@
-SECRET_KEY=a-string-secret-at-least-256-bits-long
-EMAIL_SERVER_HOST=
-EMAIL_SERVER_PASSWORD=
-EMAIL_SERVER_USER=

--- a/backend/.env.testing
+++ b/backend/.env.testing
@@ -1,6 +1,0 @@
-# App
-SECRET_KEY='secret-key'
-
-DATABASE_ECHO=true
-DATABASE_ECHO_POOL=false
-LITESTAR_DEBUG=true

--- a/backend/README.md
+++ b/backend/README.md
@@ -3,7 +3,7 @@
 ## Requirements
 
 - [uv](https://docs.astral.sh/uv/) for Python (it will manage the Python install for you)
-- PostgreSQL if you don’t want to use the default SQLite database
+- [docker](https://www.docker.com/) for the PostgreSQL database
 
 The web framework used is [Litestar](https://litestar.dev/).
 
@@ -15,11 +15,17 @@ uv sync
 
 ## Database
 
-By default a local SQLite database will be used.
+You can run the container by hand with:
 
-### Use PostgreSQL
+```
+docker compose up -d
+```
 
-You can set the `DATABASE_URL` environment variable to a PostgreSQL DSN (specifying the `asyncpg` driver) if you don’t want to use SQLite.
+Or you can let `npm run start:dev` do it for you.
+
+### Specify database DSN by hand
+
+You can set the `DATABASE_URL` environment variable to a PostgreSQL DSN (specifying the `asyncpg` driver) if you don’t want to use the default docker database.
 
 For example:
 
@@ -36,7 +42,7 @@ uv run backend database upgrade --no-prompt
 ## Run the dev server
 
 ```bash
-uv run backend run --debug --reload
+uv run backend run --reload
 ```
 
 Calling `http://localhost:8000/health` should give you the following JSON:
@@ -49,19 +55,25 @@ Calling `http://localhost:8000/health` should give you the following JSON:
 }
 ```
 
-## Load component fixtures
+## Reset DB and load fixtures
 
-If you want you can first reset your DB:
+If you want you can first reset your docker DB and load the dev fixtures by running this script:
 
 ```bash
-rm db.sqlite3
-uv run backend database upgrade --no-prompt
+./bin/reset-docker-db.sh
 ```
 
-And then load your `components.json` file:
+## Backend CLI
+
+### Get all possible commands
 
 ```bash
-uv run backend fixtures load-components public/data/object/components.json
+un run backend --help
+```
+### Get help on a specific command
+
+```bash
+un run backend users --help
 ```
 
 ## OpenAPI documentation

--- a/backend/src/app/cli/commands.py
+++ b/backend/src/app/cli/commands.py
@@ -74,7 +74,7 @@ async def _create_user(
 
 
 @user_management_group.command(
-    name="create-default-super-user", help="Create the default super user"
+    name="create-default-user", help="Create the default user"
 )
 @click.option(
     "--first-name",
@@ -109,7 +109,7 @@ def create_default_user(
 
     console = get_console()
 
-    console.rule("Create the default super user of the app.")
+    console.rule("Create the default user of the app.")
     superuser = False
 
     settings = get_settings()
@@ -228,10 +228,24 @@ async def load_components_fixtures(components_data: dict) -> None:
             email=settings.app.DEFAULT_USER_EMAIL
         )
         if not user:
-            await logger.aerror(
-                f"default super user {settings.app.DEFAULT_USER_EMAIL} not found"
+            await logger.awarning(
+                f"default super user {settings.app.DEFAULT_USER_EMAIL} not found, creating it"
             )
-            return
+
+            await _create_user(
+                email=settings.app.DEFAULT_USER_EMAIL,
+                first_name="Admin",
+                last_name="Ecobalyse",
+                organization="Ecobalyse",
+                # Not super user
+                superuser=False,
+                # Deactivate default user
+                is_active=False,
+            )
+
+            user = await users_service.get_one_or_none(
+                email=settings.app.DEFAULT_USER_EMAIL
+            )
 
         components_service = await anext(provide_components_service(db_session))
 

--- a/backend/src/app/config/app.py
+++ b/backend/src/app/config/app.py
@@ -73,6 +73,14 @@ def convert_sqlalchemy_exceptions_internal_to_problem_details(
     )
 
 
+def convert_unknown_exception_to_problem_details(
+    exc: Exception,
+) -> ProblemDetailsException:
+    return ProblemDetailsException(
+        detail="Internal Server Error", status_code=HTTP_500_INTERNAL_SERVER_ERROR
+    )
+
+
 problem_details = ProblemDetailsConfig(
     enable_for_all_http_exceptions=True,
     exception_to_problem_detail_map={
@@ -80,6 +88,7 @@ problem_details = ProblemDetailsConfig(
         IntegrityError: convert_sqlalchemy_exceptions_conflict_to_problem_details,
         ForeignKeyError: convert_sqlalchemy_exceptions_conflict_to_problem_details,
         InternalServerException: convert_sqlalchemy_exceptions_internal_to_problem_details,
+        HTTP_500_INTERNAL_SERVER_ERROR: convert_unknown_exception_to_problem_details,
     },
 )
 

--- a/backend/src/app/domain/journal_entries/deps.py
+++ b/backend/src/app/domain/journal_entries/deps.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 from app.db import models as m
 from app.domain.journal_entries.services import JournalEntryService
 from app.lib.deps import create_service_provider
-from sqlalchemy.orm import joinedload, selectinload
+from sqlalchemy.orm import joinedload
 
 provide_journal_entries_service = create_service_provider(
     JournalEntryService,
     load=[
-        selectinload(m.JournalEntry.user).options(
+        joinedload(m.JournalEntry.user, innerjoin=True).options(
             joinedload(m.User.profile, innerjoin=True)
         ),
     ],

--- a/backend/src/app/domain/journal_entries/deps.py
+++ b/backend/src/app/domain/journal_entries/deps.py
@@ -3,8 +3,13 @@ from __future__ import annotations
 from app.db import models as m
 from app.domain.journal_entries.services import JournalEntryService
 from app.lib.deps import create_service_provider
+from sqlalchemy.orm import joinedload, selectinload
 
 provide_journal_entries_service = create_service_provider(
     JournalEntryService,
-    load=[m.JournalEntry.user],
+    load=[
+        selectinload(m.JournalEntry.user).options(
+            joinedload(m.User.profile, innerjoin=True)
+        ),
+    ],
 )

--- a/bin/load-fixtures.sh
+++ b/bin/load-fixtures.sh
@@ -11,7 +11,7 @@ if [ "$IS_REVIEW_APP" == "true" ]; then
    uv run backend database drop-all --no-prompt
    uv run backend database upgrade --no-prompt
    echo "-> Loading components fixtures";
-   uv run backend users create-default-super-user
+   uv run backend users create-default-user
    uv run backend fixtures load-components public/data/object/components.json
 fi
 

--- a/bin/reset-docker-db.sh
+++ b/bin/reset-docker-db.sh
@@ -1,5 +1,5 @@
 docker compose exec -T db dropdb --if-exists -U ecobalyse ecobalyse_dev
 docker compose exec -T db createdb -U ecobalyse ecobalyse_dev
 uv run backend database upgrade --no-prompt
-uv run backend users create-default-super-user
+uv run backend users create-default-user
 uv run backend fixtures load-components public/data/object/components.json

--- a/tests/backend/data_fixtures.py
+++ b/tests/backend/data_fixtures.py
@@ -101,6 +101,19 @@ def fx_raw_users() -> list[User | dict[str, Any]]:
             ),
         },
         {
+            "id": "503b826c-78a0-44d9-9122-50a162aad306",
+            "email": "other_superuser@example.com",
+            "magic_link_token": "Test_Password1!_token_other",
+            "is_superuser": True,
+            "is_active": True,
+            "first_name": "Other Super",
+            "last_name": "User",
+            "organization": OrganizationCreate(
+                name="Super organization",
+                type=OrganizationType.ASSOCIATION,
+            ),
+        },
+        {
             "id": "5ef29f3c-3560-4d15-ba6b-a2e5c721e4d2",
             "email": "user@example.com",
             "magic_link_token": "Test_Password2!_token",

--- a/tests/backend/integration/conftest.py
+++ b/tests/backend/integration/conftest.py
@@ -189,6 +189,19 @@ def fx_superuser_token_headers() -> dict[str, str]:
     }
 
 
+@pytest.fixture(name="other_superuser_token_headers")
+def fx_other_superuser_token_headers() -> dict[str, str]:
+    """Valid superuser token.
+
+    ```text
+    ValueError: The future belongs to a different loop than the one specified as the loop argument
+    ```
+    """
+    return {
+        "Authorization": f"Bearer {auth.create_token(identifier='other_superuser@example.com')}"
+    }
+
+
 @pytest.fixture(name="user_token_headers")
 def fx_user_token_headers() -> dict[str, str]:
     """Valid user token.

--- a/tests/backend/integration/test_access.py
+++ b/tests/backend/integration/test_access.py
@@ -353,7 +353,7 @@ async def test_magic_link_expiration(
     async with UserService.new(session) as users_service:
         # Magic link login is ok
         authenticated_user = await users_service.authenticate_magic_token(
-            raw_users[1]["email"], "Test_Password2!_token"
+            raw_users[2]["email"], "Test_Password2!_token"
         )
         assert authenticated_user.magic_link_sent_at is None
         assert authenticated_user.magic_link_hashed_token is None
@@ -361,7 +361,7 @@ async def test_magic_link_expiration(
         # Magic link is outdated 24H duration by default
         with pytest.raises(PermissionDeniedException, match="Magic link token expired"):
             authenticated_user = await users_service.authenticate_magic_token(
-                raw_users[2]["email"], "Test_Password3!_token"
+                raw_users[3]["email"], "Test_Password3!_token"
             )
 
         # Magic link was not generated
@@ -369,7 +369,7 @@ async def test_magic_link_expiration(
             PermissionDeniedException, match="User not found or password invalid"
         ):
             authenticated_user = await users_service.authenticate_magic_token(
-                raw_users[3]["email"], ""
+                raw_users[4]["email"], ""
             )
 
 

--- a/tests/backend/integration/test_journal_entries.py
+++ b/tests/backend/integration/test_journal_entries.py
@@ -17,6 +17,7 @@ async def test_components_journal(
     client: "AsyncClient",
     session: AsyncSession,
     superuser_token_headers: dict[str, str],
+    other_superuser_token_headers: dict[str, str],
 ) -> None:
     async with JournalEntryService.new(session) as journal_entries_service:
         json_content = [
@@ -102,6 +103,26 @@ async def test_components_journal(
             == 1
         )
 
+        json_content = [
+            {
+                "elements": [
+                    {
+                        "amount": 0.00022,
+                        "material": "07e9e916-e02b-45e2-a298-2b5084de6242",
+                    }
+                ],
+                "id": "64fa65b3-c2df-4fd0-958b-83965bd6aa08",
+                "name": "Pied 70 cm (plein bois) - Test",
+            },
+        ]
+
+        # Ensure that we have entries with different users
+        response = await client.patch(
+            "/api/components",
+            json=json_content,
+            headers=other_superuser_token_headers,
+        )
+
         # Remove everything
 
         response = await client.patch(
@@ -112,13 +133,13 @@ async def test_components_journal(
         assert response.status_code == 200
 
         entries = await journal_entries_service.list()
-        assert len(entries) == 13
+        assert len(entries) == 14
 
         response = await client.get("/api/journal", headers=superuser_token_headers)
         json_response = response.json()
         assert response.status_code == 200
 
-        assert len(json_response) == 13
+        assert len(json_response) == 14
 
         response = await client.get(
             "/api/journal/component", headers=superuser_token_headers
@@ -126,7 +147,7 @@ async def test_components_journal(
         json_response = response.json()
         assert response.status_code == 200
 
-        assert len(json_response) == 13
+        assert len(json_response) == 14
 
         response = await client.get(
             "/api/journal/unknown", headers=superuser_token_headers


### PR DESCRIPTION
## :wrench: Problem

When displaying the history of a component, the backend throws an error 500 when one of the users in the history is not the current user. Moreover the format of the default 500 exception doesn’t follow the problem details spec (`status_code` instead of `status`) https://datatracker.ietf.org/doc/html/rfc9457

## :cake: Solution

Retrieve the related user when fetching journal entries and fix the default exception format.


## :rotating_light:  Points to watch/comments

The two useless `.env` files of the `backend/` directory have been removed too.

## :desert_island: How to test

Was fixed with TDD, so tests have been added to check that it works as expected.

If you want to test by hand: create 2 different users, and modify the same component with the two different users. You shouldn’t see any error.