### PR TITLE
fix(api): expose server fqdn and version to urls in responses

### DIFF
--- a/server.js
+++ b/server.js
@@ -18,9 +18,8 @@ const { setupSentry } = require("./lib/sentry"); // MUST be required BEFORE expr
 const { createMatomoTracker } = require("./lib/matomo");
 const { createPosthogTracker } = require("./lib/posthog");
 const express = require("express");
-const os = require("os");
 
-const expressHost = os.hostname();
+const expressHost = "0.0.0.0";
 const expressPort = 8001;
 
 // Env vars
@@ -257,6 +256,7 @@ api.all(/(.*)/, bodyParser.json(), jsonErrorHandler, async (req, res) => {
   elmApp.ports.input.send({
     method: req.method,
     url: req.url,
+    host: req.get("host"),
     body: req.body,
     processes,
     jsResponseHandler: async ({ status, body }) => {

--- a/server.js
+++ b/server.js
@@ -18,8 +18,9 @@ const { setupSentry } = require("./lib/sentry"); // MUST be required BEFORE expr
 const { createMatomoTracker } = require("./lib/matomo");
 const { createPosthogTracker } = require("./lib/posthog");
 const express = require("express");
+const os = require("os");
 
-const expressHost = "0.0.0.0";
+const expressHost = os.hostname();
 const expressPort = 8001;
 
 // Env vars

--- a/server.js
+++ b/server.js
@@ -255,6 +255,7 @@ api.all(/(.*)/, bodyParser.json(), jsonErrorHandler, async (req, res) => {
 
   elmApp.ports.input.send({
     method: req.method,
+    protocol: req.protocol,
     url: req.url,
     host: req.get("host"),
     body: req.body,
@@ -321,6 +322,8 @@ version.all(
 
     elmApp.ports.input.send({
       method: req.method,
+      protocol: req.protocol,
+      host: req.get("host"),
       url: urlWithoutPrefix,
       body: req.body,
       processes: versionProcesses,

--- a/src/Data/Textile/Simulator.elm
+++ b/src/Data/Textile/Simulator.elm
@@ -9,6 +9,7 @@ module Data.Textile.Simulator exposing
     )
 
 import Array
+import Data.Common.EncodeUtils as EU
 import Data.Component as Component
 import Data.Country as Country
 import Data.Env as Env
@@ -52,18 +53,19 @@ type alias Simulator =
     }
 
 
-encode : Simulator -> Encode.Value
-encode v =
-    Encode.object
-        [ ( "complementsImpacts", Impact.encodeComplementsImpacts v.complementsImpacts )
-        , ( "daysOfWear", v.daysOfWear |> Duration.inDays |> round |> Encode.int )
-        , ( "durability", v.durability |> Unit.floatDurabilityFromHolistic |> Encode.float )
-        , ( "impacts", Impact.encode v.impacts )
-        , ( "impactsWithoutDurability", Impact.encode (getTotalImpactsWithoutDurability v) )
-        , ( "inputs", Inputs.encode v.inputs )
-        , ( "lifeCycle", LifeCycle.encode v.lifeCycle )
-        , ( "transport", Transport.encode v.transport )
-        , ( "useNbCycles", Encode.int v.useNbCycles )
+encode : Maybe String -> Simulator -> Encode.Value
+encode webUrl v =
+    EU.optionalPropertiesObject
+        [ ( "complementsImpacts", Impact.encodeComplementsImpacts v.complementsImpacts |> Just )
+        , ( "daysOfWear", v.daysOfWear |> Duration.inDays |> round |> Encode.int |> Just )
+        , ( "durability", v.durability |> Unit.floatDurabilityFromHolistic |> Encode.float |> Just )
+        , ( "impacts", Impact.encode v.impacts |> Just )
+        , ( "impactsWithoutDurability", Impact.encode (getTotalImpactsWithoutDurability v) |> Just )
+        , ( "inputs", Inputs.encode v.inputs |> Just )
+        , ( "lifeCycle", LifeCycle.encode v.lifeCycle |> Just )
+        , ( "transport", Transport.encode v.transport |> Just )
+        , ( "useNbCycles", Encode.int v.useNbCycles |> Just )
+        , ( "webUrl", webUrl |> Maybe.map Encode.string )
         ]
 
 

--- a/src/Server.elm
+++ b/src/Server.elm
@@ -23,7 +23,6 @@ import Data.Textile.Query as TextileQuery
 import Data.Textile.Simulator as Simulator exposing (Simulator)
 import Data.Textile.WellKnown exposing (WellKnown)
 import Data.Validation as Validation
-import Http exposing (request)
 import Json.Encode as Encode
 import Route as WebRoute
 import Server.Request exposing (Request)

--- a/src/Server.elm
+++ b/src/Server.elm
@@ -45,7 +45,16 @@ apiDocUrl request =
 
 serverRootUrl : Request -> String
 serverRootUrl request =
-    request.protocol ++ "://" ++ request.host ++ "/"
+    request.protocol
+        ++ "://"
+        ++ request.host
+        ++ (case request.version of
+                Just version ->
+                    "/versions/" ++ version ++ "/"
+
+                Nothing ->
+                    "/"
+           )
 
 
 sendResponse : Int -> Request -> Encode.Value -> Cmd Msg

--- a/src/Server.elm
+++ b/src/Server.elm
@@ -49,7 +49,7 @@ apiDocUrl =
 
 
 sendResponse : Int -> Request -> Encode.Value -> Cmd Msg
-sendResponse httpStatus { jsResponseHandler, method, url, host } body =
+sendResponse httpStatus { host, jsResponseHandler, method, url } body =
     Encode.object
         [ ( "status", Encode.int httpStatus )
         , ( "method", Encode.string method )

--- a/src/Server/Request.elm
+++ b/src/Server/Request.elm
@@ -18,4 +18,7 @@ type alias Request =
 
     -- ExpressJS' request `url` string
     , url : String
+
+    -- host retrieved from the request
+    , host : String
     }

--- a/src/Server/Request.elm
+++ b/src/Server/Request.elm
@@ -7,6 +7,9 @@ type alias Request =
     { -- JSON body; if no JSON body exist in the request, fallbacks to `{}`
       body : Encode.Value
 
+    -- host retrieved from the request
+    , host : String
+
     -- ExpressJS response callback function
     , jsResponseHandler : Encode.Value
 
@@ -18,7 +21,4 @@ type alias Request =
 
     -- ExpressJS' request `url` string
     , url : String
-
-    -- host retrieved from the request
-    , host : String
     }

--- a/src/Server/Request.elm
+++ b/src/Server/Request.elm
@@ -24,4 +24,7 @@ type alias Request =
 
     -- ExpressJS' request `url` string, actually a path
     , url : String
+
+    -- Version number, if any
+    , version : Maybe String
     }

--- a/src/Server/Request.elm
+++ b/src/Server/Request.elm
@@ -19,6 +19,9 @@ type alias Request =
     -- Raw JSON processes as a string
     , processes : String
 
-    -- ExpressJS' request `url` string
+    -- Protocol (either 'http' or 'https')
+    , protocol : String
+
+    -- ExpressJS' request `url` string, actually a path
     , url : String
     }

--- a/tests/Server/RouteTest.elm
+++ b/tests/Server/RouteTest.elm
@@ -234,22 +234,22 @@ textileEndpoints db =
     ]
 
 
-testEndpoint : StaticDb.Db -> ( String, String, String ) -> String -> Encode.Value -> Maybe Route.Route
-testEndpoint dbs ( protocol, host, method ) url =
-    createServerRequest dbs ( protocol, method, host ) url
+testEndpoint : StaticDb.Db -> { method : String, protocol : String, host : String, version : Maybe String } -> String -> Encode.Value -> Maybe Route.Route
+testEndpoint dbs params url =
+    createServerRequest dbs params url
         >> Route.endpoint dbs
 
 
 testFoodEndpoint : StaticDb.Db -> Encode.Value -> Maybe Route.Route
 testFoodEndpoint dbs body =
     body
-        |> testEndpoint dbs ( "POST", "http", "fqdn" ) "/food"
+        |> testEndpoint dbs { method = "POST", protocol = "http", host = "fqdn", version = Nothing } "/food"
 
 
 testTextileEndpoint : StaticDb.Db -> Encode.Value -> Maybe Route.Route
 testTextileEndpoint dbs body =
     body
-        |> testEndpoint dbs ( "POST", "http", "fqdn" ) "/textile/simulator"
+        |> testEndpoint dbs { method = "POST", protocol = "http", host = "fqdn", version = Nothing } "/textile/simulator"
 
 
 expectFoodValidationError : String -> String -> Maybe Route.Route -> Expect.Expectation

--- a/tests/Server/RouteTest.elm
+++ b/tests/Server/RouteTest.elm
@@ -234,22 +234,22 @@ textileEndpoints db =
     ]
 
 
-testEndpoint : StaticDb.Db -> String -> Encode.Value -> String -> Maybe Route.Route
-testEndpoint dbs method body =
-    createServerRequest dbs method body
+testEndpoint : StaticDb.Db -> String -> String -> Encode.Value -> String -> Maybe Route.Route
+testEndpoint dbs host method body =
+    createServerRequest dbs host method body
         >> Route.endpoint dbs
 
 
 testFoodEndpoint : StaticDb.Db -> Encode.Value -> Maybe Route.Route
 testFoodEndpoint dbs body =
     "/food"
-        |> testEndpoint dbs "POST" body
+        |> testEndpoint dbs "fqdn" "POST" body
 
 
 testTextileEndpoint : StaticDb.Db -> Encode.Value -> Maybe Route.Route
 testTextileEndpoint dbs body =
     "/textile/simulator"
-        |> testEndpoint dbs "POST" body
+        |> testEndpoint dbs "fqdn" "POST" body
 
 
 expectFoodValidationError : String -> String -> Maybe Route.Route -> Expect.Expectation

--- a/tests/Server/RouteTest.elm
+++ b/tests/Server/RouteTest.elm
@@ -234,22 +234,22 @@ textileEndpoints db =
     ]
 
 
-testEndpoint : StaticDb.Db -> String -> String -> Encode.Value -> String -> Maybe Route.Route
-testEndpoint dbs host method body =
-    createServerRequest dbs host method body
+testEndpoint : StaticDb.Db -> String -> String -> String -> Encode.Value -> String -> Maybe Route.Route
+testEndpoint dbs host method protocol body =
+    createServerRequest dbs host method protocol body
         >> Route.endpoint dbs
 
 
 testFoodEndpoint : StaticDb.Db -> Encode.Value -> Maybe Route.Route
 testFoodEndpoint dbs body =
     "/food"
-        |> testEndpoint dbs "fqdn" "POST" body
+        |> testEndpoint dbs "fqdn" "POST" "http" body
 
 
 testTextileEndpoint : StaticDb.Db -> Encode.Value -> Maybe Route.Route
 testTextileEndpoint dbs body =
     "/textile/simulator"
-        |> testEndpoint dbs "fqdn" "POST" body
+        |> testEndpoint dbs "fqdn" "POST" "http" body
 
 
 expectFoodValidationError : String -> String -> Maybe Route.Route -> Expect.Expectation

--- a/tests/Server/RouteTest.elm
+++ b/tests/Server/RouteTest.elm
@@ -234,22 +234,42 @@ textileEndpoints db =
     ]
 
 
-testEndpoint : StaticDb.Db -> { method : String, protocol : String, host : String, version : Maybe String } -> String -> Encode.Value -> Maybe Route.Route
-testEndpoint dbs params url =
-    createServerRequest dbs params url
+testEndpoint :
+    StaticDb.Db
+    ->
+        { method : String
+        , protocol : String
+        , host : String
+        , url : String
+        , version : Maybe String
+        }
+    -> Encode.Value
+    -> Maybe Route.Route
+testEndpoint dbs params =
+    createServerRequest dbs params
         >> Route.endpoint dbs
 
 
 testFoodEndpoint : StaticDb.Db -> Encode.Value -> Maybe Route.Route
-testFoodEndpoint dbs body =
-    body
-        |> testEndpoint dbs { method = "POST", protocol = "http", host = "fqdn", version = Nothing } "/food"
+testFoodEndpoint dbs =
+    testEndpoint dbs
+        { method = "POST"
+        , protocol = "http"
+        , host = "fqdn"
+        , url = "/food"
+        , version = Nothing
+        }
 
 
 testTextileEndpoint : StaticDb.Db -> Encode.Value -> Maybe Route.Route
-testTextileEndpoint dbs body =
-    body
-        |> testEndpoint dbs { method = "POST", protocol = "http", host = "fqdn", version = Nothing } "/textile/simulator"
+testTextileEndpoint dbs =
+    testEndpoint dbs
+        { method = "POST"
+        , protocol = "http"
+        , host = "fqdn"
+        , url = "/textile/simulator"
+        , version = Nothing
+        }
 
 
 expectFoodValidationError : String -> String -> Maybe Route.Route -> Expect.Expectation

--- a/tests/Server/RouteTest.elm
+++ b/tests/Server/RouteTest.elm
@@ -234,22 +234,22 @@ textileEndpoints db =
     ]
 
 
-testEndpoint : StaticDb.Db -> String -> String -> String -> Encode.Value -> String -> Maybe Route.Route
-testEndpoint dbs host method protocol body =
-    createServerRequest dbs host method protocol body
+testEndpoint : StaticDb.Db -> ( String, String, String ) -> String -> Encode.Value -> Maybe Route.Route
+testEndpoint dbs ( protocol, host, method ) url =
+    createServerRequest dbs ( protocol, method, host ) url
         >> Route.endpoint dbs
 
 
 testFoodEndpoint : StaticDb.Db -> Encode.Value -> Maybe Route.Route
 testFoodEndpoint dbs body =
-    "/food"
-        |> testEndpoint dbs "fqdn" "POST" "http" body
+    body
+        |> testEndpoint dbs ( "POST", "http", "fqdn" ) "/food"
 
 
 testTextileEndpoint : StaticDb.Db -> Encode.Value -> Maybe Route.Route
 testTextileEndpoint dbs body =
-    "/textile/simulator"
-        |> testEndpoint dbs "fqdn" "POST" "http" body
+    body
+        |> testEndpoint dbs ( "POST", "http", "fqdn" ) "/textile/simulator"
 
 
 expectFoodValidationError : String -> String -> Maybe Route.Route -> Expect.Expectation

--- a/tests/Server/ServerTest.elm
+++ b/tests/Server/ServerTest.elm
@@ -25,7 +25,13 @@ suite =
                 ]
             , describe "handleRequest"
                 [ Encode.null
-                    |> createServerRequest dbs { method = "GET", protocol = "http", host = "fqdn", version = Nothing } "/invalid"
+                    |> createServerRequest dbs
+                        { method = "GET"
+                        , protocol = "http"
+                        , host = "fqdn"
+                        , url = "/invalid"
+                        , version = Nothing
+                        }
                     |> Server.handleRequest dbs
                     |> Tuple.first
                     |> Expect.equal 404
@@ -33,7 +39,13 @@ suite =
 
                 -- POST queries
                 , Encode.null
-                    |> createServerRequest dbs { method = "POST", protocol = "http", host = "fqdn", version = Nothing } "/food"
+                    |> createServerRequest dbs
+                        { method = "POST"
+                        , protocol = "http"
+                        , host = "fqdn"
+                        , url = "/food"
+                        , version = Nothing
+                        }
                     |> Server.handleRequest dbs
                     |> Tuple.first
                     |> Expect.equal 400
@@ -54,7 +66,13 @@ suite =
                                 , preparation = []
                                 , transform = Nothing
                                 }
-                                |> createServerRequest dbs { method = "POST", protocol = "http", host = "fqdn", version = Nothing } "/food"
+                                |> createServerRequest dbs
+                                    { method = "POST"
+                                    , protocol = "http"
+                                    , host = "fqdn"
+                                    , url = "/food"
+                                    , version = Nothing
+                                    }
                                 |> Server.handleRequest dbs
                                 |> Tuple.first
                                 |> Expect.equal 200

--- a/tests/Server/ServerTest.elm
+++ b/tests/Server/ServerTest.elm
@@ -25,7 +25,7 @@ suite =
                 ]
             , describe "handleRequest"
                 [ "/invalid"
-                    |> createServerRequest dbs "GET" Encode.null
+                    |> createServerRequest dbs "fqdn" "GET" Encode.null
                     |> Server.handleRequest dbs
                     |> Tuple.first
                     |> Expect.equal 404
@@ -33,7 +33,7 @@ suite =
 
                 -- POST queries
                 , "/food"
-                    |> createServerRequest dbs "POST" Encode.null
+                    |> createServerRequest dbs "fqdn" "POST" Encode.null
                     |> Server.handleRequest dbs
                     |> Tuple.first
                     |> Expect.equal 400
@@ -43,6 +43,7 @@ suite =
                         Just id ->
                             "/food"
                                 |> createServerRequest dbs
+                                    "fqdn"
                                     "POST"
                                     (FoodQuery.encode
                                         { distribution = Nothing

--- a/tests/Server/ServerTest.elm
+++ b/tests/Server/ServerTest.elm
@@ -25,7 +25,7 @@ suite =
                 ]
             , describe "handleRequest"
                 [ Encode.null
-                    |> createServerRequest dbs ( "GET", "http", "fqdn" ) "/invalid"
+                    |> createServerRequest dbs { method = "GET", protocol = "http", host = "fqdn", version = Nothing } "/invalid"
                     |> Server.handleRequest dbs
                     |> Tuple.first
                     |> Expect.equal 404
@@ -33,7 +33,7 @@ suite =
 
                 -- POST queries
                 , Encode.null
-                    |> createServerRequest dbs ( "POST", "http", "fqdn" ) "/food"
+                    |> createServerRequest dbs { method = "POST", protocol = "http", host = "fqdn", version = Nothing } "/food"
                     |> Server.handleRequest dbs
                     |> Tuple.first
                     |> Expect.equal 400
@@ -54,7 +54,7 @@ suite =
                                 , preparation = []
                                 , transform = Nothing
                                 }
-                                |> createServerRequest dbs ( "POST", "http", "fqdn" ) "/food"
+                                |> createServerRequest dbs { method = "POST", protocol = "http", host = "fqdn", version = Nothing } "/food"
                                 |> Server.handleRequest dbs
                                 |> Tuple.first
                                 |> Expect.equal 200

--- a/tests/Server/ServerTest.elm
+++ b/tests/Server/ServerTest.elm
@@ -43,9 +43,9 @@ suite =
                         Just id ->
                             "/food"
                                 |> createServerRequest dbs
-                                    "http"
                                     "fqdn"
                                     "POST"
+                                    "http"
                                     (FoodQuery.encode
                                         { distribution = Nothing
                                         , ingredients =

--- a/tests/Server/ServerTest.elm
+++ b/tests/Server/ServerTest.elm
@@ -24,16 +24,16 @@ suite =
                     |> asTest "should apply output command"
                 ]
             , describe "handleRequest"
-                [ "/invalid"
-                    |> createServerRequest dbs "fqdn" "GET" "http" Encode.null
+                [ Encode.null
+                    |> createServerRequest dbs ( "GET", "http", "fqdn" ) "/invalid"
                     |> Server.handleRequest dbs
                     |> Tuple.first
                     |> Expect.equal 404
                     |> asTest "should catch invalid endpoints"
 
                 -- POST queries
-                , "/food"
-                    |> createServerRequest dbs "fqdn" "POST" "http" Encode.null
+                , Encode.null
+                    |> createServerRequest dbs ( "POST", "http", "fqdn" ) "/food"
                     |> Server.handleRequest dbs
                     |> Tuple.first
                     |> Expect.equal 400
@@ -41,25 +41,20 @@ suite =
                 , asTest "should accept a valid POST query" <|
                     case List.head dbs.food.ingredients |> Maybe.map .id of
                         Just id ->
-                            "/food"
-                                |> createServerRequest dbs
-                                    "fqdn"
-                                    "POST"
-                                    "http"
-                                    (FoodQuery.encode
-                                        { distribution = Nothing
-                                        , ingredients =
-                                            [ { country = Nothing
-                                              , id = id
-                                              , mass = Mass.kilogram
-                                              , planeTransport = Ingredient.NoPlane
-                                              }
-                                            ]
-                                        , packaging = []
-                                        , preparation = []
-                                        , transform = Nothing
-                                        }
-                                    )
+                            FoodQuery.encode
+                                { distribution = Nothing
+                                , ingredients =
+                                    [ { country = Nothing
+                                      , id = id
+                                      , mass = Mass.kilogram
+                                      , planeTransport = Ingredient.NoPlane
+                                      }
+                                    ]
+                                , packaging = []
+                                , preparation = []
+                                , transform = Nothing
+                                }
+                                |> createServerRequest dbs ( "POST", "http", "fqdn" ) "/food"
                                 |> Server.handleRequest dbs
                                 |> Tuple.first
                                 |> Expect.equal 200

--- a/tests/Server/ServerTest.elm
+++ b/tests/Server/ServerTest.elm
@@ -25,7 +25,7 @@ suite =
                 ]
             , describe "handleRequest"
                 [ "/invalid"
-                    |> createServerRequest dbs "fqdn" "GET" Encode.null
+                    |> createServerRequest dbs "fqdn" "GET" "http" Encode.null
                     |> Server.handleRequest dbs
                     |> Tuple.first
                     |> Expect.equal 404
@@ -33,7 +33,7 @@ suite =
 
                 -- POST queries
                 , "/food"
-                    |> createServerRequest dbs "fqdn" "POST" Encode.null
+                    |> createServerRequest dbs "fqdn" "POST" "http" Encode.null
                     |> Server.handleRequest dbs
                     |> Tuple.first
                     |> Expect.equal 400
@@ -43,6 +43,7 @@ suite =
                         Just id ->
                             "/food"
                                 |> createServerRequest dbs
+                                    "http"
                                     "fqdn"
                                     "POST"
                                     (FoodQuery.encode

--- a/tests/TestUtils.elm
+++ b/tests/TestUtils.elm
@@ -105,8 +105,13 @@ expectResultWithin precision target result =
             Expect.fail err
 
 
-createServerRequest : StaticDb.Db -> ( String, String, String ) -> String -> Encode.Value -> Request
-createServerRequest dbs ( method, protocol, host ) url body =
+createServerRequest :
+    StaticDb.Db
+    -> { method : String, protocol : String, host : String, version : Maybe String }
+    -> String
+    -> Encode.Value
+    -> Request
+createServerRequest dbs { method, protocol, host, version } url body =
     let
         encode encoder =
             Encode.list encoder >> Encode.encode 0
@@ -118,4 +123,5 @@ createServerRequest dbs ( method, protocol, host ) url body =
     , processes = dbs.processes |> encode Process.encode
     , protocol = protocol
     , url = url
+    , version = version
     }

--- a/tests/TestUtils.elm
+++ b/tests/TestUtils.elm
@@ -105,8 +105,8 @@ expectResultWithin precision target result =
             Expect.fail err
 
 
-createServerRequest : StaticDb.Db -> String -> String -> Encode.Value -> String -> Request
-createServerRequest dbs host method body url =
+createServerRequest : StaticDb.Db -> String -> String -> String -> Encode.Value -> String -> Request
+createServerRequest dbs host method protocol body url =
     let
         encode encoder =
             Encode.list encoder >> Encode.encode 0
@@ -116,5 +116,6 @@ createServerRequest dbs host method body url =
     , jsResponseHandler = Encode.null
     , method = method
     , processes = dbs.processes |> encode Process.encode
+    , protocol = protocol
     , url = url
     }

--- a/tests/TestUtils.elm
+++ b/tests/TestUtils.elm
@@ -107,11 +107,10 @@ expectResultWithin precision target result =
 
 createServerRequest :
     StaticDb.Db
-    -> { method : String, protocol : String, host : String, version : Maybe String }
-    -> String
+    -> { method : String, protocol : String, host : String, url : String, version : Maybe String }
     -> Encode.Value
     -> Request
-createServerRequest dbs { method, protocol, host, version } url body =
+createServerRequest dbs { method, protocol, host, url, version } body =
     let
         encode encoder =
             Encode.list encoder >> Encode.encode 0

--- a/tests/TestUtils.elm
+++ b/tests/TestUtils.elm
@@ -105,8 +105,8 @@ expectResultWithin precision target result =
             Expect.fail err
 
 
-createServerRequest : StaticDb.Db -> String -> String -> String -> Encode.Value -> String -> Request
-createServerRequest dbs host method protocol body url =
+createServerRequest : StaticDb.Db -> ( String, String, String ) -> String -> Encode.Value -> Request
+createServerRequest dbs ( method, protocol, host ) url body =
     let
         encode encoder =
             Encode.list encoder >> Encode.encode 0

--- a/tests/TestUtils.elm
+++ b/tests/TestUtils.elm
@@ -105,13 +105,14 @@ expectResultWithin precision target result =
             Expect.fail err
 
 
-createServerRequest : StaticDb.Db -> String -> Encode.Value -> String -> Request
-createServerRequest dbs method body url =
+createServerRequest : StaticDb.Db -> String -> String -> Encode.Value -> String -> Request
+createServerRequest dbs host method body url =
     let
         encode encoder =
             Encode.list encoder >> Encode.encode 0
     in
     { body = body
+    , host = host
     , jsResponseHandler = Encode.null
     , method = method
     , processes = dbs.processes |> encode Process.encode


### PR DESCRIPTION
## :wrench: Problem

The `webUrl` returned by the API is hardcoded to `ecobalyse.beta.gouv.fr`, even when running on the staging or a review app:

```
{
  "webUrl": "https://ecobalyse.beta.gouv.fr/........
```

Also, when using a versioned API, it doesn't contain the version, making the resulting scores in the web version possibly differing from the ones in the API response. Note: this patch takes over #1363 in this regard and fixes #1360

## :cake: Solution

Instead of a harcoded FQDN, use the host transmitted from the request. Also reflect the version used for the API in the Web urls.

## :desert_island: How to test

Check in the API, when running a request, that you get the right FQDN:

Example on this PR:
```
{
  "webUrl": "https://ecobalyse-staging-pr1381.osc-fr1.scalingo.io#/food/ecs/ey.....
```

With versioned APIs, check that the version is preserved in the web urls as well.

<img width="1957" height="1251" alt="image" src="https://github.com/user-attachments/assets/728ea2ff-0a90-4588-8c47-dd38561d5e42" />
