### PR TITLE
fix: remove pkill requirement

### DIFF
--- a/bin/start.sh
+++ b/bin/start.sh
@@ -7,7 +7,7 @@ npm run server:start & SERVER_PID=$!
 bin/run             & NGINX_PID=$!
 
 # on SIGTERM kill the children we started
-trap 'kill -TERM "$SERVER_PID" "$NGINX_PID" 2>/dev/null' SIGTERM
+trap 'kill -TERM "$SERVER_PID" "$NGINX_PID"' SIGTERM
 
 # wait for the first job to finish
 wait -n


### PR DESCRIPTION
## :wrench: Problem

When deploying the textile app on the new Scalingo 24 slim stack, we have a deploy error because `pkill` is missing on the slim stack.

## :cake: Solution

Don’t use `pkill` and rely only on `kill` by remembering the PIDs.

## :desert_island: How to test

Deploy should be ok and we should have no errors in the scalingo logs.