### PR TITLE
fix(auth): require manual login confirmation

### DIFF
--- a/e2e/auth.spec.js
+++ b/e2e/auth.spec.js
@@ -71,6 +71,8 @@ test.describe("auth", () => {
 
       await page.goto(links[0]);
 
+      await page.getByTestId("auth-login-confirm").click();
+
       await expect(page.getByRole("heading", { name: "Mon compte" })).toBeVisible();
     });
 

--- a/e2e/lib.js
+++ b/e2e/lib.js
@@ -48,6 +48,8 @@ export async function loginUser(page, email) {
 
   await page.goto(links[0]);
 
+  await page.getByTestId("auth-login-confirm").click();
+
   await expectNotification(page, "Vous avez désormais accès aux impacts détaillés");
 }
 
@@ -84,6 +86,8 @@ export async function registerAndLoginUser(
   expect(links).toHaveLength(1);
 
   await page.goto(links[0]);
+
+  await page.getByTestId("auth-login-confirm").click();
 
   await expectNotification(page, "Vous avez désormais accès aux impacts détaillés");
 }

--- a/src/Page/Auth.elm
+++ b/src/Page/Auth.elm
@@ -59,7 +59,7 @@ type Msg
     | LoginResponse (WebData AccessTokenData)
     | Logout User
     | LogoutResponse (WebData ())
-    | MagicLinkLoginConfirm Email AccessToken
+    | MagicLinkLoginConfirm
     | MagicLinkResponse (WebData ())
     | MagicLinkSubmit
     | ProfileResponse { updated : Bool } AccessTokenData (WebData User)
@@ -379,10 +379,10 @@ updateMagicLinkLoginTab session email token msg model =
                     )
                 |> App.withCmds [ Nav.load <| Route.toString Route.Auth ]
 
-        MagicLinkLoginConfirm email_ token_ ->
-            { model | tab = MagicLinkLogin email_ token_ }
+        MagicLinkLoginConfirm ->
+            model
                 |> App.createUpdate session
-                |> App.withCmds [ Auth.login session LoginResponse email_ token_ ]
+                |> App.withCmds [ Auth.login session LoginResponse email token ]
 
         ProfileResponse _ accessTokenData (RemoteData.Success user) ->
             let
@@ -505,8 +505,8 @@ viewTab session currentTab =
                     MagicLinkForm email webData ->
                         viewMagicLinkForm email webData
 
-                    MagicLinkLogin email token ->
-                        viewMagicLinkLogin email token
+                    MagicLinkLogin email _ ->
+                        viewMagicLinkLogin email
 
                     MagicLinkSent email ->
                         viewMagicLinkSent email
@@ -857,8 +857,8 @@ viewMagicLinkForm email webData =
         ]
 
 
-viewMagicLinkLogin : Email -> AccessToken -> Html Msg
-viewMagicLinkLogin email token =
+viewMagicLinkLogin : Email -> Html Msg
+viewMagicLinkLogin email =
     div [ class "d-flex flex-column justify-content-center p-3" ]
         [ p [ class "d-flex align-items-baseline gap-1" ]
             [ Icon.info
@@ -867,7 +867,7 @@ viewMagicLinkLogin email token =
             ]
         , button
             [ class "btn btn-primary"
-            , onClick <| MagicLinkLoginConfirm email token
+            , onClick MagicLinkLoginConfirm
             ]
             [ text "Confirmer la connexion"
             ]

--- a/src/Page/Auth.elm
+++ b/src/Page/Auth.elm
@@ -859,15 +859,19 @@ viewMagicLinkForm email webData =
 
 viewMagicLinkLogin : Email -> Html Msg
 viewMagicLinkLogin email =
-    div [ class "d-flex flex-column justify-content-center p-3" ]
+    Html.form
+        [ class "d-flex flex-column justify-content-center p-3"
+        , onSubmit MagicLinkLoginConfirm
+        ]
         [ p [ class "d-flex align-items-baseline gap-1" ]
             [ Icon.info
             , text "Vous allez être connecté avec l'adresse email suivante\u{00A0}: "
             , strong [] [ email |> Url.percentDecode |> Maybe.withDefault email |> text ]
             ]
         , button
-            [ class "btn btn-primary"
-            , onClick MagicLinkLoginConfirm
+            [ type_ "submit"
+            , attribute "data-testid" "auth-login-confirm"
+            , class "btn btn-primary"
             ]
             [ text "Confirmer la connexion"
             ]


### PR DESCRIPTION
## :wrench: Problem

A lot of users report that when clicking their magic links, an error says the link is already expired. This must be because their email client fetches the content behind the link, therefore expiring the one-time token.

[Discussion happens here](https://mattermost.incubateur.net/fabnum-mte/pl/syc3ao89spbpumk9odyb1p3khy)

<img width="1667" height="1039" alt="Sans titre" src="https://github.com/user-attachments/assets/3c8399ed-5a5c-447f-9d3b-73ac5f9ca60f" />

## :cake: Solution

This patch implements a new login confirmation screen with a mandatory click, requiring a manual action email client can't and won't do.

## :desert_island: How to test

Login on the review app: a button should ask confirmation for effective login.

Note: I've asked this specific user to test this review app so we can see if the patch solves the problem for them.

Edit: it fixes the issue:
> Bonjour Nicolas, 
>
>Merci pour votre réponse, j'ai essayé avec le compte stagging et effectivement cela fonctionne ! 
>
>Bonne journée