### PR TITLE
chore: rewrite v7 calls to a specific application

### DIFF
--- a/servers.conf.erb
+++ b/servers.conf.erb
@@ -41,7 +41,6 @@ server {
   location ~ ^/versions/v7.0.0/(.*)$ {
     rewrite ^/versions/v7.0.0/(.*)$ /$1 break;
     proxy_pass <%= ENV["TEXTILE_URL"] %>;
-    proxy_ssl_verify off;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
   }


### PR DESCRIPTION
## :wrench: Problem

We want to host the stable `v7` on a specific domain and rewrite the requests to `/versions/v7.0.0/` to it (currently https://ecobalyse-textile.osc-secnum-fr1.scalingo.io )

## :cake: Solution

Add an nginx rule to the production server.


## :rotating_light:  Points to watch/comments

I’ve removed the `proxy_set_header Host $host;` directive as it was preventing Scalingo from displaying the page, saying that the application doesn’t exist.

## :desert_island: How to test

Open the logs for the textile app:

```
scalingo --region osc-secnum-fr1 --app ecobalyse-textile logs -f
```

And for the current PR app:

```
scalingo --region osc-fr1 --app ecobalyse-staging-pr1474 logs -f
```

Go to https://ecobalyse-staging-pr1474.osc-fr1.scalingo.io/ logs should be generated on the  `ecobalyse-staging-pr1474` review app. Select v7 in the dropdown: logs should be generated on `ecobalyse-texting` app.
Test that the API (in connected and non connected mode) works as expected.