### PR TITLE
chore: don’t deploy prereleases

### DIFF
--- a/bin/download_github_releases.py
+++ b/bin/download_github_releases.py
@@ -76,7 +76,11 @@ if __name__ == "__main__":
             continue
 
         if release.draft:
-            logger.info("Skipping draft release.")
+            logger.info(f"Skipping draft {release}.")
+            continue
+
+        if release.prerelease:
+            logger.info(f"Skipping prerelease {release}.")
             continue
 
         for asset in release.assets:


### PR DESCRIPTION
## :wrench: Problem

fixes https://github.com/MTES-MCT/ecobalyse/issues/1038

## :cake: Solution

Don’t deploy `prerelease` versions.

## :desert_island: How to test


Currently you can access https://ecobalyse.beta.gouv.fr/versions/v6.0.0/ even if it’s not in the version selector as versions that are marked as `prerelease` are still deployed.

https://ecobalyse-staging-pr1394.osc-fr1.scalingo.io/versions/v6.0.0/ should not be available anymore on this scalingo deploy, it should redirect to https://ecobalyse-staging-pr1394.osc-fr1.scalingo.io/