### PR TITLE
feat(bo): allow searching process scopes and categories.

### DIFF
--- a/src/Data/Process.elm
+++ b/src/Data/Process.elm
@@ -192,7 +192,13 @@ getMaterialTypes =
 
 asSearchableText : Process -> String
 asSearchableText process =
-    getDisplayName process ++ " " ++ getTechnicalName process ++ " " ++ process.comment
+    String.join " "
+        [ getDisplayName process
+        , getTechnicalName process
+        , process.categories |> List.map Category.toLabel |> String.join " "
+        , process.scopes |> List.map Scope.toString |> String.join " "
+        , process.comment
+        ]
 
 
 getTechnicalName : Process -> String


### PR DESCRIPTION
## :wrench: Problem

Scopes and categories are not searchable in the processes admin

## :cake: Solution

Make them searchable

## :desert_island: How to test

Check searching for "ingrédient", this should retrieve processes having the `ingredient` category. Same with scopes.