### PR TITLE
fix: detailed impacts bug on object/veli

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -436,7 +436,6 @@ update rawMsg ({ state } as model) =
 
                 ( DetailedProcessesReceived (RemoteData.Success rawDetailedProcessesJson), currentPage ) ->
                     -- When detailed processes are received, rebuild the entire static db using them
-                    -- and also reload componentConfig with the new processes
                     case StaticDb.db rawDetailedProcessesJson of
                         Err _ ->
                             notifyError model "Erreur" <|
@@ -444,8 +443,7 @@ update rawMsg ({ state } as model) =
 
                         Ok detailedDb ->
                             ( { model | state = currentPage |> Loaded { session | db = detailedDb } }
-                            , ComponentConfig.decode detailedDb.processes detailedDb.countries
-                                |> Http.get "/data/components/config.json" (ComponentConfigReceived model.url)
+                            , Cmd.none
                             )
 
                 ( DetailedProcessesReceived (RemoteData.Failure _), _ ) ->

--- a/src/Page/Auth.elm
+++ b/src/Page/Auth.elm
@@ -11,6 +11,7 @@ module Page.Auth exposing
 import App exposing (PageUpdate)
 import Browser.Navigation as Nav
 import Data.ApiToken as ApiToken exposing (CreatedToken, Token)
+import Data.Component.Config as ComponentConfig
 import Data.Env as Env
 import Data.Plausible as Plausible
 import Data.Session as Session exposing (Session)
@@ -21,6 +22,7 @@ import Html.Attributes exposing (..)
 import Html.Events exposing (..)
 import Ports
 import RemoteData
+import RemoteData.Http as Http
 import Request.ApiToken as ApiTokenHttp
 import Request.Auth as Auth
 import Request.BackendHttp exposing (WebData)
@@ -50,6 +52,7 @@ type alias Email =
 
 type Msg
     = ApiTokensResponse (WebData (List CreatedToken))
+    | ComponentConfigReceived (RemoteData.WebData ComponentConfig.Config)
     | CopyToClipboard String
     | CreateToken
     | CreateTokenResponse (WebData Token)
@@ -124,6 +127,9 @@ update : Session -> Msg -> Model -> PageUpdate Model Msg
 update session msg model =
     case msg of
         -- Generic page updates
+        ComponentConfigReceived (RemoteData.Success componentConfig) ->
+            App.createUpdate { session | componentConfig = componentConfig } model
+
         CopyToClipboard accessToken ->
             App.createUpdate session model
                 |> App.withCmds [ Ports.copyToClipboard accessToken ]
@@ -131,9 +137,17 @@ update session msg model =
 
         -- Update db with detailed processes when we get them
         DetailedProcessesResponse (RemoteData.Success rawDetailedProcessesJson) ->
+            let
+                newSession =
+                    session |> Session.updateDbProcesses rawDetailedProcessesJson
+            in
             model
-                |> App.createUpdate (session |> Session.updateDbProcesses rawDetailedProcessesJson)
-                |> App.withCmds [ Nav.pushUrl session.navKey <| Route.toString Route.Auth ]
+                |> App.createUpdate newSession
+                |> App.withCmds
+                    [ Nav.pushUrl newSession.navKey <| Route.toString Route.Auth
+                    , ComponentConfig.decode newSession.db.processes newSession.db.countries
+                        |> Http.get "/data/components/config.json" ComponentConfigReceived
+                    ]
                 |> App.notifyInfo "Vous avez désormais accès aux impacts détaillés"
                 |> App.withCmds [ Plausible.send session Plausible.AuthLoginOK ]
 


### PR DESCRIPTION
# Problem

https://github.com/MTES-MCT/ecobalyse/issues/1701

It seems endOflife, Transports impacts are stored in ComponentConfig.
ComponentConfig is not updated with detailed impacts on authentification.
Therefore we don't have detailed impacts in steps other than production for sectors `object` or `veli`

# Solution

reload componentConfig with new processes when detailed processes are received

EDIT : Fix doesn't work until page is reloaded :(

# How to test

- Go to object and select an example
- Login to access detailed impacts
- Select a detailed impact `Changement climatique` for example
- Transports and End of life impacts are 0 :( (thats the bug)
- Reload the page
- Transports and End of life impacts are now correct