### PR TITLE
fix: only match and change `sslmode` parameter

### DIFF
--- a/bin/load-fixtures.sh
+++ b/bin/load-fixtures.sh
@@ -7,6 +7,7 @@ ROOT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )
 cd $ROOT_DIR
 
 # Fix outdated Scalingo DSN to be compatible with asyncpg
+# see https://stackoverflow.com/a/66365284 for the sed magic to exit with code 100 in case of error
 DATABASE_URL=$(echo "$DATABASE_URL" | sed -e 's/postgres/postgresql+asyncpg/;tx;q100;:x' | sed -e 's/sslmode=/ssl=/;tx;q100;:x')
 export DATABASE_URL
 

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -8,6 +8,7 @@ ROOT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )
 cd $ROOT_DIR
 
 # Fix outdated Scalingo DSN to be compatible with asyncpg
+# see https://stackoverflow.com/a/66365284 for the sed magic to exit with code 100 in case of error
 DATABASE_URL=$(echo "$DATABASE_URL" | sed -e 's/postgres/postgresql+asyncpg/;tx;q100;:x' | sed -e 's/sslmode=/ssl=/;tx;q100;:x')
 export DATABASE_URL
 


### PR DESCRIPTION
fixes #1807 

Forcing

```bash
set -euo pipefail
```

To exit if any error is present.

Separate the `export` (because `export` always succeed and hides any error in the `sed` commands) from the `sed` commands.

Do some magic with `sed` to exit with an error code if no replacement is made (see https://stackoverflow.com/a/66365284 for more details)

Hard to test apart from modifying scalingo database url with some bad values and test the deployment. I dit it myself and deployment fails as expected if the `sed` fails.