### PR TITLE
fix: revert bookmarks local storage update

### DIFF
--- a/src/Page/Food.elm
+++ b/src/Page/Food.elm
@@ -367,7 +367,7 @@ update ({ db, queries } as session) msg model =
                     { model | bookmarkBeingRenamed = Nothing }
                         |> createPageUpdate
                             (session
-                                |> Session.replaceBookmark bookmark
+                                |> Session.renameBookmark bookmark
                             )
 
                 Nothing ->
@@ -576,7 +576,6 @@ selectIngredient autocompleteState pageUpdate =
 findExistingBookmarkName : Session -> Query -> String
 findExistingBookmarkName { db, store } query =
     store.bookmarks
-        |> Bookmark.onlyValid
         |> Bookmark.findByFoodQuery query
         |> Maybe.map .name
         |> Maybe.withDefault

--- a/src/Page/Object.elm
+++ b/src/Page/Object.elm
@@ -220,7 +220,6 @@ suggestBookmarkName { db, store } examples query =
         -- Existing user bookmark?
         userBookmark =
             store.bookmarks
-                |> Bookmark.onlyValid
                 |> Bookmark.findByObjectQuery query
 
         -- Matching product example name?
@@ -397,7 +396,7 @@ update ({ navKey } as session) msg model =
                     { model | bookmarkBeingRenamed = Nothing }
                         |> createPageUpdate
                             (session
-                                |> Session.replaceBookmark bookmark
+                                |> Session.renameBookmark bookmark
                             )
 
                 Nothing ->

--- a/src/Page/Textile.elm
+++ b/src/Page/Textile.elm
@@ -259,7 +259,6 @@ suggestBookmarkName { db, store } query =
         -- Existing user bookmark?
         userBookmark =
             store.bookmarks
-                |> Bookmark.onlyValid
                 |> Bookmark.findByTextileQuery query
 
         -- Matching product example name?
@@ -431,7 +430,7 @@ update ({ db, queries, navKey } as session) msg model =
                     { model | bookmarkBeingRenamed = Nothing }
                         |> createPageUpdate
                             (session
-                                |> Session.replaceBookmark bookmark
+                                |> Session.renameBookmark bookmark
                             )
 
                 Nothing ->

--- a/src/Views/Bookmark.elm
+++ b/src/Views/Bookmark.elm
@@ -400,7 +400,6 @@ queryFromScope session scope =
 scopedBookmarks : Session -> Scope -> List Bookmark
 scopedBookmarks session scope =
     session.store.bookmarks
-        |> Bookmark.onlyValid
         |> List.filter
             (case scope of
                 Scope.Food ->

--- a/src/Views/Comparator.elm
+++ b/src/Views/Comparator.elm
@@ -80,7 +80,6 @@ sidebarView config =
         , button [ class "btn btn-sm btn-link pt-0", onClick config.selectNone ] [ text "tout désélectionner" ]
         ]
     , config.session.store.bookmarks
