### PR TITLE
fix: backend url rewriting

### DIFF
--- a/.proxyrc.json
+++ b/.proxyrc.json
@@ -4,6 +4,13 @@
     "target": "http://127.0.0.1:8002/",
     "timeout": 30000
   },
+  "/versions/v6.0.0/backend": {
+    "target": "http://127.0.0.1:8002/",
+    "pathRewrite": {
+      "^/versions/v6.0.0/backend": ""
+    },
+    "timeout": 30000
+  },
   "/backend": {
     "target": "http://127.0.0.1:8002/",
     "pathRewrite": {

--- a/backend/src/app/cli/commands.py
+++ b/backend/src/app/cli/commands.py
@@ -69,8 +69,10 @@ async def _create_user(
 
     async with alchemy.get_session() as db_session:
         users_service = await anext(provide_users_service(db_session))
-        user = await users_service.upsert(data=obj_in.to_dict(), auto_commit=True)
-        console.print(f"User created: {user.email}")
+        user = await users_service.upsert(
+            data=obj_in.to_dict(), auto_commit=True, match_fields=["email"]
+        )
+        console.print(f"User upserted: {user.email}")
 
 
 @user_management_group.command(

--- a/bin/build-specific-app-version.sh
+++ b/bin/build-specific-app-version.sh
@@ -159,6 +159,11 @@ if [ -z "$BUILD_CURRENT_VERSION" ]; then
   # Patch old versions of the app so that it gets the version file using relative path in Elm
   # Otherwise serving the app from /versions will not display the good version number
   # Also patch the local storage key to avoid messing things up between versions
+  rm $PUBLIC_GIT_CLONE_DIR"/pyproject.toml"
+
+  if [ "$COMMIT_OR_TAG" = "v6.0.0" ]; then
+    uv run $ROOT_DIR/bin/patch_files_for_versions_compat.py double-slash $INDEX_JS_FILE $ROOT_DIR/packages/python/ecobalyse/ecobalyse/0002-patch-index-js-client-path-backend.patch $PUBLIC_GIT_CLONE_DIR
+  fi
   uv run $ROOT_DIR/bin/patch_files_for_versions_compat.py elm-version $ELM_VERSION_FILE
   uv run $ROOT_DIR/bin/patch_files_for_versions_compat.py local-storage-key $INDEX_JS_FILE $COMMIT_OR_TAG
   uv run $ROOT_DIR/bin/patch_files_for_versions_compat.py version-selector $ROOT_DIR/packages/python/ecobalyse/ecobalyse/0001-feat-patch-homepage-link-and-inject-and-inject-versi.patch $PUBLIC_GIT_CLONE_DIR

--- a/bin/patch_files_for_versions_compat.py
+++ b/bin/patch_files_for_versions_compat.py
@@ -11,6 +11,7 @@ from ecobalyse import logging_config as logging_config
 from ecobalyse.patch_files import (
     add_entry_to_version_file,
     patch_cross_origin_index_html_file,
+    patch_double_slash,
     patch_elm_version_file,
     patch_index_js_file,
     patch_version_selector,
@@ -86,6 +87,50 @@ def local_storage_key(
     Patch main index.js file to add the version to the local storage key
     """
     patch_index_js_file(index_js_file, suffix)
+
+
+@app.command()
+def double_slash(
+    index_js_file: Annotated[
+        pathlib.Path,
+        typer.Argument(
+            help="The full path to the index.js file.",
+            exists=True,
+            file_okay=True,
+            dir_okay=False,
+            writable=True,
+            readable=True,
+            resolve_path=True,
+        ),
+    ],
+    patch_file: Annotated[
+        pathlib.Path,
+        typer.Argument(
+            help="The full path of the patch to apply.",
+            exists=True,
+            file_okay=True,
+            dir_okay=False,
+            writable=True,
+            readable=True,
+            resolve_path=True,
+        ),
+    ],
+    git_dir: Annotated[
+        pathlib.Path,
+        typer.Argument(
+            help="The full path of the git repo where to apply the patch.",
+            exists=True,
+            file_okay=False,
+            dir_okay=True,
+            readable=True,
+            resolve_path=True,
+        ),
+    ],
+):
+    """
+    Patch main index.js file to remove trailing /
+    """
+    patch_double_slash(index_js_file, patch_file, git_dir)
 
 
 @app.command()

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ function loadScript(scriptUrl) {
 const storeKey = "store";
 
 // Remove trailing slash from root because it's used by the Elm API to resolve backend api urls
-const clientUrl = location.origin + (location.pathname == "/" ? "" : location.pathname);
+const clientUrl = (location.origin + location.pathname).replace(/\/+$/g, "");
 
 const app = Elm.Main.init({
   flags: {

--- a/packages/python/ecobalyse/ecobalyse/0002-patch-index-js-client-path-backend.patch
+++ b/packages/python/ecobalyse/ecobalyse/0002-patch-index-js-client-path-backend.patch
@@ -1,0 +1,13 @@
+diff --git i/index.js w/index.js
+index 19a6031e..b6a247bb 100644
+--- i/index.js
++++ w/index.js
+@@ -35,7 +35,7 @@ function loadScript(scriptUrl) {
+ const storeKey = "store";
+
+ // Remove trailing slash from root because it's used by the Elm API to resolve backend api urls
+-const clientUrl = location.origin + (location.pathname == "/" ? "" : location.pathname);
++const clientUrl = (location.origin + location.pathname).replace(/\/+$/g, "");
+
+ const app = Elm.Main.init({
+   flags: {

--- a/packages/python/ecobalyse/ecobalyse/patch_files.py
+++ b/packages/python/ecobalyse/ecobalyse/patch_files.py
@@ -64,6 +64,24 @@ def patch_index_js_file(index_js_file: pathlib.Path, version: str):
     write_patched_data(nb_patched, data, index_js_file)
 
 
+def patch_double_slash(
+    index_js_file: pathlib.Path, patch_file: pathlib.Path, git_dir: pathlib.Path
+):
+    with (
+        open(index_js_file, "r") as index_file,
+    ):
+        data = index_file.read()
+        if data.count("replace") > 0:
+            logger.info(
+                f"Patch content already present in `{index_js_file}`, skipping."
+            )
+        else:
+            logger.info(
+                f"Applying patch file `{patch_file}` to `{git_dir}` using `git apply`."
+            )
+            subprocess.run(["git", "apply", patch_file], check=True, cwd=git_dir)
+
+
 def patch_version_json(json_content: dict, key: str, value: str):
     (data, nb_patched) = (json_content, 0)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ requires = ["hatchling", "setuptools"]
 allow-direct-references = true
 
 [tool.hatch.build]
-dev-mode-dirs = ["packages/python/ecobalyse", "backend/src", "."]
+dev-mode-dirs = ["./packages/python/ecobalyse", "./backend/src", "."]
 ignore-vcs = true
 sources = ["src"]
 

--- a/servers.conf.erb
+++ b/servers.conf.erb
@@ -22,6 +22,15 @@ server {
     proxy_set_header X-Real-IP $remote_addr ;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for ;
   }
+  #
+  # Reroute versions to backend
+  location ~ ^/versions/[^/]+/backend/(.*)$ {
+    rewrite ^/versions/[^/]+/backend/(.*)$ /$1 break;
+    proxy_pass http://localhost:8002;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  }
 
   # Needed for the OpenAPI doc to work properly
   location /schema {


### PR DESCRIPTION
## :wrench: Problem

- When browsing the `v6.0.0` version in the selector, a `/` is added to the `clientUrl` causing http errors because of `//` in urls
- Versions under the `/versions/v6.0.0/` url for example are doing HTTP calls to `/versions/v6.0.0/backend` instead of `/backend`

## :cake: Solution

- Use a regex to remove all trailing `/` in clientUrl
- Patch the v6.0.0
- Use a nginx rewrite rule for backend calls


## :rotating_light:  Points to watch/comments

I was unable to find how to manage the `.proxyrc.json` of Parcel to handle URLs rewriting in a clean way, so I’ve hardcoded the version number for now. Happy to receive some help here.

The best solution for me would be to use nginx locally like in production to avoid those kind of problems and possible errors.

The `v6.0.0` release have been patched and deployed in production.

## :desert_island: How to test

In the review app, browse to the `v6.0.0` version in the selector and try to login/register/see detailed impacts: it should work as expected.