### PR TITLE
feat: allow configuring version polling interval

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -20,3 +20,4 @@ SECRET_KEY=needed-for-jwt-decoding
 SCALINGO_POSTGRESQL_URL=please-change-this
 SENTRY_DSN=please-change-this
 TRANSCRYPT_KEY=use-key-in-vaultwarden
+VERSION_POLL_SECONDS=300

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Les variables d'environnement suivantes doivent être définies :
 - `SENTRY_DSN`: le DSN [Sentry](https://sentry.io) à utiliser pour les rapports d'erreur.
 - `TRANSCRYPT_KEY`: la clé utilisée et autogénérée par [transcrypt](https://github.com/elasticdog/transcrypt/blob/main/INSTALL.md) et disponible dans [https://vaultwarden.incubateur.net](https://vaultwarden.incubateur.net/).
 - `ENCRYPTION_KEY` : la clé utilisée par les scripts `npm run encrypt` et  `npm run decrypt` pour chiffrer/déchiffrer les fichiers d’impacts détaillés inclus dans chaque archive de release. Pour générer une nouvelle clé, vous pouvez utiliser le script `bin/generate-crypto-key`.
+- `VERSION_POLL_SECONDS`: The number of seconds between two http polls to retrieve the current app version (`/version.json`, défault: `300`)
 
 En développement, copiez le fichier `.env.sample`, renommez-le `.env`, et mettez à jour les valeurs qu'il contient ; le serveur de développement node chargera les variables en conséquences.
 

--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ const app = Elm.Main.init({
       host: process.env.MATOMO_HOST || "",
       siteId: process.env.MATOMO_SITE_ID || "",
     },
-    versionPollSeconds: process.env.VERSION_POLL_SECONDS || 300,
+    versionPollSeconds: parseInt(process.env.VERSION_POLL_SECONDS) || 300,
   },
 });
 

--- a/index.js
+++ b/index.js
@@ -90,6 +90,7 @@ const app = Elm.Main.init({
       host: process.env.MATOMO_HOST || "",
       siteId: process.env.MATOMO_SITE_ID || "",
     },
+    versionPollSeconds: process.env.VERSION_POLL_SECONDS || 300,
   },
 });
 

--- a/src/Data/Session.elm
+++ b/src/Data/Session.elm
@@ -69,6 +69,7 @@ type alias Session =
     , queries : Queries
     , releases : WebData (List Github.Release)
     , store : Store
+    , versionPollSeconds : Int
     }
 
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -43,6 +43,7 @@ type alias Flags =
     , enabledSections : Session.EnabledSections
     , matomo : { host : String, siteId : String }
     , rawStore : String
+    , versionPollSeconds : Int
     }
 
 
@@ -160,6 +161,7 @@ setupSession navKey flags db =
             }
         , releases = RemoteData.NotAsked
         , store = Session.defaultStore
+        , versionPollSeconds = flags.versionPollSeconds
         }
 
 
@@ -481,7 +483,12 @@ subscriptions : Model -> Sub Msg
 subscriptions { state } =
     Sub.batch
         [ Ports.storeChanged StoreChanged
-        , Request.Version.pollVersion VersionPoll
+        , case state of
+            Loaded { versionPollSeconds } _ ->
+                Request.Version.pollVersion versionPollSeconds VersionPoll
+
+            _ ->
+                Sub.none
         , case state of
             Loaded _ (ComponentAdminPage subModel) ->
                 ComponentAdmin.subscriptions subModel

--- a/src/Request/Version.elm
+++ b/src/Request/Version.elm
@@ -81,9 +81,9 @@ loadVersion event =
     Http.get "version.json" event decodeData
 
 
-pollVersion : msg -> Sub msg
-pollVersion event =
-    Time.every (60 * 1000) (always event)
+pollVersion : Int -> msg -> Sub msg
+pollVersion versionPollSeconds =
+    always >> Time.every (toFloat versionPollSeconds * 1000)
 
 
 toMaybe : Version -> Maybe VersionData


### PR DESCRIPTION
Allow specifying `VERSION_POLL_SECONDS` to tweak the current version polling interval