### PR TITLE
chore: improve token handling feedback

### DIFF
--- a/backend/src/app/domain/accounts/services.py
+++ b/backend/src/app/domain/accounts/services.py
@@ -85,7 +85,7 @@ class UserService(SQLAlchemyAsyncRepositoryService[m.User]):
         self, db_obj: m.User | None, password: str, hashed_password: str
     ) -> None:
         if hashed_password is None:
-            msg = "User not found or password invalid"
+            msg = "Token not found or already used"
             raise PermissionDeniedException(detail=msg)
         if not await crypt.verify_password(password, hashed_password):
             msg = "User not found or password invalid"

--- a/backend/src/app/domain/accounts/tasks.py
+++ b/backend/src/app/domain/accounts/tasks.py
@@ -29,12 +29,12 @@ async def send_magic_link_email_task(
         subject=T("Lien de connexion à Ecobalyse"),
         html=T(
             """<p>Vous avez reçu cet e-mail car vous avez demandé un lien de connexion à Ecobalyse.</p>
-            <p>Veuillez cliquer sur le lien suivant pour vous connecter :</p>
+            <p>Veuillez cliquer sur le lien suivant pour vous connecter (attention ce lien n’est valide qu’une fois) :</p>
             <p><a href="{{ url }}/{{ email }}/{{ token }}">Se connecter à Ecobalyse</a></p>
             <p>L'équipe Ecobalyse</p>"""
         ),
         text=T("""Vous avez reçu cet e-mail car vous avez demandé un lien de connexion à Ecobalyse.
-            Veuillez cliquer sur le lien suivant pour vous connecter : {{ url }}/{{ email }}/{{ token }}
+            Veuillez cliquer sur le lien suivant pour vous connecter (attention ce lien n’est valide qu’une fois) : {{ url }}/{{ email }}/{{ token }}
             L'équipe Ecobalyse"""),
         mail_from=("Ecobalyse", settings.email.FROM),
     )

--- a/src/Views/Page.elm
+++ b/src/Views/Page.elm
@@ -509,7 +509,7 @@ notificationView { session, toMsg } notification =
                             }
                         -- Note: despite the message, there's no "password" involved, just an expired magic link
 
-                    else if statusCode == 403 && (title |> Maybe.map (String.contains "password invalid") |> Maybe.withDefault False) then
+                    else if statusCode == 403 && (title |> Maybe.map (String.contains "already used") |> Maybe.withDefault False) then
                         Alert.simple
                             { attributes = []
                             , close = Just closeNotification

--- a/tests/backend/integration/test_access.py
+++ b/tests/backend/integration/test_access.py
@@ -361,6 +361,14 @@ async def test_magic_link_expiration(
         assert authenticated_user.magic_link_sent_at is None
         assert authenticated_user.magic_link_hashed_token is None
 
+        # Magic link already used
+        with pytest.raises(
+            PermissionDeniedException, match="Token not found or already used"
+        ):
+            authenticated_user = await users_service.authenticate_magic_token(
+                raw_users[2]["email"], "Test_Password2!_token"
+            )
+
         # Magic link is outdated 24H duration by default
         with pytest.raises(PermissionDeniedException, match="Magic link token expired"):
             authenticated_user = await users_service.authenticate_magic_token(
@@ -369,7 +377,7 @@ async def test_magic_link_expiration(
 
         # Magic link was not generated
         with pytest.raises(
-            PermissionDeniedException, match="User not found or password invalid"
+            PermissionDeniedException, match="Token not found or already used"
         ):
             authenticated_user = await users_service.authenticate_magic_token(
                 raw_users[4]["email"], ""


### PR DESCRIPTION
## :wrench: Problem

fixes #1268 

It looks like people are clicking on the login link twice and get a 403 error as the token can only be used once.

## :cake: Solution

Improve already used token error message, give visual feedback to the users when they are clicking on the send email links (to avoid clicking twice if the backend doesn’t respond fast enough), improve login email content by specifying that the link can only be used once.

## :desert_island: How to test

Test the login/signup process.

Clicking on « Recevoir un email de connexion » should disable the button and briefly display « Email de connexion en cours d’envoi… » before redirecting.
Clicking on « Valider mon inscription » should disable the button and briefly display « Envoi de la demande d’inscription en cours… » before redirecting.

Click on the link received by email, see that everything works. Logout and the click again on the login link in the email, the backend error received should be `Token not found or already used`.