### PR TITLE
fix: we don’t need to fail on unbound variable

### DIFF
--- a/bin/load-fixtures.sh
+++ b/bin/load-fixtures.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Fail if they is an error
-set -euo pipefail
+set -eo pipefail
 
 ROOT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )
 cd $ROOT_DIR


### PR DESCRIPTION
## :wrench: Problem

Error on deploy

```
2026-02-25 16:08:58.727017192 +0100 CET [manager] container [postdeploy-8082] (699f108a998269a990af132c) started with the command './bin/load-fixtures.sh'
2026-02-25 16:08:58.761872706 +0100 CET [postdeploy-8082] ./bin/load-fixtures.sh: line 14: IS_REVIEW_APP: unbound variable
2026-02-25 16:08:59.039568103 +0100 CET [manager] container [postdeploy-8082] (699f108a998269a990af132c) has stopped with exit code: 1
```

## :cake: Solution

Don’t use `-u` for fixtures loading as `$IS_REVIEW_APP` is expected to be unset

## :desert_island: How to test

Can only be tested by deploying on production
