### PR TITLE
ci: cache elm deps

### DIFF
--- a/.github/workflows/create_release_archive.yml
+++ b/.github/workflows/create_release_archive.yml
@@ -1,11 +1,10 @@
 name: Create release archive
 
 env:
-  ELM_HOME: ".elm"
+  TRANSCRYPT_KEY: ${{ secrets.TRANSCRYPT_KEY }}
   ENCRYPTION_KEY: ${{ secrets.ENCRYPTION_KEY }}
   ENABLE_FOOD_SECTION: "True"
   ENABLE_OBJECTS_SECTION: "True"
-  TRANSCRYPT_KEY: ${{ secrets.TRANSCRYPT_KEY }}
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## :wrench: Problem

Lots of builds are failing due to connectivity issues to the elm package registry.

## :cake: Solution

Use cache when building the release the same way it’s done for tests.

## :desert_island: How to test

CI should be green
