### PR TITLE
feat: list and parse scalingo logs

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -18,6 +18,7 @@ POSTHOG_HOST=https://eu.i.posthog.com
 POSTHOG_KEY=phc_xxxxxx
 SECRET_KEY=needed-for-jwt-decoding
 SCALINGO_POSTGRESQL_URL=please-change-this
+SCALINGO_API_TOKEN=token-for-scalingo-scripts
 SENTRY_DSN=please-change-this
 TRANSCRYPT_KEY=use-key-in-vaultwarden
 VERSION_POLL_SECONDS=300

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ db.sqlite3
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+
+# Scalingo logs
+/archives_logs/

--- a/bin/scalingo_api.py
+++ b/bin/scalingo_api.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+import logging
+import os
+from enum import Enum
+
+import typer
+from ecobalyse import logging_config as logging_config
+from ecobalyse import scalingo
+from typing_extensions import Annotated
+
+
+class LoggingLevels(str, Enum):
+    CRITICAL = "CRITICAL"
+    DEBUG = "DEBUG"
+    ERROR = "ERROR"
+    INFO = "INFO"
+    NOTSET = "NOTSET"
+    WARNING = "WARNING"
+
+
+app = typer.Typer(help="Interact with the scalingo HTTP API")
+
+logger = logging.getLogger(__name__)
+
+
+@app.callback()
+def main(
+    loglevel: Annotated[
+        LoggingLevels, typer.Option("--loglevel", "-l")
+    ] = LoggingLevels.INFO,
+):
+    logger.setLevel(loglevel.value)
+
+
+@app.command()
+def log_archives():
+    """
+    Get the list of archived logs
+    """
+
+    api_token = os.getenv("SCALINGO_API_TOKEN")
+    bearer_token = scalingo.get_bearer_token(api_token=api_token)
+    logs = scalingo.list_logs_archives(bearer_token=bearer_token)
+    print(logs)
+
+
+if __name__ == "__main__":
+    app()

--- a/bin/scalingo_api.py
+++ b/bin/scalingo_api.py
@@ -1,15 +1,21 @@
 #!/usr/bin/env python
+import fileinput
+import glob
 import logging
+import multiprocessing
 import os
+import re
 from datetime import UTC, datetime, timedelta
 from enum import Enum
+from multiprocessing import Pool
 from pathlib import Path
 from typing import Optional
 
-import requests
 import typer
+from dateutil import parser
 from ecobalyse import logging_config as logging_config
 from ecobalyse import scalingo
+from rich import print
 from typing_extensions import Annotated
 
 
@@ -25,6 +31,60 @@ class LoggingLevels(str, Enum):
 app = typer.Typer(help="Interact with the scalingo HTTP API")
 
 logger = logging.getLogger(__name__)
+
+
+def parse_log_line(log_line):
+    # Split the log line into parts
+    parts = log_line.split(" ")
+
+    # Extract timestamp and timezone
+    timestamp = parser.parse(" ".join(parts[:3]))
+
+    # Initialize the dictionary with the timestamp
+    log_dict = {"timestamp": timestamp}
+
+    # Use regex to find key-value pairs
+    key_value_pairs = re.findall(r'(\w+)=("[^"]*"|\S+)', log_line)
+
+    # Populate the dictionary with key-value pairs
+    for key, value in key_value_pairs:
+        value = value.strip('"')
+
+        if key == "duration":
+            value = float(value.strip("s"))
+        elif key == "status" or key == "bytes":
+            value = int(value)
+
+        log_dict[key] = value
+
+    return log_dict
+
+
+def get_log_stats(filename):
+    with fileinput.input(
+        files=[filename],
+        openhook=fileinput.hook_compressed,
+        encoding="utf-8",
+    ) as f:
+        slowest_lines = []
+        max_lines = 20
+        for line in f:
+            if "[router]" in line:
+                parsed_line = parse_log_line(line)
+                if len(slowest_lines) < max_lines:
+                    slowest_lines.append(parsed_line)
+                    slowest_lines = sorted(
+                        slowest_lines, key=lambda value: value["duration"], reverse=True
+                    )
+                    continue
+
+                if parsed_line["duration"] > slowest_lines[-1]["duration"]:
+                    slowest_lines.append(parsed_line)
+                    slowest_lines = sorted(
+                        slowest_lines, key=lambda value: value["duration"], reverse=True
+                    )[:10]
+
+        return slowest_lines
 
 
 @app.callback()
