### PR TITLE
chore: add back pg docker-compose for dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+  db:
+    container_name: ecobalyse_dev_db
+    # Use the same version than Scalingo in production
+    image: postgres:14
+    environment:
+      POSTGRES_DB: ecobalyse_dev
+      POSTGRES_USER: ecobalyse
+      POSTGRES_HOST_AUTH_METHOD: trust
+    ports:
+      # Don’t conflict with my local PG
+      - "5433:5432"
+    healthcheck:
+      test: "pg_isready -U ecobalyse"
+      interval: 5s
+      timeout: 5s
+      retries: 5


### PR DESCRIPTION
## :wrench: Problem

`docker-compose.yml` used for the dev PG database was deleted in https://github.com/MTES-MCT/ecobalyse/commit/7436adb337861ac1acff940f6005fe3421d086f6

## :cake: Solution

Add it back.

## :desert_island: How to test

Running `./bin/check-db.sh` should work as expected.