### PR TITLE
refactor: handle empty responses from the backend api

### DIFF
--- a/backend/src/app/domain/accounts/controllers/access.py
+++ b/backend/src/app/domain/accounts/controllers/access.py
@@ -34,7 +34,6 @@ from litestar.di import Provide
 from litestar.exceptions import PermissionDeniedException
 from litestar.params import Parameter
 from litestar.security.jwt import Token
-from litestar.status_codes import HTTP_200_OK
 
 if TYPE_CHECKING:
     from app.domain.accounts.services import UserService
@@ -245,8 +244,6 @@ class AccessController(Controller):
         operation_id="DeleteToken",
         guards=[requires_active_user],
         path=urls.TOKEN_DELETE,
-        # Force body (instead of 204) to ease Elm parsing
-        status_code=HTTP_200_OK,
     )
     async def delete_token(
         self,

--- a/backend/src/app/domain/components/controllers/component.py
+++ b/backend/src/app/domain/components/controllers/component.py
@@ -23,7 +23,6 @@ from litestar import delete, get, patch, post
 from litestar.controller import Controller
 from litestar.di import Provide
 from litestar.params import Parameter
-from litestar.status_codes import HTTP_204_NO_CONTENT
 
 if TYPE_CHECKING:
     from app.domain.components.services import ComponentService
@@ -113,7 +112,6 @@ class ComponentController(Controller):
         operation_id="DeleteComponent",
         guards=[requires_superuser],
         path=urls.COMPONENT_DELETE,
-        status_code=HTTP_204_NO_CONTENT,
     )
     async def delete_component(
         self,

--- a/backend/src/app/domain/components/controllers/component.py
+++ b/backend/src/app/domain/components/controllers/component.py
@@ -23,7 +23,7 @@ from litestar import delete, get, patch, post
 from litestar.controller import Controller
 from litestar.di import Provide
 from litestar.params import Parameter
-from litestar.status_codes import HTTP_200_OK
+from litestar.status_codes import HTTP_204_NO_CONTENT
 
 if TYPE_CHECKING:
     from app.domain.components.services import ComponentService
@@ -113,7 +113,7 @@ class ComponentController(Controller):
         operation_id="DeleteComponent",
         guards=[requires_superuser],
         path=urls.COMPONENT_DELETE,
-        status_code=HTTP_200_OK,
+        status_code=HTTP_204_NO_CONTENT,
     )
     async def delete_component(
         self,

--- a/src/Request/BackendHttp.elm
+++ b/src/Request/BackendHttp.elm
@@ -59,10 +59,12 @@ expectJson toMsg decoder =
                 Http.BadUrl_ url ->
                     Err (BadUrl url)
 
-                Http.GoodStatus_ metadata body ->
-                    -- map an empty body to a valid JSON null value so that we can
-                    -- accept empty response bodies (eg. DELETE requests)
-                    (if String.isEmpty body then
+                Http.GoodStatus_ { headers, statusCode, url } body ->
+                    (if statusCode == 204 && String.isEmpty body then
+                        -- Map an empty body to a valid JSON "null" string so that we can
+                        -- accept an empty response body for 204 No Content responses
+                        -- Note: this is intended to work with expectWhatever which always
+                        -- succeeds with a () value
                         "null"
 
                      else
@@ -73,10 +75,10 @@ expectJson toMsg decoder =
                             (\err ->
                                 BadBody
                                     { detail = Decode.errorToString err
-                                    , headers = metadata.headers
-                                    , statusCode = metadata.statusCode
+                                    , headers = headers
+                                    , statusCode = statusCode
                                     , title = Just "Corps de réponse invalide"
-                                    , url = metadata.url
+                                    , url = url
                                     }
                             )
 

--- a/tests/backend/integration/test_access.py
+++ b/tests/backend/integration/test_access.py
@@ -540,8 +540,7 @@ async def test_token_delete(
         "/api/tokens/" + user_token_id,
         headers=user_token_headers,
     )
-    assert response.status_code == 200
-    assert response.json() is None
+    assert response.status_code == 204
 
 
 async def test_token_validation(

--- a/tests/backend/integration/test_components.py
+++ b/tests/backend/integration/test_components.py
@@ -213,7 +213,7 @@ async def test_components_delete(
             "/api/components/8ca2ca05-8aec-4121-acaa-7cdcc03150a9",
             headers=superuser_token_headers,
         )
-        assert response.status_code == 200
+        assert response.status_code == 204
 
         entries = await journal_entries_service.list()
         assert len(entries) == 1


### PR DESCRIPTION
## :wrench: Problem

The Elm backend http client doesn't handle an empty http response by (eg. for 204 responses), let's fix that.

## :cake: Solution

Default empty body string to `"null"` so it's always valid JSON.

## :rotating_light:  Points to watch/comments

Backend API now responds with 204 for deletions.

## :desert_island: How to test

Tests have been updated, so… not much. Maybe manually ensure that deleting a component from the admin doesn't explode your computer.