### PR TITLE
fix: don’t hardcode backend URL

### DIFF
--- a/server.js
+++ b/server.js
@@ -25,10 +25,10 @@ const expressPort = 8001;
 // Env vars
 const {
   ENABLE_FOOD_SECTION,
+  INTERNAL_BACKEND_URL,
   NODE_ENV,
   RATELIMIT_MAX_RPM,
   RATELIMIT_WHITELIST,
-  INTERNAL_BACKEND_URL,
 } = process.env;
 
 const app = express(); // web app


### PR DESCRIPTION
## :wrench: Problem

Token validation doesn’t work on textile stable because the node JS server tries to call the local backend that doesn’t exists.

## :cake: Solution

Use an environment variable to fetch the backend URL and set it to `https://ecobalyse-staging-pr1474.osc-fr1.scalingo.io/backend`

## :desert_island: How to test

> _What someone else than you should do to validate that the solution you implemented is working as expected. Don't hesitate to be too verbose and to explain in details, using bullet points for example, the steps to follow to test the expected behavior._
