### PR TITLE
feat(auth,ui): improve error on expired magic link

### DIFF
--- a/src/Views/Page.elm
+++ b/src/Views/Page.elm
@@ -497,7 +497,7 @@ notificationView { session, toMsg } notification =
                     backendError |> Alert.backendError session (Just closeNotification)
             in
             case backendError of
-                BackendError.BadStatus { detail, statusCode } ->
+                BackendError.BadStatus { detail, statusCode, title } ->
                     if statusCode == 409 && String.contains "user already exists" detail then
                         Alert.simple
                             { attributes = []
@@ -505,6 +505,19 @@ notificationView { session, toMsg } notification =
                             , content = [ text "Un compte associé à cette adresse email existe déjà." ]
                             , level = Alert.Warning
                             , title = Just "Compte utilisateur existant"
+                            }
+                        -- Note: despite the message, there's no "password" involved, just an expired magic link
+
+                    else if statusCode == 403 && (title |> Maybe.map (String.contains "password invalid") |> Maybe.withDefault False) then
+                        Alert.simple
+                            { attributes = []
+                            , close = Just closeNotification
+                            , content =
+                                [ text """Ce lien d'authentification à usage unique a déjà été utilisé.
+                                          Vous pouvez en redemander un nouveau via le formulaire de connexion ci-dessous."""
+                                ]
+                            , level = Alert.Warning
+                            , title = Just "Lien d'identification expiré"
                             }
 
                     else


### PR DESCRIPTION
## :wrench: Problem

When reusing an expired magic link to log in, the generic backend error message is confusing:

![image](https://github.com/user-attachments/assets/2fb2ea25-74f0-42a3-88ea-26592d39a12c)

## :cake: Solution

Improve the error message:

![image](https://github.com/user-attachments/assets/a2dcc91c-6db1-41e8-b1f0-a0d53bc87a04)

## :desert_island: How to test

Try to reuse a same magic link twice.