### PR TITLE
fix(bo,ui): constrain comment cell height in processes admin

### DIFF
--- a/src/Page/Admin/Process.elm
+++ b/src/Page/Admin/Process.elm
@@ -217,7 +217,9 @@ processRowView definitions selected process =
         , td [ class "text-end" ]
             [ process.impacts |> Format.formatImpact (Definition.get Definition.Ecs definitions) ]
         , td []
-            [ span [ class "fs-9" ] [ text process.comment ] ]
+            [ span [ class "d-block overflow-scroll fs-9", style "max-height" "100px" ]
+                [ text process.comment ]
+            ]
         ]
 
 


### PR DESCRIPTION
## :wrench: Problem

Before:

<img width="2899" height="2032" alt="image" src="https://github.com/user-attachments/assets/d2425901-8b3e-4373-9c37-6256e6556c44" />

## :cake: Solution

After:

<img width="2911" height="969" alt="image" src="https://github.com/user-attachments/assets/3d658bb0-4340-4685-bf82-5926fb58a8cb" />

