### PR TITLE
feat(ui): update textile CTA links to regulatory version, add banner

### DIFF
--- a/src/Page/Home.elm
+++ b/src/Page/Home.elm
@@ -57,17 +57,13 @@ update session msg model =
         NoOp ->
             App.createUpdate session model
 
-        ProcessLink link ->
+        ProcessLink (ExternalLink url) ->
             App.createUpdate session model
-                |> App.withCmds
-                    [ Nav.load <|
-                        case link of
-                            ExternalLink url ->
-                                url
+                |> App.withCmds [ Nav.load url ]
 
-                            RouteLink route ->
-                                Route.toString route
-                    ]
+        ProcessLink (RouteLink route) ->
+            App.createUpdate session model
+                |> App.withCmds [ Nav.load <| Route.toString route ]
 
 
 simulatorButton : ButtonParams -> Html Msg

--- a/src/Page/Home.elm
+++ b/src/Page/Home.elm
@@ -28,11 +28,16 @@ type Msg
     = NoOp
 
 
+type Link
+    = ExternalLink String
+    | RouteLink Route
+
+
 type alias ButtonParams =
     { label : String
     , subLabel : Maybe String
     , callToAction : Bool
-    , route : Route
+    , link : Link
     , testId : String
     }
 
@@ -48,12 +53,22 @@ update session _ model =
     App.createUpdate session model
 
 
+linkHref : Link -> Attribute msg
+linkHref link =
+    case link of
+        ExternalLink url ->
+            href url
+
+        RouteLink route ->
+            Route.href route
+
+
 simulatorButton : ButtonParams -> Html Msg
-simulatorButton { label, subLabel, callToAction, route, testId } =
+simulatorButton { label, subLabel, callToAction, link, testId } =
     a
         [ class "btn btn-lg d-flex flex-column align-items-center justify-content-center"
         , classList [ ( "btn-primary", callToAction ), ( "btn-outline-primary", not callToAction ) ]
-        , Route.href route
+        , linkHref link
         , attribute "data-testid" testId
         ]
         [ text label
@@ -83,7 +98,7 @@ viewHero { enabledSections } =
                     { label = "Calculer l’impact d’un vêtement"
                     , subLabel = Nothing
                     , callToAction = True
-                    , route = Route.TextileSimulatorHome
+                    , link = ExternalLink "/versions/v7.0.0/#/textile/simulator"
                     , testId = "textile-callout-button"
                     }
                 , if enabledSections.food then
@@ -91,7 +106,7 @@ viewHero { enabledSections } =
                         { label = "Calculer l’impact de l’alimentation"
                         , subLabel = Just "Méthodologie en concertation"
                         , callToAction = False
-                        , route = Route.FoodBuilderHome
+                        , link = RouteLink Route.FoodBuilderHome
                         , testId = "food-callout-button"
                         }
 
@@ -102,7 +117,7 @@ viewHero { enabledSections } =
                         { label = "Calculer l’impact d’un objet"
                         , subLabel = Just "Simulateur en construction"
                         , callToAction = False
-                        , route = Route.ObjectSimulatorHome Scope.Object
+                        , link = RouteLink <| Route.ObjectSimulatorHome Scope.Object
                         , testId = "object-callout-button"
                         }
 
@@ -113,7 +128,7 @@ viewHero { enabledSections } =
                         { label = "Calculer l’impact d’un véhicule"
                         , subLabel = Just "Simulateur en construction"
                         , callToAction = False
-                        , route = Route.ObjectSimulatorHome Scope.Veli
+                        , link = RouteLink <| Route.ObjectSimulatorHome Scope.Veli
                         , testId = "veli-callout-button"
                         }
 

--- a/src/Views/Page.elm
+++ b/src/Views/Page.elm
@@ -77,7 +77,12 @@ frame ({ activePage } as config) ( title, content ) =
                         [ text "Cette version est en cours de développement." ]
                     , span [ class "ms-1" ]
                         [ text "La version réglementaire est la v7.0.0."
-                        , a [ href "/versions/v7.0.0/", class "ms-1" ]
+                        , button
+                            [ type_ "button"
+                            , class "btn btn-link"
+                            , onClick <| config.toMsg <| App.LoadUrl "/versions/v7.0.0/#/textile/simulator"
+                            , class "ms-1"
+                            ]
                             [ text "Accéder à la version réglementaire" ]
                         ]
                     ]

--- a/src/Views/Page.elm
+++ b/src/Views/Page.elm
@@ -68,6 +68,23 @@ frame ({ activePage } as config) ( title, content ) =
         [ stagingAlert config
         , newVersionAlert config
         , pageHeader config
+        , if activePage == TextileSimulator then
+            div [ class "page-notice", attribute "role" "notice" ]
+                [ div [ class "container" ]
+                    [ span [ class "me-1" ]
+                        [ Icon.info ]
+                    , span [ class "fw-bold" ]
+                        [ text "Cette version est en cours de développement." ]
+                    , span [ class "ms-1" ]
+                        [ text "La version réglementaire est la v7.0.0."
+                        , a [ href "/versions/v7.0.0/", class "ms-1" ]
+                            [ text "Accéder à la version réglementaire" ]
+                        ]
+                    ]
+                ]
+
+          else
+            text ""
         , if config.mobileNavigationOpened then
             mobileNavigation config
 

--- a/src/Views/Page.elm
+++ b/src/Views/Page.elm
@@ -70,7 +70,7 @@ frame ({ activePage } as config) ( title, content ) =
         , pageHeader config
         , if activePage == TextileSimulator then
             div [ class "page-notice", attribute "role" "notice" ]
-                [ div [ class "container" ]
+                [ div [ class "container px-4" ]
                     [ span [ class "me-1" ]
                         [ Icon.info ]
                     , span [ class "fw-bold" ]
@@ -79,7 +79,7 @@ frame ({ activePage } as config) ( title, content ) =
                         [ text "La version réglementaire est la v7.0.0."
                         , button
                             [ type_ "button"
-                            , class "btn btn-link"
+                            , class "btn btn-link p-0 mb-1"
                             , onClick <| config.toMsg <| App.LoadUrl "/versions/v7.0.0/#/textile/simulator"
                             , class "ms-1"
                             ]

--- a/styles.scss
+++ b/styles.scss
@@ -1460,3 +1460,12 @@ q {
     }
   }
 }
+
+.page-notice {
+  position: relative;
+  background-color: #e8edff;
+  color: #0063cb;
+  padding: 1rem;
+  box-shadow: inset 0 3px 5px rgba(194, 209, 255, 0.8);
+  margin-top: -7px;
+}


### PR DESCRIPTION
refs #1368

This patch updates the CTA to link to the textile simulator in version 7.0.0, which is the official regulatory one. It doesn't update the link in the header navigation menu, but I can do that too if required. I've added a banner on the production textile page (today in 7.1.1, tomorrow most likely in 7.2) to indicate that the regulatory version is 7.0.0 with a link to it. Banner text is mine, but could probably be improved.

I feel it's kinda ok and not too confusing, though I'm all ears for improvements.