### PR TITLE
fix: add uv to scalingo when updating version

### DIFF
--- a/bin/update-version.sh
+++ b/bin/update-version.sh
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
 
 
-if [[ ! -z "${SOURCE_VERSION}" ]]; then
-  export PATH=~/.local/bin:$PATH
-  uv run python --help
-fi
 
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 ROOT_DIR=$( dirname $SCRIPT_DIR )
@@ -12,9 +8,11 @@ ROOT_DIR=$( dirname $SCRIPT_DIR )
 # If the SOURCE_VERSION is provided (usually by scalingo), search for a corresponding TAG
 # Using the github API or use the provided one in the tag ENV variable
 if [[ ! -z "${SOURCE_VERSION}" ]]; then
+  # Add uv to the path on scalingo
+  export PATH=~/.local/bin:$PATH
+
   HASH=$SOURCE_VERSION
 
-  uv run python $SCRIPT_DIR/get_tag_for_commit.py $HASH
 
   if [[ ! -z "${TAG}" ]]; then
     TAG_NAME=$TAG


### PR DESCRIPTION
## :wrench: Problem

For a reason I don’t get, the PATH doesn’t contain `uv` on scalingo when calling a shell script from NPM.

## :cake: Solution

Export it manually.

## :desert_island: How to test

I’ve tested that the PATH export works in previous commits.
Next version should contain the tag in `/version.json`