### PR TITLE
fix: JSON parsing in versions

### DIFF
--- a/server.js
+++ b/server.js
@@ -294,7 +294,8 @@ const checkVersionAndPath = (req, res, next) => {
   const version = availableVersions.find((version) => version.dir === versionNumber);
 
   if (!version) {
-    res.status(404).send("Version not found");
+    // If no version is found, don’t display a blank page but redirect to the home
+    res.redirect("/");
   }
   const staticDir = path.join(__dirname, "versions", versionNumber);
   req.staticDir = staticDir;
@@ -353,7 +354,11 @@ version.get("/:versionNumber/processes/processes.json", checkVersionAndPath, asy
     (version) => version.dir === versionNumber,
   );
 
-  return res.status(200).send(await getProcesses(req.headers, processesImpacts, processes));
+  // Note: JSON parsing is done in Elm land
+  return res
+    .status(200)
+    .contentType("text/plain")
+    .send(JSON.stringify(await getProcesses(req.headers, processesImpacts, processes)));
 });
 
 api.use(cors()); // Enable CORS for all API requests


### PR DESCRIPTION
## :wrench: Problem

Serving processes for versions fails with a JSON decoding error because we are returning real JSON for processes instead of a string containing the JSON.

Commit here: https://github.com/MTES-MCT/ecobalyse/commit/9c3806a3374c6ea7c9dc577d4fe14c4274a6af2f#diff-a4c65ede64197e1a112899a68bf994485b889c4b143198bac4af53425b38406fR248-R253

![250702_23-30-46](https://github.com/user-attachments/assets/757900b8-28ac-4903-9316-0337b594fe88)


## :cake: Solution

Always return a string for processes of old versions.

Another solution would be to just remove this version mess 🙄

## :desert_island: How to test

Login to the unreleased version, display detailed impacts, switch to v6.1.1 in the selector and go back to the unreleased, you should see no error.
