### PR TITLE
fix: update CSP for posthog requirements

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -1,5 +1,7 @@
 function createCSPDirectives(env) {
   const { MATOMO_HOST = "", POSTHOG_HOST = "" } = env;
+  const FULL_MATOMO_HOST = `https://${MATOMO_HOST}`;
+  const POSTHOG_ASSETS_HOST = POSTHOG_HOST ? "https://eu-assets.i.posthog.com" : "";
 
   const onlyValid = (list) => list.filter((x) => x && !x.endsWith("://"));
 
@@ -9,7 +11,8 @@ function createCSPDirectives(env) {
       "https://api.github.com",
       "https://raw.githubusercontent.com",
       "https://sentry.incubateur.net",
-      "https://stats.beta.gouv.fr",
+      FULL_MATOMO_HOST,
+      POSTHOG_ASSETS_HOST,
     ],
     "img-src": [
       "'self'",
@@ -24,15 +27,23 @@ function createCSPDirectives(env) {
       "'self'",
       "https://api.github.com",
       "https://raw.githubusercontent.com",
+      FULL_MATOMO_HOST,
       POSTHOG_HOST,
+      POSTHOG_ASSETS_HOST,
     ]),
-    "frame-src": onlyValid(["'self'", `https://${MATOMO_HOST}`]),
+    "frame-src": onlyValid(["'self'", FULL_MATOMO_HOST]),
     // FIXME: We should be able to remove 'unsafe-inline' as soon as the Matomo
     // server sends the appropriate `Access-Control-Allow-Origin` header
     // or that we eventually switch to using Posthog only
     // @see https://matomo.org/faq/how-to/faq_18694/
-    "script-src": onlyValid(["'self'", "'unsafe-inline'", `https://${MATOMO_HOST}`, POSTHOG_HOST]),
-    "worker-src": onlyValid(["'self'", POSTHOG_HOST]),
+    "script-src": onlyValid([
+      "'self'",
+      "'unsafe-inline'",
+      FULL_MATOMO_HOST,
+      POSTHOG_HOST,
+      POSTHOG_ASSETS_HOST,
+    ]),
+    "worker-src": onlyValid(["'self'", POSTHOG_HOST, POSTHOG_ASSETS_HOST]),
   };
 }
 

--- a/tests/lib/http.spec.js
+++ b/tests/lib/http.spec.js
@@ -12,7 +12,9 @@ describe("lib.http", () => {
         "'self'",
         "https://api.github.com",
         "https://raw.githubusercontent.com",
+        "https://matomo.example.com",
         "https://posthog.example.com",
+        "https://eu-assets.i.posthog.com",
       ]);
       expect(directives["frame-src"]).toEqual(["'self'", "https://matomo.example.com"]);
       expect(directives["script-src"]).toEqual([
@@ -20,8 +22,13 @@ describe("lib.http", () => {
         "'unsafe-inline'",
         "https://matomo.example.com",
         "https://posthog.example.com",
+        "https://eu-assets.i.posthog.com",
       ]);
-      expect(directives["worker-src"]).toEqual(["'self'", "https://posthog.example.com"]);
+      expect(directives["worker-src"]).toEqual([
+        "'self'",
+        "https://posthog.example.com",
+        "https://eu-assets.i.posthog.com",
+      ]);
     });
 
     test("should create a CSP directives object with no tracker hosts", () => {


### PR DESCRIPTION
Posthog connects to the `eu-assets.i.posthog.com` external host so we must add to our Content Security Policy configuration in order to collect events.