### PR TITLE
feat: express textile garment mass in grams

### DIFF
--- a/src/Page/Textile.elm
+++ b/src/Page/Textile.elm
@@ -861,7 +861,7 @@ massField massInput =
         [ label [ for "mass", class "form-label text-truncate" ]
             [ text "Masse du produit fini" ]
         , div
-            [ class "input-group", title "Mass du produit fini, en grammes" ]
+            [ class "input-group", title "Masse du produit fini, en grammes" ]
             [ input
                 [ type_ "number"
                 , class "form-control text-end"


### PR DESCRIPTION
## :wrench: Problem

Fixes #1553. Entering textile garment mass is a pain, because it's expressed as a float number of kg, which makes it difficult to enter while always having a valid computational state.

## :cake: Solution

Invite users to express garment mass  in grams.

## :desert_island: How to test

Enter a garment mass, then cry of joy.