### PR TITLE
refactor: make process location a country code

### DIFF
--- a/src/Data/Country/Code.elm
+++ b/src/Data/Country/Code.elm
@@ -1,0 +1,40 @@
+module Data.Country.Code exposing
+    ( Code(..)
+    , decode
+    , encode
+    , fromString
+    , toString
+    , unknown
+    )
+
+import Json.Decode as Decode exposing (Decoder)
+import Json.Encode as Encode
+
+
+type Code
+    = Code String
+
+
+decode : Decoder Code
+decode =
+    Decode.map Code Decode.string
+
+
+encode : Code -> Encode.Value
+encode (Code string) =
+    Encode.string string
+
+
+fromString : String -> Code
+fromString =
+    Code
+
+
+toString : Code -> String
+toString (Code string) =
+    string
+
+
+unknown : Code
+unknown =
+    Code "---"

--- a/src/Data/Dataset.elm
+++ b/src/Data/Dataset.elm
@@ -12,7 +12,7 @@ module Data.Dataset exposing
     )
 
 import Data.Component as Component
-import Data.Country as Country
+import Data.Country.Code as CountryCode
 import Data.Food.Ingredient as Ingredient
 import Data.Impact.Definition as Definition
 import Data.Process as Process
@@ -30,7 +30,7 @@ It's used by Page.Explore and related routes.
 -}
 type Dataset
     = Components Scope (Maybe Component.Id)
-    | Countries (Maybe Country.Code)
+    | Countries (Maybe CountryCode.Code)
     | FoodExamples (Maybe Uuid)
     | FoodIngredients (Maybe Ingredient.Id)
     | Impacts (Maybe Definition.Trigram)
@@ -283,7 +283,7 @@ setIdFromString idString dataset =
             Components scope (Component.idFromString idString |> Result.toMaybe)
 
         Countries _ ->
-            Countries (Just (Country.codeFromString idString))
+            Countries (Just (CountryCode.fromString idString))
 
         FoodExamples _ ->
             FoodExamples (idString |> Uuid.fromString |> Result.toMaybe)
@@ -365,7 +365,7 @@ toRoutePath dataset =
             [ slug dataset ]
 
         Countries (Just code) ->
-            [ slug dataset, Country.codeToString code ]
+            [ slug dataset, CountryCode.toString code ]
 
         Countries Nothing ->
             [ slug dataset ]

--- a/src/Data/Food/Query.elm
+++ b/src/Data/Food/Query.elm
@@ -26,7 +26,7 @@ module Data.Food.Query exposing
 import Base64
 import Data.Common.DecodeUtils as DU
 import Data.Common.EncodeUtils as EU
-import Data.Country as Country
+import Data.Country.Code as CountryCode
 import Data.Food.Ingredient as Ingredient
 import Data.Food.Preparation as Preparation
 import Data.Food.Retail as Retail
@@ -40,7 +40,7 @@ import Url.Parser as Parser exposing (Parser)
 
 
 type alias IngredientQuery =
-    { country : Maybe Country.Code
+    { country : Maybe CountryCode.Code
     , id : Ingredient.Id
     , mass : Mass
     , planeTransport : Ingredient.PlaneTransport
@@ -144,7 +144,7 @@ decodeProcess =
 decodeIngredient : Decoder IngredientQuery
 decodeIngredient =
     Decode.succeed IngredientQuery
-        |> DU.strictOptional "country" Country.decodeCode
+        |> DU.strictOptional "country" CountryCode.decode
         |> Pipe.required "id" Ingredient.decodeId
         |> Pipe.required "mass" decodeMassInGrams
         |> DU.strictOptionalWithDefault "byPlane" decodePlaneTransport Ingredient.PlaneNotApplicable
@@ -212,7 +212,7 @@ encodeIngredient v =
     EU.optionalPropertiesObject
         [ ( "id", Ingredient.encodeId v.id |> Just )
         , ( "mass", encodeMassAsGrams v.mass |> Just )
-        , ( "country", v.country |> Maybe.map Country.encodeCode )
+        , ( "country", v.country |> Maybe.map CountryCode.encode )
         , ( "byPlane", v.planeTransport |> Ingredient.encodePlaneTransport )
         ]
 

--- a/src/Data/Food/Recipe.elm
+++ b/src/Data/Food/Recipe.elm
@@ -24,6 +24,7 @@ module Data.Food.Recipe exposing
     )
 
 import Data.Country as Country exposing (Country)
+import Data.Country.Code as CountryCode
 import Data.Food.EcosystemicServices as EcosystemicServices exposing (EcosystemicServices)
 import Data.Food.Ingredient as Ingredient exposing (Ingredient)
 import Data.Food.Origin as Origin
@@ -51,9 +52,9 @@ import String.Extra as SE
 import Volume exposing (Volume)
 
 
-france : Country.Code
+france : CountryCode.Code
 france =
-    Country.codeFromString "FR"
+    CountryCode.fromString "FR"
 
 
 type alias Packaging =
@@ -373,7 +374,7 @@ computeIngredientTransport db { country, ingredient, mass, planeTransport } =
             -- [transport documentation](https://fabrique-numerique.gitbook.io/ecobalyse/alimentaire/transport#circuits-consideres)
             case country of
                 Just { code } ->
-                    if code /= Country.codeFromString "FR" then
+                    if code /= CountryCode.fromString "FR" then
                         Transport.addRoadWithCooling (Length.kilometers 500) (ingredient.transportCooling == Ingredient.AlwaysCool) t
 
                     else

--- a/src/Data/Textile/Inputs.elm
+++ b/src/Data/Textile/Inputs.elm
@@ -17,6 +17,7 @@ module Data.Textile.Inputs exposing
 import Data.Common.EncodeUtils as EU
 import Data.Component as Component exposing (Item)
 import Data.Country as Country exposing (Country)
+import Data.Country.Code as CountryCode
 import Data.Impact as Impact
 import Data.Process as Process
 import Data.Split as Split exposing (Split)
@@ -151,10 +152,10 @@ fromQuery { countries, textile } query =
                 |> fromMaterialQuery textile.materials countries
 
         franceResult =
-            Country.findByCode (Country.Code "FR") countries
+            Country.findByCode (CountryCode.Code "FR") countries
 
         unknownCountryResult =
-            Country.findByCode Country.unknownCountryCode countries
+            Country.findByCode CountryCode.unknown countries
 
         mainMaterialCountry =
             materials_
@@ -248,9 +249,9 @@ toQuery inputs =
     }
 
 
-toQueryCountryCode : Country.Code -> Maybe Country.Code
+toQueryCountryCode : CountryCode.Code -> Maybe CountryCode.Code
 toQueryCountryCode c =
-    if c == Country.unknownCountryCode then
+    if c == CountryCode.unknown then
         Nothing
 
     else
@@ -481,7 +482,7 @@ getOutOfEuropeEOLComplement { mass, materials } =
          )
 
 
