### PR TITLE
chore: add mention in the API about the persistence of ids

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -81,7 +81,7 @@ paths:
         - Textile
       summary: Calcul des impacts environnementaux d'un produit textile
       requestBody:
-        description: Requête modélisant les paramètres du produit à évaluer
+        description: Requête modélisant les paramètres du produit à évaluer. L'id des matières est invariable dans le temps.
         required: true
         content:
           application/json:
@@ -113,7 +113,7 @@ paths:
       parameters:
         - $ref: "#/components/parameters/impactUrlParam"
       requestBody:
-        description: Requête modélisant les paramètres du produit à évaluer
+        description: Requête modélisant les paramètres du produit à évaluer. L'id des matières est invariable dans le temps.
         required: true
         content:
           application/json:
@@ -143,7 +143,7 @@ paths:
         - Textile
       summary: Calcul des impacts environnementaux d'un produit textile
       requestBody:
-        description: Requête modélisant les paramètres du produit à évaluer
+        description: Requête modélisant les paramètres du produit à évaluer. L'id des matières est invariable dans le temps.
         required: true
         content:
           application/json:
@@ -233,7 +233,7 @@ paths:
         - Alimentaire
       summary: Calcul des impacts environnementaux d'une recette alimentaire
       requestBody:
-        description: Requête modélisant les éléments de la recette à évaluer
+        description: Requête modélisant les éléments de la recette à évaluer. L'id des ingrédients est invariable dans le temps.
         required: true
         content:
           application/json:


### PR DESCRIPTION
## :wrench: Problem

We had a discussion about the peristent of ids (ingredients and materials)

## :cake: Solution

Just menion in the API that the ids are persistent

## :rotating_light:  Points to watch/comments

More detailed informations have been put in our internal doc about when an id can be changed.

## :desert_island: How to test

Check the mention in the API.