### PR TITLE
fix(textile): missing v7 slash

### DIFF
--- a/servers.conf.erb
+++ b/servers.conf.erb
@@ -39,7 +39,7 @@ server {
 
   # Add missing trailing slash after /versions/v7.0.0
   location = /versions/v7.0.0 {
-      return 301 /versions/v7.0.0/;
+      return 301 https://$host/versions/v7.0.0/;
   }
 
   # Reroute v7 to textile stable version


### PR DESCRIPTION
fixes #1773 

https://ecobalyse-staging-pr1777.osc-fr1.scalingo.io/versions/v7.0.0#/textile/simulator/ecs/eyJhaXJUcmFuc3BvcnRSYXRpbyI6MCwiYnVzaW5lc3MiOiJsYXJnZS1idXNpbmVzcy13aXRob3V0LXNlcnZpY2VzIiwiY291bnRyeUR5ZWluZyI6IkNOIiwiY291bnRyeUZhYnJpYyI6IkNOIiwiY291bnRyeU1ha2luZyI6IkNOIiwiY291bnRyeVNwaW5uaW5nIjoiQ04iLCJmYWRpbmciOmZhbHNlLCJtYXNzIjowLjA1MSwibWF0ZXJpYWxzIjpbeyJjb3VudHJ5IjoiQ04iLCJpZCI6ImVpLWNvdG9uIiwic2hhcmUiOjAuNzV9LHsiY291bnRyeSI6IkNOIiwiaWQiOiJlaS1wYSIsInNoYXJlIjowLjJ9LHsiY291bnRyeSI6IkNOIiwiaWQiOiJlbGFzdGhhbmUiLCJzaGFyZSI6MC4wNX1dLCJudW1iZXJPZlJlZmVyZW5jZXMiOjEwMDAsInByaWNlIjoxMiwicHJvZHVjdCI6ImNoYXVzc2V0dGVzIiwidXBjeWNsZWQiOmZhbHNlfQ==

Should be properly redirected