-        |> Bookmark.onlyValid
         |> List.map
             (\bookmark ->
                 let
@@ -196,7 +195,6 @@ comparatorView ({ session } as config) =
     let
         charts =
             session.store.bookmarks
-                |> Bookmark.onlyValid
                 |> List.filterMap
                     (\bookmark ->
                         if Set.member (Bookmark.toId bookmark) session.store.comparedSimulations then

--- a/src/Views/Page.elm
+++ b/src/Views/Page.elm
@@ -563,10 +563,7 @@ notificationView { session, toMsg } notification =
                 { attributes = []
                 , close = Nothing
                 , content =
-                    [ p [ class "fw-bold mb-2" ] [ text "Vos précédente session n'a pas pu être récupérée et doit être réinitialisée." ]
-                    , p [ class "fs-7 d-flex align-items-baseline gap-1" ]
-                        [ text "ⓘ Cela se produit généralement lorsque de nouvelles fonctionnalités ou correctifs appliqués introduisent des incompatibilités avec le format de ces données."
-                        ]
+                    [ p [] [ text "Votre précédente session n'a pas pu être récupérée, elle doit donc être réinitialisée." ]
                     , p []
                         [ button
                             [ class "btn btn-primary"
@@ -574,14 +571,13 @@ notificationView { session, toMsg } notification =
                             ]
                             [ text "D’accord, réinitialiser la session" ]
                         ]
-                    , details [ class "fs-8" ]
+                    , details []
                         [ summary [] [ text "Afficher les détails techniques de l'erreur" ]
-                        , pre [ class "card p-2 mt-2 bg-light" ]
-                            [ code [] [ text <| Decode.errorToString decodeError ] ]
+                        , pre [] [ text <| Decode.errorToString decodeError ]
                         ]
                     ]
-                , level = Alert.Info
-                , title = Just "Problème de récupération de la session"
+                , level = Alert.Warning
+                , title = Just "Erreur de récupération de session"
                 }
 
 

--- a/tests/Data/BookmarkTest.elm
+++ b/tests/Data/BookmarkTest.elm
@@ -1,97 +1,34 @@
 module Data.BookmarkTest exposing (..)
 
-import Data.Bookmark as Bookmark
 import Data.Session as Session
 import Expect
 import Test exposing (..)
-import TestUtils exposing (it)
+import TestUtils exposing (asTest)
 
 
 suite : Test
 suite =
     describe "Data.Session"
         [ describe "bookmarks should"
-            [ it "be moved correctly from top to bottom"
+            [ asTest "be moved correctly from top to bottom"
                 ([ 1, 2, 3, 4 ]
                     |> Session.moveListElement 1 3
                     |> Expect.equal [ 2, 3, 1, 4 ]
                 )
-            , it "be moved correctly from bottom to top"
+            , asTest "be moved correctly from bottom to top"
                 ([ 1, 2, 3, 4 ]
                     |> Session.moveListElement 3 1
                     |> Expect.equal [ 3, 1, 2, 4 ]
                 )
-            , it "not be moved if there is nothing to move"
+            , asTest "not be moved if there is nothing to move"
                 ([ 1, 2, 3, 4 ]
                     |> Session.moveListElement 1 1
                     |> Expect.equal [ 1, 2, 3, 4 ]
                 )
-            , it "not be moved if indexes are out of bounds"
+            , asTest "not be moved if indexes are out of bounds"
                 ([ 1, 2, 3, 4 ]
                     |> Session.moveListElement 5 6
                     |> Expect.equal [ 1, 2, 3, 4 ]
-                )
-            ]
-        , describe "onlyValid"
-            [ it "should exclude invalid bookmarks and retain valid ones"
-                ([ Bookmark.JsonBookmark """{
-                    "created": 1767710889190,
-                    "name": "first valid bookmark",
-                    "query": {
-                        "mass": 0.15,
-                        "materials": [
-                        {
-                            "id": "62a4d6fb-3276-4ba5-93a3-889ecd3bff84",
-                            "share": 1
-                        }
-                        ],
-                        "product": "tshirt"
-                    }
-                    }"""
-                 , Bookmark.JsonBookmark """{
-                    "created": 1767710889191,
-                    "name": "invalid JSON bookmark with missing product category",
-                    "query": {
-                        "mass": 0.15,
-                        "materials": [
-                        {
-                            "id": "62a4d6fb-3276-4ba5-93a3-889ecd3bff84",
-                            "share": 1
-                        }
-                        ]
-                    }
-                    }"""
-                 , Bookmark.JsonBookmark """{
-                    "created": 1767710889192,
-                    "name": "invalid JSON bookmark with too much material",
-                    "query": {
-                        "mass": 0.15,
-                        "materials": [
-                        {
-                            "id": "62a4d6fb-3276-4ba5-93a3-889ecd3bff84",
-                            "share": 1.5
-                        }
-                        ]
-                    }
-                    }"""
-                 , Bookmark.JsonBookmark """{
-                    "created": 1767710889193,
-                    "name": "second valid bookmark",
-                    "query": {
-                        "mass": 0.15,
-                        "materials": [
-                        {
-                            "id": "62a4d6fb-3276-4ba5-93a3-889ecd3bff84",
-                            "share": 1
-                        }
-                        ],
-                        "product": "pantalon"
-                    }
-                    }"""
-                 ]
-                    |> Bookmark.onlyValid
-                    |> List.map .name
-                    |> Expect.equal [ "first valid bookmark", "second valid bookmark" ]
                 )
             ]
         ]


### PR DESCRIPTION
This patch reverts #1694 as we discovered live during a demo that the previous static version exports don't apply the patch, therefore every version switch between current, stable and/or static versions implies resetting the session, which is a worse situation than the initial one the patch intended to fix.

We'll definitely have to wait for the static versioning stuff to be entirely gone to land this safely.