### PR TITLE
chore: replace deprecated passlib

### DIFF
--- a/backend/src/app/lib/crypt.py
+++ b/backend/src/app/lib/crypt.py
@@ -4,9 +4,10 @@ import asyncio
 import base64
 
 from asyncstdlib.functools import cache
-from passlib.context import CryptContext
+from pwdlib import PasswordHash
+from pwdlib.hashers.argon2 import Argon2Hasher
 
-password_crypt_context = CryptContext(schemes=["argon2"], deprecated="auto")
+password_hash = PasswordHash((Argon2Hasher(),))
 
 
 def get_encryption_key(secret: str) -> bytes:
@@ -33,7 +34,7 @@ async def get_password_hash(password: str | bytes) -> str:
         str: Hashed password
     """
     return await asyncio.get_running_loop().run_in_executor(
-        None, password_crypt_context.hash, password
+        None, password_hash.hash, password
     )
 
 
@@ -50,7 +51,7 @@ async def verify_password(plain_password: str | bytes, hashed_password: str) -> 
     """
     valid, _ = await asyncio.get_running_loop().run_in_executor(
         None,
-        password_crypt_context.verify_and_update,
+        password_hash.verify_and_update,
         plain_password,
         hashed_password,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ dependencies = [
     "asyncpg>=0.30.0",
     "structlog>=25.2.0",
     "orjson>=3.10.16",
-    "passlib[argon2]>=1.7.4",
     "aiosmtplib>=4.0.0",
     "emails>=0.6",
     "python-stdnum>=2.1",
@@ -23,7 +22,8 @@ dependencies = [
     "typer>=0.16.0",
     "pytest-mock>=3.14.1",
     "asyncstdlib>=3.13.1",
-    "sentry-sdk[litestar]>=2.41"
+    "sentry-sdk[litestar]>=2.41",
+    "pwdlib[argon2]>=0.2.1",
 ]
 
 [build-system]

--- a/uv.lock
+++ b/uv.lock
@@ -356,8 +356,8 @@ dependencies = [
     { name = "litestar", extra = ["jwt", "sqlalchemy", "standard"] },
     { name = "msgspec" },
     { name = "orjson" },
-    { name = "passlib", extra = ["argon2"] },
     { name = "psycopg", extra = ["binary", "pool"] },
+    { name = "pwdlib", extra = ["argon2"] },
     { name = "pygithub" },
     { name = "pytest-databases", extra = ["postgres"] },
     { name = "pytest-mock" },
@@ -386,8 +386,8 @@ requires-dist = [
     { name = "litestar", extras = ["jwt", "sqlalchemy", "standard"], specifier = ">=2.16.0" },
     { name = "msgspec", specifier = ">=0.19.0" },
     { name = "orjson", specifier = ">=3.10.16" },
-    { name = "passlib", extras = ["argon2"], specifier = ">=1.7.4" },
     { name = "psycopg", extras = ["binary", "pool"], specifier = ">=3.2.6" },
+    { name = "pwdlib", extras = ["argon2"], specifier = ">=0.2.1" },
     { name = "pygithub", specifier = ">=2.6.1" },
     { name = "pytest-databases", extras = ["postgres"], specifier = ">=0.12.0" },
     { name = "pytest-mock", specifier = ">=3.14.1" },
@@ -847,20 +847,6 @@ wheels = [
 ]
 
 [[package]]
-name = "passlib"
-version = "1.7.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b6/06/9da9ee59a67fae7761aab3ccc84fa4f3f33f125b370f1ccdb915bf967c11/passlib-1.7.4.tar.gz", hash = "sha256:defd50f72b65c5402ab2c573830a6978e5f202ad0d984793c8dde2c4152ebe04", size = 689844, upload-time = "2020-10-08T19:00:52.121Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/a4/ab6b7589382ca3df236e03faa71deac88cae040af60c071a78d254a62172/passlib-1.7.4-py2.py3-none-any.whl", hash = "sha256:aa6bca462b8d8bda89c70b382f0c298a20b5560af6cbfa2dce410c0a2fb669f1", size = 525554, upload-time = "2020-10-08T19:00:49.856Z" },
-]
-
-[package.optional-dependencies]
-argon2 = [
-    { name = "argon2-cffi" },
-]
-
-[[package]]
 name = "platformdirs"
 version = "4.3.8"
 source = { registry = "https://pypi.org/simple" }
@@ -972,6 +958,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/cf/13/1e7850bb2c69a63267c3dbf37387d3f71a00fd0e2fa55c5db14d64ba1af4/psycopg_pool-3.2.6.tar.gz", hash = "sha256:0f92a7817719517212fbfe2fd58b8c35c1850cdd2a80d36b581ba2085d9148e5", size = 29770, upload-time = "2025-02-26T12:03:47.129Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/47/fd/4feb52a55c1a4bd748f2acaed1903ab54a723c47f6d0242780f4d97104d4/psycopg_pool-3.2.6-py3-none-any.whl", hash = "sha256:5887318a9f6af906d041a0b1dc1c60f8f0dda8340c2572b74e10907b51ed5da7", size = 38252, upload-time = "2025-02-26T12:03:45.073Z" },
+]
+
+[[package]]
+name = "pwdlib"
+version = "0.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/a0/9daed437a6226f632a25d98d65d60ba02bdafa920c90dcb6454c611ead6c/pwdlib-0.2.1.tar.gz", hash = "sha256:9a1d8a8fa09a2f7ebf208265e55d7d008103cbdc82b9e4902ffdd1ade91add5e", size = 11699, upload-time = "2024-08-19T06:48:59.58Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/f3/0dae5078a486f0fdf4d4a1121e103bc42694a9da9bea7b0f2c63f29cfbd3/pwdlib-0.2.1-py3-none-any.whl", hash = "sha256:1823dc6f22eae472b540e889ecf57fd424051d6a4023ec0bcf7f0de2d9d7ef8c", size = 8082, upload-time = "2024-08-19T06:49:00.997Z" },
+]
+
+[package.optional-dependencies]
+argon2 = [
+    { name = "argon2-cffi" },
 ]
 
 [[package]]


### PR DESCRIPTION
## :wrench: Problem

fixes #1430 

## :cake: Solution

See https://github.com/fastapi-users/fastapi-users/issues/1325#issuecomment-1979832994


## :desert_island: How to test

- [x] Tests should be green
- [x] No warning should be issued when running `npm run test:backend` 
- [x] Dumping the staging db locally and check that already existing users can still login