-computeMaterialTransport : Distances -> Country.Code -> MaterialInput -> Transport
+computeMaterialTransport : Distances -> CountryCode.Code -> MaterialInput -> Transport
 computeMaterialTransport distances nextCountryCode { country, material, share } =
     if share /= Split.zero then
         let
@@ -537,7 +538,7 @@ encode inputs =
 encodeMaterialInput : MaterialInput -> Encode.Value
 encodeMaterialInput v =
     EU.optionalPropertiesObject
-        [ ( "country", v.country |> Maybe.map (.code >> Country.encodeCode) )
+        [ ( "country", v.country |> Maybe.map (.code >> CountryCode.encode) )
         , ( "material", Material.encode v.material |> Just )
         , ( "share", Split.encodeFloat v.share |> Just )
         , ( "spinning", v.spinning |> Maybe.map Spinning.encode )

--- a/src/Data/Textile/Material.elm
+++ b/src/Data/Textile/Material.elm
@@ -12,7 +12,7 @@ module Data.Textile.Material exposing
     , idToString
     )
 
-import Data.Country as Country
+import Data.Country.Code as CountryCode
 import Data.Process as Process exposing (Process)
 import Data.Split as Split exposing (Split)
 import Data.Textile.Material.Origin as Origin exposing (Origin)
@@ -25,7 +25,7 @@ import Json.Encode as Encode
 type alias Material =
     { alias : String
     , cffData : Maybe CFFData
-    , defaultCountry : Country.Code -- Default country for Material and Spinning steps
+    , defaultCountry : CountryCode.Code -- Default country for Material and Spinning steps
     , geographicOrigin : String -- A textual information about the geographic origin of the material
     , id : Id
     , name : String
@@ -87,6 +87,7 @@ getRecyclingData material materials =
 
 ---- Helpers
 
+
 findById : Id -> List Material -> Result String Material
 findById id =
     List.filter (.id >> (==) id)
@@ -99,7 +100,7 @@ decode processes =
     Decode.succeed Material
         |> JDP.required "alias" Decode.string
         |> JDP.required "cff" (Decode.maybe decodeCFFData)
-        |> JDP.required "defaultCountry" (Decode.string |> Decode.map Country.codeFromString)
+        |> JDP.required "defaultCountry" CountryCode.decode
         |> JDP.required "geographicOrigin" Decode.string
         |> JDP.required "id" decodeId
         |> JDP.required "name" Decode.string
@@ -124,7 +125,7 @@ encode : Material -> Encode.Value
 encode v =
     Encode.object
         [ ( "alias", Encode.string v.alias )
-        , ( "defaultCountry", v.defaultCountry |> Country.codeToString |> Encode.string )
+        , ( "defaultCountry", v.defaultCountry |> CountryCode.encode )
         , ( "id", encodeId v.id )
         , ( "geographicOrigin", Encode.string v.geographicOrigin )
         , ( "name", v.name |> Encode.string )

--- a/src/Data/Textile/Query.elm
+++ b/src/Data/Textile/Query.elm
@@ -26,7 +26,7 @@ import Base64
 import Data.Common.DecodeUtils as DU
 import Data.Common.EncodeUtils as EU
 import Data.Component as Component exposing (Item)
-import Data.Country as Country
+import Data.Country.Code as CountryCode
 import Data.Split as Split exposing (Split)
 import Data.Textile.Dyeing as Dyeing exposing (ProcessType)
 import Data.Textile.Economics as Economics
@@ -47,7 +47,7 @@ import Url.Parser as Parser exposing (Parser)
 
 
 type alias MaterialQuery =
-    { country : Maybe Country.Code
+    { country : Maybe CountryCode.Code
     , id : Material.Id
     , share : Split
     , spinning : Maybe Spinning
@@ -57,10 +57,10 @@ type alias MaterialQuery =
 type alias Query =
     { airTransportRatio : Maybe Split
     , business : Maybe Economics.Business
-    , countryDyeing : Maybe Country.Code
-    , countryFabric : Maybe Country.Code
-    , countryMaking : Maybe Country.Code
-    , countrySpinning : Maybe Country.Code
+    , countryDyeing : Maybe CountryCode.Code
+    , countryFabric : Maybe CountryCode.Code
+    , countryMaking : Maybe CountryCode.Code
+    , countrySpinning : Maybe CountryCode.Code
     , disabledSteps : List Label
     , dyeingProcessType : Maybe ProcessType
     , fabricProcess : Maybe Fabric
@@ -145,10 +145,10 @@ decode =
     Decode.succeed Query
         |> DU.strictOptional "airTransportRatio" Split.decodeFloat
         |> DU.strictOptional "business" Economics.decodeBusiness
-        |> DU.strictOptional "countryDyeing" Country.decodeCode
-        |> DU.strictOptional "countryFabric" Country.decodeCode
-        |> DU.strictOptional "countryMaking" Country.decodeCode
-        |> DU.strictOptional "countrySpinning" Country.decodeCode
+        |> DU.strictOptional "countryDyeing" CountryCode.decode
+        |> DU.strictOptional "countryFabric" CountryCode.decode
+        |> DU.strictOptional "countryMaking" CountryCode.decode
+        |> DU.strictOptional "countrySpinning" CountryCode.decode
         |> Pipe.optional "disabledSteps" (Decode.list Label.decodeFromCode) []
         |> DU.strictOptional "dyeingProcessType" Dyeing.decode
         |> DU.strictOptional "fabricProcess" Fabric.decode
@@ -172,7 +172,7 @@ decode =
 decodeMaterialQuery : Decoder MaterialQuery
 decodeMaterialQuery =
     Decode.succeed MaterialQuery
-        |> DU.strictOptional "country" Country.decodeCode
+        |> DU.strictOptional "country" CountryCode.decode
         |> Pipe.required "id" Material.decodeId
         |> Pipe.required "share" Split.decodeFloat
         |> DU.strictOptional "spinning" Spinning.decode
@@ -183,10 +183,10 @@ encode query =
     EU.optionalPropertiesObject
         [ ( "airTransportRatio", query.airTransportRatio |> Maybe.map Split.encodeFloat )
         , ( "business", query.business |> Maybe.map Economics.encodeBusiness )
-        , ( "countryDyeing", query.countryDyeing |> Maybe.map Country.encodeCode )
-        , ( "countryFabric", query.countryFabric |> Maybe.map Country.encodeCode )
-        , ( "countryMaking", query.countryMaking |> Maybe.map Country.encodeCode )
-        , ( "countrySpinning", query.countrySpinning |> Maybe.map Country.encodeCode )
+        , ( "countryDyeing", query.countryDyeing |> Maybe.map CountryCode.encode )
+        , ( "countryFabric", query.countryFabric |> Maybe.map CountryCode.encode )
+        , ( "countryMaking", query.countryMaking |> Maybe.map CountryCode.encode )
+        , ( "countrySpinning", query.countrySpinning |> Maybe.map CountryCode.encode )
         , ( "disabledSteps"
           , case query.disabledSteps of
                 [] ->
@@ -218,7 +218,7 @@ encode query =
 encodeMaterialQuery : MaterialQuery -> Encode.Value
 encodeMaterialQuery v =
     EU.optionalPropertiesObject
-        [ ( "country", v.country |> Maybe.map Country.encodeCode )
+        [ ( "country", v.country |> Maybe.map CountryCode.encode )
         , ( "id", Material.encodeId v.id |> Just )
         , ( "share", Split.encodeFloat v.share |> Just )
         , ( "spinning", v.spinning |> Maybe.map Spinning.encode )
@@ -366,11 +366,11 @@ updateProduct product query =
         query
 
 
-updateStepCountry : Label -> Country.Code -> Query -> Query
+updateStepCountry : Label -> CountryCode.Code -> Query -> Query
 updateStepCountry label code query =
     let
         maybeCode =
-            if code == Country.unknownCountryCode then
+            if code == CountryCode.unknown then
                 Nothing
 
             else
@@ -434,10 +434,10 @@ default =
     -- Note: the default query doesn't have any materials
     { airTransportRatio = Nothing
     , business = Nothing
-    , countryDyeing = Just (Country.Code "CN")
-    , countryFabric = Just (Country.Code "CN")
-    , countryMaking = Just (Country.Code "CN")
-    , countrySpinning = Just (Country.Code "CN")
+    , countryDyeing = Just (CountryCode.Code "CN")
+    , countryFabric = Just (CountryCode.Code "CN")
+    , countryMaking = Just (CountryCode.Code "CN")
+    , countrySpinning = Just (CountryCode.Code "CN")
     , disabledSteps = []
     , dyeingProcessType = Nothing
     , fabricProcess = Nothing

--- a/src/Data/Textile/Step.elm
+++ b/src/Data/Textile/Step.elm
@@ -24,6 +24,7 @@ module Data.Textile.Step exposing
 
 import Area exposing (Area)
 import Data.Country as Country exposing (Country)
+import Data.Country.Code as CountryCode
 import Data.Impact as Impact exposing (Impacts)
 import Data.Process as Process exposing (Process)
 import Data.Split as Split exposing (Split)
@@ -494,7 +495,7 @@ airTransportDisabled : Step -> Bool
 airTransportDisabled { country, enabled, label } =
     not enabled
         || -- Note: disallow air transport from France to France at the Making step
-           (label == Label.Making && country.code == Country.codeFromString "FR")
+           (label == Label.Making && country.code == CountryCode.fromString "FR")
 
 
 airTransportRatioToString : Split -> String

--- a/src/Data/Transport.elm
+++ b/src/Data/Transport.elm
@@ -14,7 +14,7 @@ module Data.Transport exposing
     , totalKm
     )
 
-import Data.Country as Country
+import Data.Country.Code as CountryCode
 import Data.Food.WellKnown exposing (WellKnown)
 import Data.Impact as Impact exposing (Impacts)
 import Data.Split as Split exposing (Split)
@@ -29,11 +29,11 @@ import Quantity
 
 
 type alias Distance =
-    AnyDict String Country.Code Transport
+    AnyDict String CountryCode.Code Transport
 
 
 type alias Distances =
-    AnyDict String Country.Code Distance
+    AnyDict String CountryCode.Code Distance
 
 
 type alias Transport =
@@ -172,8 +172,8 @@ roadSeaTransportRatio { road, sea } =
 
 getTransportBetween :
     Impacts
-    -> Country.Code
-    -> Country.Code
+    -> CountryCode.Code
+    -> CountryCode.Code
     -> Distances
     -> Transport
 getTransportBetween impacts cA cB distances =
@@ -232,8 +232,8 @@ decodeDistance : Decoder Distance
 decodeDistance =
     -- FIXME: Ideally we want to check for available country codes
     Dict.decode
-        (\str _ -> Country.codeFromString str)
-        Country.codeToString
+        (\str _ -> CountryCode.fromString str)
+        CountryCode.toString
         decode
 
 
@@ -241,6 +241,6 @@ decodeDistances : Decoder Distances
 decodeDistances =
     -- FIXME: Ideally we want to check for available country codes
     Dict.decode
-        (\str _ -> Country.codeFromString str)
-        Country.codeToString
+        (\str _ -> CountryCode.fromString str)
+        CountryCode.toString
         decodeDistance

--- a/src/Page/Explore.elm
+++ b/src/Page/Explore.elm
@@ -14,6 +14,7 @@ import Browser.Events
 import Browser.Navigation as Nav
 import Data.Component as Component exposing (Component)
 import Data.Country as Country exposing (Country)
+import Data.Country.Code as CountryCode
 import Data.Dataset as Dataset exposing (Dataset)
 import Data.Example as Example exposing (Example)
 import Data.Food.Db as FoodDb
@@ -263,7 +264,7 @@ countriesExplorer :
     -> Table.Config Country Msg
     -> SortableTable.State
     -> Scope
-    -> Maybe Country.Code
+    -> Maybe CountryCode.Code
     -> List (Html Msg)
 countriesExplorer { distances, countries } tableConfig tableState scope maybeCode =
     [ countries

--- a/src/Page/Explore/Countries.elm
+++ b/src/Page/Explore/Countries.elm
@@ -1,6 +1,7 @@
 module Page.Explore.Countries exposing (table)
 
 import Data.Country as Country exposing (Country)
+import Data.Country.Code as CountryCode
 import Data.Dataset as Dataset
 import Data.Gitbook as Gitbook
 import Data.Process as Process
@@ -21,22 +22,22 @@ import Views.Link as Link
 table : Transport.Distances -> List Country.Country -> { detailed : Bool, scope : Scope } -> Table Country String msg
 table distances countries { detailed, scope } =
     { filename = "countries"
-    , toId = .code >> Country.codeToString
+    , toId = .code >> CountryCode.toString
     , toRoute = .code >> Just >> Dataset.Countries >> Route.Explore scope
     , legend = []
     , columns =
         List.filterMap identity
             [ Just
                 { label = "Code"
-                , toValue = Table.StringValue <| .code >> Country.codeToString
+                , toValue = Table.StringValue <| .code >> CountryCode.toString
                 , toCell =
                     \country ->
                         if detailed then
-                            code [] [ text (Country.codeToString country.code) ]
+                            code [] [ text (CountryCode.toString country.code) ]
 
                         else
                             a [ Route.href (Route.Explore scope (Dataset.Countries (Just country.code))) ]
-                                [ code [] [ text (Country.codeToString country.code) ] ]
+                                [ code [] [ text (CountryCode.toString country.code) ] ]
                 }
             , Just
                 { label = "Nom"
@@ -107,13 +108,13 @@ displayDistances countries distances country =
             text ""
 
 
-distancesToRows : List Country.Country -> Country.Code -> Transport.Transport -> List (Html msg) -> List (Html msg)
+distancesToRows : List Country.Country -> CountryCode.Code -> Transport.Transport -> List (Html msg) -> List (Html msg)
 distancesToRows countries countryCode transport rows =
     rows
         |> (::) (transportToRow countryCode countries transport)
 
 
-transportToRow : Country.Code -> List Country.Country -> Transport.Transport -> Html msg
+transportToRow : CountryCode.Code -> List Country.Country -> Transport.Transport -> Html msg
 transportToRow countryCode countries transport =
     let
         formatDistance length =
@@ -130,7 +131,7 @@ transportToRow countryCode countries transport =
                 |> Result.withDefault ""
                 |> title
             ]
-            [ text <| Country.codeToString countryCode ]
+            [ text <| CountryCode.toString countryCode ]
         , td [] [ formatDistance transport.air ]
         , td [] [ formatDistance transport.road ]
         , td [] [ formatDistance transport.sea ]

--- a/src/Page/Object.elm
+++ b/src/Page/Object.elm
@@ -14,7 +14,7 @@ import Browser.Events
 import Browser.Navigation as Navigation
 import Data.Bookmark as Bookmark exposing (Bookmark)
 import Data.Component as Component exposing (Component, Index, TargetElement, TargetItem)
-import Data.Country as Country
+import Data.Country.Code as CountryCode
 import Data.Dataset as Dataset
 import Data.Env as Env
 import Data.Example as Example exposing (Example)
@@ -103,7 +103,7 @@ type Msg
     | SwitchImpactsTab ImpactTabs.Tab
     | ToggleComparedSimulation Bookmark Bool
     | UpdateBookmarkName String
-    | UpdateComponentItemCountry Index (Maybe Country.Code)
+    | UpdateComponentItemCountry Index (Maybe CountryCode.Code)
     | UpdateComponentItemName TargetItem String
     | UpdateComponentItemQuantity Index Component.Quantity
     | UpdateDurability (Result String Unit.Ratio)

--- a/src/Page/Textile.elm
+++ b/src/Page/Textile.elm
@@ -16,7 +16,7 @@ import Browser.Navigation as Navigation
 import Data.AutocompleteSelector as AutocompleteSelector
 import Data.Bookmark as Bookmark exposing (Bookmark)
 import Data.Component as Component exposing (Component, Index)
-import Data.Country as Country
+import Data.Country.Code as CountryCode
 import Data.Dataset as Dataset
 import Data.Example as Example
 import Data.Gitbook as Gitbook
@@ -148,7 +148,7 @@ type Msg
     | UpdatePhysicalDurability (Maybe Unit.PhysicalDurability)
     | UpdatePrice (Maybe Economics.Price)
     | UpdatePrinting (Maybe Printing)
-    | UpdateStepCountry Label Country.Code
+    | UpdateStepCountry Label CountryCode.Code
     | UpdateSurfaceMass (Maybe Unit.SurfaceMass)
     | UpdateTrimQuantity Index Component.Quantity
     | UpdateUpcycled Bool

--- a/src/Server.elm
+++ b/src/Server.elm
@@ -6,7 +6,8 @@ port module Server exposing
     )
 
 import Data.Component as Component exposing (Component)
-import Data.Country as Country exposing (Country)
+import Data.Country exposing (Country)
+import Data.Country.Code as CountryCode
 import Data.Food.Ingredient as Ingredient
 import Data.Food.Origin as Origin
 import Data.Food.Query as FoodQuery
@@ -169,7 +170,7 @@ executeTextileQuery request db encoder query =
 encodeCountry : Country -> Encode.Value
 encodeCountry { code, name } =
     Encode.object
-        [ ( "code", Country.encodeCode code )
+        [ ( "code", CountryCode.encode code )
         , ( "name", Encode.string name )
         ]
 

--- a/src/Views/BaseElement.elm
+++ b/src/Views/BaseElement.elm
@@ -3,6 +3,7 @@ module Views.BaseElement exposing (Config, deleteItemButton, view)
 import Autocomplete exposing (Autocomplete)
 import Data.AutocompleteSelector as AutocompleteSelector
 import Data.Country as Country exposing (Country)
+import Data.Country.Code as CountryCode
 import Data.Impact exposing (Impacts)
 import Data.Impact.Definition exposing (Definition, Definitions)
 import Html exposing (..)
@@ -82,7 +83,7 @@ view ({ baseElement, db, impact } as config) =
             (\{ code, name } ->
                 option
                     [ selected (Maybe.map .code baseElement.country == Just code)
-                    , value <| Country.codeToString code
+                    , value <| CountryCode.toString code
                     ]
                     [ text name ]
             )
@@ -101,7 +102,7 @@ view ({ baseElement, db, impact } as config) =
                         { baseElement
                             | country =
                                 if val /= "" then
-                                    Country.codeFromString val
+                                    CountryCode.fromString val
                                         |> (\countryCode -> Country.findByCode countryCode db.countries)
                                         |> Result.toMaybe
 

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -17,7 +17,8 @@ import Data.Component as Component
         , TargetElement
         , TargetItem
         )
-import Data.Country as Country exposing (Country)
+import Data.Country exposing (Country)
+import Data.Country.Code as CountryCode
 import Data.Impact as Impact
 import Data.Impact.Definition as Definition exposing (Definition)
 import Data.Process as Process exposing (Process)
@@ -63,7 +64,7 @@ type alias Config db msg =
     , setDetailed : List Index -> msg
     , title : String
     , updateElementAmount : TargetElement -> Maybe Amount -> msg
-    , updateItemCountry : Index -> Maybe Country.Code -> msg
+    , updateItemCountry : Index -> Maybe CountryCode.Code -> msg
     , updateItemName : TargetItem -> String -> msg
     , updateItemQuantity : Index -> Quantity -> msg
     }
@@ -202,7 +203,7 @@ componentView config itemIndex item { component, country, elements, quantity } i
                                         (\( name, maybeCode ) ->
                                             option
                                                 [ maybeCode
-                                                    |> Maybe.map Country.codeToString
+                                                    |> Maybe.map CountryCode.toString
                                                     |> Maybe.withDefault ""
                                                     |> value
                                                 , selected <| Maybe.map .code country == maybeCode
@@ -218,7 +219,7 @@ componentView config itemIndex item { component, country, elements, quantity } i
                                                         Nothing
 
                                                      else
-                                                        Just <| Country.codeFromString str
+                                                        Just <| CountryCode.fromString str
                                                     )
                                         ]
                                 ]

--- a/src/Views/CountrySelect.elm
+++ b/src/Views/CountrySelect.elm
@@ -1,6 +1,7 @@
 module Views.CountrySelect exposing (view)
 
-import Data.Country as Country exposing (Country)
+import Data.Country exposing (Country)
+import Data.Country.Code as CountryCode
 import Data.Scope as Scope exposing (Scope)
 import Html exposing (..)
 import Html.Attributes exposing (..)
@@ -10,9 +11,9 @@ import Html.Events exposing (..)
 type alias Config msg =
     { attributes : List (Attribute msg)
     , countries : List Country
-    , onSelect : Country.Code -> msg
+    , onSelect : CountryCode.Code -> msg
     , scope : Scope
-    , selectedCountry : Country.Code
+    , selectedCountry : CountryCode.Code
     }
 
 
@@ -25,13 +26,13 @@ view { attributes, countries, onSelect, scope, selectedCountry } =
             (\{ code, name } ->
                 option
                     [ selected (selectedCountry == code)
-                    , value <| Country.codeToString code
+                    , value <| CountryCode.toString code
                     ]
                     [ text name ]
             )
         |> select
             (class
                 "form-select"
-                :: onInput (Country.codeFromString >> onSelect)
+                :: onInput (CountryCode.fromString >> onSelect)
                 :: attributes
             )

--- a/src/Views/Textile/Step.elm
+++ b/src/Views/Textile/Step.elm
@@ -2,7 +2,7 @@ module Views.Textile.Step exposing (view)
 
 import Autocomplete exposing (Autocomplete)
 import Data.AutocompleteSelector as AutocompleteSelector
-import Data.Country as Country
+import Data.Country.Code as CountryCode
 import Data.Dataset as Dataset
 import Data.Env as Env
 import Data.Gitbook as Gitbook
@@ -65,7 +65,7 @@ type alias Config msg modal =
     , toggleFading : Bool -> msg
     , toggleStep : Label -> msg
     , updateAirTransportRatio : Maybe Split -> msg
-    , updateCountry : Label -> Country.Code -> msg
+    , updateCountry : Label -> CountryCode.Code -> msg
     , updateDyeingProcessType : ProcessType -> msg
     , updateFabricProcess : Fabric -> msg
     , updateMakingComplexity : MakingComplexity -> msg
@@ -92,7 +92,7 @@ countryField { current, db, updateCountry } =
                 { attributes =
                     [ class "form-select"
                     , disabled (not current.enabled)
-                    , onInput (Country.codeFromString >> updateCountry current.label)
+                    , onInput (CountryCode.fromString >> updateCountry current.label)
                     ]
                 , countries = db.countries
                 , onSelect = updateCountry current.label

--- a/tests/Data/Food/RecipeTest.elm
+++ b/tests/Data/Food/RecipeTest.elm
@@ -1,6 +1,6 @@
 module Data.Food.RecipeTest exposing (..)
 
-import Data.Country as Country
+import Data.Country.Code as CountryCode
 import Data.Example
 import Data.Food.Ingredient as Ingredient
 import Data.Food.Preparation as Preparation
@@ -297,7 +297,7 @@ suite =
                             |> Result.map firstIngredientAirDistance
                             |> Expect.equal (Ok (Just 18000))
                             |> asTest "should have air transport for mango from its default origin"
-                        , { ingredients = [ { mango | country = Just (Country.codeFromString "CN"), planeTransport = Ingredient.ByPlane } ]
+                        , { ingredients = [ { mango | country = Just (CountryCode.fromString "CN"), planeTransport = Ingredient.ByPlane } ]
                           , transform = Nothing
                           , packaging = []
                           , distribution = Just Retail.ambient
@@ -307,7 +307,7 @@ suite =
                             |> Result.map firstIngredientAirDistance
                             |> Expect.equal (Ok (Just 8189))
                             |> asTest "should always have air transport for mango even from other countries if 'planeTransport' is 'byPlane'"
-                        , { ingredients = [ { mango | country = Just (Country.codeFromString "CN"), planeTransport = Ingredient.NoPlane } ]
+                        , { ingredients = [ { mango | country = Just (CountryCode.fromString "CN"), planeTransport = Ingredient.NoPlane } ]
                           , transform = Nothing
                           , packaging = []
                           , distribution = Just Retail.ambient

--- a/tests/Data/Textile/InputsTest.elm
+++ b/tests/Data/Textile/InputsTest.elm
@@ -1,6 +1,6 @@
 module Data.Textile.InputsTest exposing (..)
 
-import Data.Country as Country
+import Data.Country.Code as CountryCode
 import Data.Split as Split
 import Data.Textile.Inputs as Inputs
 import Data.Textile.Material as Material
@@ -21,21 +21,21 @@ suite =
                     tShirtCotonFrance
                     (\query ->
                         [ { query
-                            | countryFabric = Just (Country.Code "CN")
-                            , countryDyeing = Just (Country.Code "CN")
-                            , countryMaking = Just (Country.Code "CN")
+                            | countryFabric = Just (CountryCode.Code "CN")
+                            , countryDyeing = Just (CountryCode.Code "CN")
+                            , countryMaking = Just (CountryCode.Code "CN")
                           }
                             |> Inputs.fromQuery db
                             |> Result.map Inputs.countryList
                             |> Result.andThen (LE.getAt 0 >> Maybe.map .code >> Result.fromMaybe "")
-                            |> Expect.equal (Ok (Country.codeFromString "CN"))
+                            |> Expect.equal (Ok (CountryCode.fromString "CN"))
                             |> asTest "replace the first country with the material's default country"
                         ]
                     )
                 , { default
-                    | countryFabric = Just (Country.Code "XX")
-                    , countryDyeing = Just (Country.Code "CN")
-                    , countryMaking = Just (Country.Code "CN")
+                    | countryFabric = Just (CountryCode.Code "XX")
+                    , countryDyeing = Just (CountryCode.Code "CN")
+                    , countryMaking = Just (CountryCode.Code "CN")
                   }
                     |> Inputs.fromQuery db
                     |> Expect.equal (Err "Code pays invalide: XX.")

--- a/tests/Data/Textile/LifeCycleTest.elm
+++ b/tests/Data/Textile/LifeCycleTest.elm
@@ -1,6 +1,6 @@
 module Data.Textile.LifeCycleTest exposing (..)
 
-import Data.Country as Country
+import Data.Country.Code as CountryCode
 import Data.Textile.Inputs as Inputs
 import Data.Textile.LifeCycle as LifeCycle exposing (LifeCycle)
 import Data.Textile.Query exposing (Query)
@@ -43,9 +43,9 @@ suite =
                             |> Result.map
                                 (\query ->
                                     { query
-                                        | countryFabric = Just (Country.Code "FR")
-                                        , countryDyeing = Just (Country.Code "IN") -- Ennoblement in India
-                                        , countryMaking = Just (Country.Code "FR")
+                                        | countryFabric = Just (CountryCode.Code "FR")
+                                        , countryDyeing = Just (CountryCode.Code "IN") -- Ennoblement in India
+                                        , countryMaking = Just (CountryCode.Code "FR")
                                     }
                                 )
                   in

--- a/tests/Data/Textile/QueryTest.elm
+++ b/tests/Data/Textile/QueryTest.elm
@@ -1,6 +1,6 @@
 module Data.Textile.QueryTest exposing (..)
 
-import Data.Country as Country
+import Data.Country.Code as CountryCode
 import Data.Split as Split
 import Data.Textile.Inputs as Inputs
 import Data.Textile.MakingComplexity as MakingComplexity
@@ -21,7 +21,7 @@ sampleQuery =
                     [ { id = polyesterId
                       , share = Split.full
                       , spinning = Nothing
-                      , country = Just (Country.Code "CN")
+                      , country = Just (CountryCode.Code "CN")
                       }
                     ]
             }
@@ -124,16 +124,16 @@ suite =
                     (Material.idFromString "73ef624d-250e-4a9a-af5d-43505b21b527")
                     (\cottonId syntheticId ->
                         [ [ { id = cottonId
-                                  , share = Split.half
-                                  , spinning = Nothing
-                                  , country = Nothing
-                                  }
-                                , { id = syntheticId
-                                  , share = Split.half
-                                  , spinning = Nothing
-                                  , country = Nothing
-                                  }
-                                ]
+                            , share = Split.half
+                            , spinning = Nothing
+                            , country = Nothing
+                            }
+                          , { id = syntheticId
+                            , share = Split.half
+                            , spinning = Nothing
+                            , country = Nothing
+                            }
+                          ]
                             |> Query.validateMaterials
                             |> Expect.ok
                             |> asTest "validates complete sum of materials"
@@ -146,21 +146,21 @@ suite =
                     (Material.idFromString "62a4d6fb-3276-4ba5-93a3-889ecd3bff84")
                     (\polyesterId polypropyleneId cottonId ->
                         [ [ { id = polyesterId
-                                  , share = Split.sixty
-                                  , spinning = Nothing
-                                  , country = Nothing
-                                  }
-                                , { id = polypropyleneId
-                                  , share = Split.thirty
-                                  , spinning = Nothing
-                                  , country = Nothing
-                                  }
-                                  , { id = cottonId
-                                  , share = Split.tenth
-                                  , spinning = Nothing
-                                  , country = Nothing
-                                  }
-                                ]
+                            , share = Split.sixty
+                            , spinning = Nothing
+                            , country = Nothing
+                            }
+                          , { id = polypropyleneId
+                            , share = Split.thirty
+                            , spinning = Nothing
+                            , country = Nothing
+                            }
+                          , { id = cottonId
+                            , share = Split.tenth
+                            , spinning = Nothing
+                            , country = Nothing
+                            }
+                          ]
                             |> Query.validateMaterials
                             |> Expect.ok
                             |> asTest "validates complete sum of materials with rounding error"

--- a/tests/Data/Textile/SimulatorTest.elm
+++ b/tests/Data/Textile/SimulatorTest.elm
@@ -1,7 +1,7 @@
 module Data.Textile.SimulatorTest exposing (..)
 
 import Data.Component as Component
-import Data.Country as Country
+import Data.Country.Code as CountryCode
 import Data.Impact as Impact
 import Data.Impact.Definition as Definition
 import Data.Split as Split
@@ -173,7 +173,7 @@ suite =
                 , suiteFromResult "should be full for products not coming from Europe or Turkey"
                     tShirtCotonFrance
                     (\query ->
-                        [ { query | countryMaking = Just (Country.Code "CN") }
+                        [ { query | countryMaking = Just (CountryCode.Code "CN") }
                             |> computeWithDefaultComponentConfig db
                             |> Result.map (.lifeCycle >> LifeCycle.getStepProp Label.Making .airTransportRatio Split.half)
                             |> Expect.equal (Ok Split.full)
@@ -189,7 +189,7 @@ suite =
                                     | numberOfReferences = Just 10
                                     , price = Just <| Economics.priceFromFloat 100
                                     , physicalDurability = Just <| Unit.physicalDurability 1.1
-                                    , countryMaking = Just (Country.Code "CN")
+                                    , countryMaking = Just (CountryCode.Code "CN")
                                 }
                         in
                         [ tShirtCotonWithSmallerPhysicalDurabilityCn
@@ -203,7 +203,7 @@ suite =
                     tShirtCotonFrance
                     (\query ->
                         [ { query
-                            | countryMaking = Just (Country.Code "CN")
+                            | countryMaking = Just (CountryCode.Code "CN")
                             , airTransportRatio = Just Split.two
                           }
                             |> computeWithDefaultComponentConfig db

--- a/tests/Data/TransportTest.elm
+++ b/tests/Data/TransportTest.elm
@@ -1,6 +1,6 @@
 module Data.TransportTest exposing (..)
 
-import Data.Country as Country
+import Data.Country.Code as CountryCode
 import Data.Impact as Impact exposing (Impacts)
 import Data.Transport as Transport exposing (Transport, getTransportBetween)
 import Dict.Any as AnyDict
@@ -38,16 +38,16 @@ suite =
                         AnyDict.keys db.distances
                             |> List.member code
                             |> Expect.equal True
-                            |> asTest ("Country " ++ Country.codeToString code ++ " should have transports data available")
+                            |> asTest ("Country " ++ CountryCode.toString code ++ " should have transports data available")
                     )
                 |> describe "transports data availability checks"
             , describe "getTransportBetween"
                 [ db.distances
-                    |> Transport.getTransportBetween Impact.empty (Country.Code "FR") (Country.Code "CN")
+                    |> Transport.getTransportBetween Impact.empty (CountryCode.Code "FR") (CountryCode.Code "CN")
                     |> Expect.equal (franceChina Impact.empty)
                     |> asTest "should retrieve distance between two countries"
                 , db.distances
-                    |> Transport.getTransportBetween Impact.empty (Country.Code "CN") (Country.Code "FR")
+                    |> Transport.getTransportBetween Impact.empty (CountryCode.Code "CN") (CountryCode.Code "FR")
                     |> Expect.equal (franceChina Impact.empty)
                     |> asTest "should retrieve distance between two swapped countries"
                 , db.countries

--- a/tests/Server/RouteTest.elm
+++ b/tests/Server/RouteTest.elm
@@ -1,7 +1,7 @@
 module Server.RouteTest exposing (..)
 
 import Data.Component as Component
-import Data.Country as Country
+import Data.Country.Code as CountryCode
 import Data.Example as Example
 import Data.Food.Preparation as Preparation
 import Data.Food.Query as FoodQuery
@@ -71,7 +71,7 @@ foodEndpoints db =
                 , FoodQuery.encode
                     { royalPizza
                         | ingredients =
-                            royalPizza.ingredients |> List.map (\i -> { i | country = Just <| Country.Code "XX" })
+                            royalPizza.ingredients |> List.map (\i -> { i | country = Just <| CountryCode.Code "XX" })
                     }
                     |> testFoodEndpoint db
                     |> expectFoodValidationError "ingredients" "Code pays invalide: XX."
@@ -79,7 +79,7 @@ foodEndpoints db =
                 , FoodQuery.encode
                     { royalPizza
                         | ingredients =
-                            royalPizza.ingredients |> List.map (\i -> { i | country = Just <| Country.Code "BD" })
+                            royalPizza.ingredients |> List.map (\i -> { i | country = Just <| CountryCode.Code "BD" })
                     }
                     |> testFoodEndpoint db
                     |> expectFoodValidationError "ingredients" "Le code pays BD n'est pas utilisable dans un contexte Alimentaire."
@@ -168,7 +168,7 @@ textileEndpoints db =
             (\query ->
                 [ TextileQuery.encode
                     { query
-                        | countrySpinning = Just (Country.Code "invalid")
+                        | countrySpinning = Just (CountryCode.Code "invalid")
                     }
                     |> testTextileEndpoint db
                     |> expectTextileValidationError "countrySpinning" "Code pays invalide: invalid."
@@ -186,7 +186,7 @@ textileEndpoints db =
                             [ { id = decodedId
                               , share = Split.full
                               , spinning = Nothing
-                              , country = Just (Country.Code "invalid")
+                              , country = Just (CountryCode.Code "invalid")
                               }
                             ]
                     }
@@ -240,7 +240,7 @@ textileEndpoints db =
                             [ { id = decodedId
                               , share = Split.full
                               , spinning = Nothing
-                              , country = Just (Country.Code "NotACountryCode")
+                              , country = Just (CountryCode.Code "NotACountryCode")
                               }
                             ]
                     }
@@ -254,7 +254,7 @@ textileEndpoints db =
             (\query ->
                 [ TextileQuery.encode
                     { query
-                        | countryDyeing = Just <| Country.Code "US"
+                        | countryDyeing = Just <| CountryCode.Code "US"
                     }
                     |> testTextileEndpoint db
                     |> expectTextileValidationError "countryDyeing" "Le code pays US n'est pas utilisable dans un contexte Textile."

--- a/tests/TestUtils.elm
+++ b/tests/TestUtils.elm
@@ -13,7 +13,7 @@ module TestUtils exposing
     , tShirtCotonFrance
     )
 
-import Data.Country as Country
+import Data.Country.Code as CountryCode
 import Data.Impact as Impact exposing (Impacts)
 import Data.Impact.Definition as Definition exposing (Trigrams)
 import Data.Process as Process
@@ -175,9 +175,9 @@ tShirtCotonFrance =
         |> Result.map
             (\query ->
                 { query
-                    | countryDyeing = Just (Country.Code "FR")
-                    , countryFabric = Just (Country.Code "FR")
-                    , countryMaking = Just (Country.Code "FR")
-                    , countrySpinning = Just (Country.Code "FR")
+                    | countryDyeing = Just (CountryCode.Code "FR")
+                    , countryFabric = Just (CountryCode.Code "FR")
+                    , countryMaking = Just (CountryCode.Code "FR")
+                    , countrySpinning = Just (CountryCode.Code "FR")
                 }
             )


### PR DESCRIPTION
## :wrench: Problem

The recently introduced `Process.location` field is typed as a `String` (see #1507), while we have `Country.Code` which carries the same information and could be statically checked and dynamically validated when parsing databases.

## :cake: Solution

Make the `location` field of the `Process` record type a `Country.Code`

## :rotating_light:  Points to watch/comments

- To avoid circular `Process <-> Country` imports (which are forbidden in Elm), the `Country.Code` type has been moved to its won dedicated `Data.Country.Code` module.
- This work is unrelated to the broader goal of renaming "countries" to "regions" everywhere applicable.

## :desert_island: How to test

- [ ] tests are green
- [ ] no functional regression
- [ ] explorer show full country/region names in explorer (see capture)
<img width="2851" height="1575" alt="image" src="https://github.com/user-attachments/assets/ecf0f69b-34ef-4694-a359-8eef62e147a1" />
