### PR TITLE
fix: backport #1825 and #1826

### DIFF
--- a/src/Views/Modal.elm
+++ b/src/Views/Modal.elm
@@ -3,6 +3,7 @@ module Views.Modal exposing (Size(..), view)
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (..)
+import Json.Decode
 
 
 type alias Config msg =
@@ -44,6 +45,11 @@ view config =
             , attribute "tabindex" "-1"
             , attribute "aria-modal" "true"
             , attribute "role" "dialog"
+            , attribute "data-dismiss" "modal"
+            , on "click"
+                (Json.Decode.at [ "target", "dataset", "dismiss" ] Json.Decode.string
+                    |> Json.Decode.map (always config.close)
+                )
             ]
             [ div
                 [ class "modal-dialog modal-dialog-centered modal-dialog-scrollable"

--- a/styles.scss
+++ b/styles.scss
@@ -622,6 +622,7 @@ q {
 
   &Choice {
 
+    transition: none;
     &.selected,
     &:hover {
       color: #fff !important;


### PR DESCRIPTION
backport #1825 (close the modal when clicking outside) and #1826 (remove css transition on autocomplete lists)