### PR TITLE
feat(object): improve results serialization

### DIFF
--- a/tests/Data/ComponentTest.elm
+++ b/tests/Data/ComponentTest.elm
@@ -115,6 +115,7 @@ suite =
                             { amount = Component.Amount 1
                             , impacts = Impact.empty
                             , items = []
+                            , label = Nothing
                             , mass = Mass.kilogram
                             , stage = Nothing
                             }
@@ -143,6 +144,7 @@ suite =
                             { amount = Component.Amount 1
                             , impacts = Impact.empty
                             , items = []
+                            , label = Nothing
                             , mass = Mass.kilogram
                             , stage = Nothing
                             }
@@ -196,6 +198,7 @@ suite =
                                 { amount = Component.Amount 1
                                 , impacts = Impact.empty
                                 , items = []
+                                , label = Nothing
                                 , mass = Mass.kilogram
                                 , stage = Nothing
                                 }
@@ -210,6 +213,7 @@ suite =
                             { amount = Component.Amount 1
                             , impacts = Impact.empty |> Impact.insertWithoutAggregateComputation Definition.Ecs (Unit.impact 100)
                             , items = []
+                            , label = Nothing
                             , mass = Mass.kilogram
                             , stage = Nothing
                             }


### PR DESCRIPTION
## :wrench: Problem

It's very hard to debug the object/veli simulator with the current JSON debug output, as we have to matching labels for nested data structures:

```json
{
  "impacts": 26984.102173350588,
  "items": [
    {
      "impacts": 101.28574385510996,
      "items": [
        {
          "impacts": 101.28574385510996,
          "items": [
            {
              "impacts": 57.5503234152652,
              "items": [],
              "mass": 0.517464424320828,
              "stage": "material"
            },
            {
              "impacts": 43.73542043984476,
              "items": [],
              "mass": 0.4,
              "stage": "transformation"
            }
          ],
          "mass": 0.4
        }
      ],
      "mass": 0.4
    },
    {
      "impacts": 7343.216429495473,
      "items": [
        {
          "impacts": 7343.216429495473,
          "items": [
            {
              "impacts": 4172.398447606727,
              "items": [],
              "mass": 37.51617076326003,
              "stage": "material"
            },
            {
              "impacts": 3170.817981888745,
              "items": [],
              "mass": 29,
              "stage": "transformation"
            }
          ],
          "mass": 29
        }
      ],
      "mass": 29
    },
    {
      "impacts": 19539.600000000002,
      "items": [
        {
          "impacts": 19539.600000000002,
          "items": [
            {
              "impacts": 19539.600000000002,
              "items": [],
              "mass": 15,
              "stage": "material"
            }
          ],
          "mass": 15
        }
      ],
      "mass": 15
    }
  ],
  "mass": 44.4
}
```

## :cake: Solution

Add a meaningful `label` property to each nested result substructure, making identifying components, elements, material and transforms easier:

```json
{
  "label": "Complete product",
  "mass": 44.4,
  "impacts": 26984.102173350588,
  "items": [
    {
      "label": "Pied chaise acier",
      "mass": 0.4,
      "impacts": 101.28574385510996,
      "items": [
        {
          "label": "Element: Acier (non allié)",
          "mass": 0.4,
          "impacts": 101.28574385510996,
          "items": [
            {
              "label": "Acier (non allié)",
              "stage": "material",
              "mass": 0.517464424320828,
              "impacts": 57.5503234152652,
              "items": []
            },
            {
              "label": "Transformation finale (acier)",
              "stage": "transformation",
              "mass": 0.4,
              "impacts": 43.73542043984476,
              "items": []
            }
          ]
        }
      ]
    },
    {
      "label": "Structure acier (canapé 3p)",
      "mass": 29,
      "impacts": 7343.216429495473,
      "items": [
        {
          "label": "Element: Acier (non allié)",
          "mass": 29,
          "impacts": 7343.216429495473,
          "items": [
            {
              "label": "Acier (non allié)",
              "stage": "material",
              "mass": 37.51617076326003,
              "impacts": 4172.398447606727,
              "items": []
            },
            {
              "label": "Transformation finale (acier)",
              "stage": "transformation",
              "mass": 29,
              "impacts": 3170.817981888745,
              "items": []
            }
          ]
        }
      ]
    },
    {
      "label": "Mousse polyurethane (canapé 3p)",
      "mass": 15,
      "impacts": 19539.600000000002,
      "items": [
        {
          "label": "Element: Mousse rigide (PUR)",
          "mass": 15,
          "impacts": 19539.600000000002,
          "items": [
            {
              "label": "Mousse rigide (PUR)",
              "stage": "material",
              "mass": 15,
              "impacts": 19539.600000000002,
              "items": []
            }
          ]
        }
      ]
    }
  ]
}
```

## :desert_island: How to test

Inspect the debug output in the object simulator.