@@ -54,26 +114,30 @@ def log_archives(
     api_token = os.getenv("SCALINGO_API_TOKEN")
     bearer_token = scalingo.get_bearer_token(api_token=api_token)
 
-    archives = scalingo.list_logs_archives_for_range(
-        start_date=now, end_date=now - timedelta(days=14), bearer_token=bearer_token
-    )
+    if False:
+        (archives, downloaded_files) = scalingo.list_logs_archives_for_range(
+            start_date=now,
+            end_date=now - timedelta(days=14),
+            bearer_token=bearer_token,
+            download_dir=download_dir,
+        )
 
-    logger.info(f"-> Got {len(archives)} archives")
+    cpu_count = multiprocessing.cpu_count() - 1 or 1
 
-    for archive in archives:
-        url = archive["url"]
+    slowest_lines = []
+    with Pool(cpu_count) as pool:
+        logs_slowest_lines = pool.starmap(
+            get_log_stats,
+            [(filename,) for filename in glob.glob(f"{download_dir}/*.log-*.gz")],
+        )
+        slowest_lines = sorted(
+            # Flatmap starmap results
+            [y for ys in logs_slowest_lines for y in ys],
+            key=lambda value: value["duration"],
+            reverse=True,
+        )[:20]
 
-        filename = url.rsplit("/", 1)[1].rsplit("?", 1)[0]
-        dest_file_path = os.path.join(download_dir, filename)
-
-        # Download only if file is not present on disk
-        if not Path(dest_file_path).is_file():
-            response = requests.get(url, allow_redirects=True)
-            open(dest_file_path, "wb").write(response.content)
-        else:
-            logger.info(
-                f"File `{filename}` already present in `{download_dir}`, skipping download"
-            )
+    print(slowest_lines)
 
 
 if __name__ == "__main__":

--- a/bin/scalingo_api.py
+++ b/bin/scalingo_api.py
@@ -123,6 +123,7 @@ def log_archives(
     download: Annotated[
         bool, typer.Option(help="Download the archives from scalingo")
     ] = True,
+    days: Annotated[int, typer.Option(help="Number of days to download")] = 14,
 ):
     """
     Get the list of archived logs
@@ -138,7 +139,7 @@ def log_archives(
     if download:
         (archives, downloaded_files) = scalingo.list_logs_archives_for_range(
             start_date=now,
-            end_date=now - timedelta(days=14),
+            end_date=now - timedelta(days=days),
             bearer_token=bearer_token,
             download_dir=download_dir,
         )

--- a/bin/scalingo_api.py
+++ b/bin/scalingo_api.py
@@ -1,8 +1,12 @@
 #!/usr/bin/env python
 import logging
 import os
+from datetime import UTC, datetime, timedelta
 from enum import Enum
+from pathlib import Path
+from typing import Optional
 
+import requests
 import typer
 from ecobalyse import logging_config as logging_config
 from ecobalyse import scalingo
@@ -18,7 +22,7 @@ class LoggingLevels(str, Enum):
     WARNING = "WARNING"
 
 
-app = typer.Typer(help="Interact with the scalingo HTTP API")
+app = typer.Typer(help="Interact with the scalingo HTTP API")
 
 logger = logging.getLogger(__name__)
 
@@ -33,15 +37,43 @@ def main(
 
 
 @app.command()
-def log_archives():
+def log_archives(
+    download_dir: Annotated[
+        Optional[Path],
+        typer.Argument(help="The output CSV file."),
+    ] = Path("./archives_logs"),
+):
     """
     Get the list of archived logs
     """
 
+    # Create dir if it doesn’t exist
+    os.makedirs(download_dir, exist_ok=True)
+
+    now = datetime.now(UTC)
     api_token = os.getenv("SCALINGO_API_TOKEN")
     bearer_token = scalingo.get_bearer_token(api_token=api_token)
-    logs = scalingo.list_logs_archives(bearer_token=bearer_token)
-    print(logs)
+
+    archives = scalingo.list_logs_archives_for_range(
+        start_date=now, end_date=now - timedelta(days=14), bearer_token=bearer_token
+    )
+
+    logger.info(f"-> Got {len(archives)} archives")
+
+    for archive in archives:
+        url = archive["url"]
+
+        filename = url.rsplit("/", 1)[1].rsplit("?", 1)[0]
+        dest_file_path = os.path.join(download_dir, filename)
+
+        # Download only if file is not present on disk
+        if not Path(dest_file_path).is_file():
+            response = requests.get(url, allow_redirects=True)
+            open(dest_file_path, "wb").write(response.content)
+        else:
+            logger.info(
+                f"File `{filename}` already present in `{download_dir}`, skipping download"
+            )
 
 
 if __name__ == "__main__":

--- a/packages/python/ecobalyse/ecobalyse/scalingo.py
+++ b/packages/python/ecobalyse/ecobalyse/scalingo.py
@@ -1,6 +1,8 @@
 import logging
+from datetime import datetime
 
 import requests
+from dateutil import parser
 from requests.auth import HTTPBasicAuth
 
 # Tell ruff to not delete the unused import by rexporting it using as
@@ -20,10 +22,17 @@ def get_bearer_token(api_token: str) -> str:
     return response.json()["token"]
 
 
-def list_logs_archives(bearer_token: str, application: str = "ecobalyse") -> dict:
-    logging.info("-> Listing log archives")
+def parse_archive_datetime(date_string: str) -> datetime:
+    date_string_clean: str = date_string.replace(" UTC", "")
+    return parser.parse(date_string_clean)
 
-    endpoint = f"https://api.osc-fr1.scalingo.com/v1/apps/{application}/logs_archives"
+
+def list_logs_archives(
+    bearer_token: str, cursor: str = "1", application: str = "ecobalyse"
+) -> dict:
+    logging.info(f"-> Listing log archives for cursor {cursor}")
+
+    endpoint = f"https://api.osc-fr1.scalingo.com/v1/apps/{application}/logs_archives?cursor={cursor}"
     headers = {
         "Accept": "application/json",
         "Authorization": f"Bearer {bearer_token}",
@@ -31,3 +40,52 @@ def list_logs_archives(bearer_token: str, application: str = "ecobalyse") -> dic
     }
     response = requests.get(endpoint, headers=headers)
     return response.json()
+
+
+def list_logs_archives_for_range(
+    start_date: datetime,
+    end_date: datetime,
+    bearer_token: str,
+    application: str = "ecobalyse",
+) -> list[dict]:
+    logging.info(f"-> Listing log archives from {start_date} to {end_date}")
+
+    cursor = 1
+    archives_logs = list_logs_archives(bearer_token=bearer_token, cursor=cursor)
+    archives = archives_logs["archives"]
+
+    if len(archives) == 0:
+        logger.info("-> No more archives, returning")
+        return
+
+    first_archive = archives[0]
+    first_archive_from_date = parse_archive_datetime(first_archive["from"])
+
+    last_archive = archives[-1]
+    last_archive_to_date = parse_archive_datetime(last_archive["to"])
+
+    while first_archive_from_date > start_date and archives_logs["has_more"]:
+        cursor = archives_logs["next_cursor"]
+        archives_logs = list_logs_archives(bearer_token=bearer_token, cursor=cursor)
+        archives = archives_logs["archives"]
+
+        if len(archives) == 0:
+            logger.info("-> No more archives, returning")
+            return
+
+        first_archive = archives[0]
+        first_archive_from_date = parse_archive_datetime(first_archive["from"])
+
+    while last_archive_to_date > end_date and archives_logs["has_more"]:
+        cursor = archives_logs["next_cursor"]
+        archives_logs = list_logs_archives(bearer_token=bearer_token, cursor=cursor)
+        archives += archives_logs["archives"]
+
+        if len(archives) == 0:
+            logger.info("-> No more archives, returning")
+            return
+
+        last_archive = archives[-1]
+        last_archive_to_date = parse_archive_datetime(last_archive["to"])
+
+    return archives

--- a/packages/python/ecobalyse/ecobalyse/scalingo.py
+++ b/packages/python/ecobalyse/ecobalyse/scalingo.py
@@ -1,0 +1,33 @@
+import logging
+
+import requests
+from requests.auth import HTTPBasicAuth
+
+# Tell ruff to not delete the unused import by rexporting it using as
+# See https://docs.astral.sh/ruff/rules/unused-import/
+from ecobalyse import logging_config as logging_config
+
+logger = logging.getLogger(__name__)
+
+
+def get_bearer_token(api_token: str) -> str:
+    logging.info("-> Getting Bearer token")
+    basic = HTTPBasicAuth("", api_token)
+    endpoint = "https://auth.scalingo.com/v1/tokens/exchange"
+    headers = {"Content-Type": "application/json", "Accept": "application/json"}
+    response = requests.post(endpoint, auth=basic, headers=headers)
+
+    return response.json()["token"]
+
+
+def list_logs_archives(bearer_token: str, application: str = "ecobalyse") -> dict:
+    logging.info("-> Listing log archives")
+
+    endpoint = f"https://api.osc-fr1.scalingo.com/v1/apps/{application}/logs_archives"
+    headers = {
+        "Accept": "application/json",
+        "Authorization": f"Bearer {bearer_token}",
+        "Content-Type": "application/json",
+    }
+    response = requests.get(endpoint, headers=headers)
+    return response.json()


### PR DESCRIPTION
## :wrench: Problem

It’s hard to get information about logs on scalingo as they are archived in a non friendly interface.

## :cake: Solution

Create a script that can download the logs and try to parse some information out of it.


## :rotating_light:  Points to watch/comments

I’m using python mutliprocessing to speed up the log parsing as it takes quite some time without it.

## :desert_island: How to test

```python
uv run bin/scalingo_api.py log-archives
```

Should display the slowest log lines, and logs should have been downloaded in `./archives_logs` directory.