### PR TITLE
feat(admin,ux): render comment column in component admin

### DIFF
--- a/src/Page/Admin/Component.elm
+++ b/src/Page/Admin/Component.elm
@@ -445,7 +445,13 @@ componentRowView db selected component =
             ]
         , td
             [ class "align-middle cursor-help"
-            , component.comment |> Maybe.withDefault "Sans commentaire" |> title
+            , title <|
+                Maybe.withDefault "Sans commentaire" component.comment
+                    ++ "\nComposition: "
+                    ++ (component
+                            |> Component.elementsToString db
+                            |> Result.withDefault "N/A"
+                       )
             ]
             [ div [ class "w-100 text-truncate", style "max-width" "400px" ]
                 [ component.comment


### PR DESCRIPTION
## :wrench: Problem

[source](https://mattermost.incubateur.net/fabnum-mte/pl/eycqn8jibpgu7yjmfkosdrccto)

> Alban 
> Question => quel est l'intérêt d'afficher par défaut les informations actuellement présentes dans le champ "Description" de l'Admin des Composants ? 
>
>Deux remarques : 
>1) il me semble que ces informations n'apportent pas grand chose
>2) je trouverais plus adapté d'afficher, lorsqu'il y en a, les information du champ "Commentaire" de chaque composant.

<img width="1437" height="547" alt="image" src="https://github.com/user-attachments/assets/8b79a857-79f8-4af2-aeee-a635221f6be3" />

## :cake: Solution

<img width="2694" height="1521" alt="image" src="https://github.com/user-attachments/assets/71468b12-df65-45ae-b4a7-1ef18c57e930" />
