### PR TITLE
feat(food2): introduce food2 scope

### DIFF
--- a/src/Data/Bookmark.elm
+++ b/src/Data/Bookmark.elm
@@ -7,6 +7,7 @@ module Data.Bookmark exposing
     , findByObjectQuery
     , findByTextileQuery
     , isFood
+    , isFood2
     , isObject
     , isTextile
     , isVeli
@@ -42,6 +43,7 @@ type alias Bookmark =
 
 type Query
     = Food FoodQuery.Query
+    | Food2 Component.Query
     | Object Component.Query
     | Textile TextileQuery.Query
     | Veli Component.Query
@@ -118,6 +120,9 @@ encodeQuery v =
         Food query ->
             FoodQuery.encode query
 
+        Food2 query ->
+            Component.encodeQuery query
+
         Object query ->
             Component.encodeQuery query
 
@@ -132,6 +137,16 @@ isFood : Bookmark -> Bool
 isFood { query } =
     case query of
         Food _ ->
+            True
+
+        _ ->
+            False
+
+
+isFood2 : Bookmark -> Bool
+isFood2 { query } =
+    case query of
+        Food2 _ ->
             True
 
         _ ->
@@ -202,6 +217,9 @@ scope bookmark =
         Food _ ->
             Scope.Food
 
+        Food2 _ ->
+            Scope.Food2
+
         Object _ ->
             Scope.Object
 
@@ -231,8 +249,13 @@ toQueryDescription db bookmark =
                 |> Result.map Recipe.toString
                 |> Result.withDefault bookmark.name
 
-        Object objectQuery ->
-            objectQuery.items
+        Food2 { items } ->
+            items
+                |> Component.itemsToString db
+                |> Result.withDefault "N/A"
+
+        Object { items } ->
+            items
                 |> Component.itemsToString db
                 |> Result.withDefault "N/A"
 
@@ -242,7 +265,7 @@ toQueryDescription db bookmark =
                 |> Result.map (Inputs.toString db.textile.wellKnown)
                 |> Result.withDefault bookmark.name
 
-        Veli objectQuery ->
-            objectQuery.items
+        Veli { items } ->
+            items
                 |> Component.itemsToString db
                 |> Result.withDefault "N/A"

--- a/src/Data/Dataset.elm
+++ b/src/Data/Dataset.elm
@@ -53,6 +53,12 @@ datasets scope =
             , Processes Scope.Food Nothing
             ]
 
+        Scope.Food2 ->
+            [ Impacts Nothing
+            , Countries Nothing
+            , Processes Scope.Food2 Nothing
+            ]
+
         Scope.Object ->
             [ ObjectExamples Nothing
             , Components Scope.Object Nothing
@@ -85,6 +91,9 @@ defaultDatasetFor scope =
     case scope of
         Scope.Food ->
             FoodExamples Nothing
+
+        Scope.Food2 ->
+            Processes Scope.Food2 Nothing
 
         Scope.Object ->
             ObjectExamples Nothing

--- a/src/Data/Scope.elm
+++ b/src/Data/Scope.elm
@@ -21,6 +21,7 @@ import Url.Parser as Parser exposing (Parser)
 
 type Scope
     = Food
+    | Food2
     | Object
     | Textile
     | Veli
@@ -93,6 +94,9 @@ toLabel scope =
         Food ->
             "Alimentaire"
 
+        Food2 ->
+            "Alimentaire²"
+
         Object ->
             "Objets"
 
@@ -108,6 +112,9 @@ toString scope =
     case scope of
         Food ->
             "food"
+
+        Food2 ->
+            "food2"
 
         Object ->
             "object"

--- a/src/Data/Session.elm
+++ b/src/Data/Session.elm
@@ -55,6 +55,7 @@ import Static.Json as StaticJson
 
 type alias Queries =
     { food : FoodQuery.Query
+    , food2 : Component.Query
     , object : Component.Query
     , textile : TextileQuery.Query
     , veli : Component.Query

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -167,6 +167,7 @@ setupSession navKey flags db componentConfig =
         , notifications = []
         , queries =
             { food = FoodQuery.empty
+            , food2 = Component.emptyQuery
             , object = Component.emptyQuery
             , textile =
                 db.textile.examples
@@ -639,7 +640,7 @@ view { mobileNavigationOpened, state, tray } =
                 FoodBuilderPage foodModel ->
                     FoodBuilder.view session foodModel
                         |> mapMsg FoodBuilderMsg
-                        |> frame Page.FoodBuilder
+                        |> frame Page.Food
 
                 HomePage _ ->
                     Home.view session

--- a/src/Page/Explore.elm
+++ b/src/Page/Explore.elm
@@ -158,6 +158,9 @@ update session msg model =
                                 Scope.Food ->
                                     Dataset.FoodExamples Nothing
 
+                                Scope.Food2 ->
+                                    Dataset.Processes Scope.Food2 Nothing
+
                                 Scope.Object ->
                                     Dataset.ObjectExamples Nothing
 

--- a/src/Route.elm
+++ b/src/Route.elm
@@ -80,6 +80,20 @@ parser =
                 </> Example.parseUuid
             )
 
+        -- Food2 specific routes
+        , Parser.map (ObjectSimulatorHome Scope.Food2)
+            (Parser.s "food2" </> Parser.s "simulator")
+        , Parser.map (ObjectSimulator Scope.Food2) <|
+            Parser.s "food2"
+                </> Parser.s "simulator"
+                </> Impact.parseTrigram
+                </> Component.parseBase64Query
+        , Parser.map (ObjectSimulatorExample Scope.Food2)
+            (Parser.s "food2"
+                </> Parser.s "edit-example"
+                </> Example.parseUuid
+            )
+
         -- Object specific routes
         , Parser.map (ObjectSimulatorHome Scope.Object)
             (Parser.s "object" </> Parser.s "simulator")

--- a/src/Views/Bookmark.elm
+++ b/src/Views/Bookmark.elm
@@ -101,6 +101,21 @@ shareTabView { copyToClipBoard, impact, scope, session } =
                         |> Encode.encode 2
                     )
 
+                Scope.Food2 ->
+                    let
+                        query =
+                            session.queries.food2
+                    in
+                    ( Just query
+                        |> Route.ObjectSimulator scope impact.trigram
+                        |> Route.toString
+                        |> (++) "/"
+                        |> (++) session.clientUrl
+                    , buildObjectApiQuery scope session.clientUrl query
+                    , Component.encodeQuery query
+                        |> Encode.encode 2
+                    )
+
                 Scope.Object ->
                     let
                         query =
@@ -315,6 +330,10 @@ bookmarkView cfg ({ name, query } as bookmark) =
                     Just foodQuery
                         |> Route.FoodBuilder cfg.impact.trigram
 
+                Bookmark.Food2 food2Query ->
+                    Just food2Query
+                        |> Route.ObjectSimulator Scope.Food2 cfg.impact.trigram
+
                 Bookmark.Object objectQuery ->
                     Just objectQuery
                         |> Route.ObjectSimulator Scope.Object cfg.impact.trigram
@@ -403,6 +422,9 @@ queryFromScope session scope =
         Scope.Food ->
             Bookmark.Food session.queries.food
 
+        Scope.Food2 ->
+            Bookmark.Food2 session.queries.food2
+
         Scope.Object ->
             Bookmark.Object session.queries.object
 
@@ -420,6 +442,9 @@ scopedBookmarks session scope =
             (case scope of
                 Scope.Food ->
                     Bookmark.isFood
+
+                Scope.Food2 ->
+                    Bookmark.isFood2
 
                 Scope.Object ->
                     Bookmark.isObject

--- a/src/Views/Comparator.elm
+++ b/src/Views/Comparator.elm
@@ -137,6 +137,24 @@ addToComparison session { name, query } =
                         }
                     )
 
+        Bookmark.Food2 food2Query ->
+            food2Query
+                |> ObjectSimulator.compute
+                    { config = session.componentConfig
+                    , db = session.db
+                    , scope = Scope.Food2
+                    }
+                |> Result.map
+                    (\lifeCycle ->
+                        { complementsImpact = Impact.noComplementsImpacts
+                        , impacts = Component.sumLifeCycleImpacts lifeCycle
+                        , label = name
+                        , stagesImpacts =
+                            lifeCycle
+                                |> ObjectSimulator.toStagesImpacts Definition.Ecs
+                        }
+                    )
+
         Bookmark.Object objectQuery ->
             objectQuery
                 |> ObjectSimulator.compute
@@ -169,8 +187,8 @@ addToComparison session { name, query } =
                         }
                     )
 
-        Bookmark.Veli objectQuery ->
-            objectQuery
+        Bookmark.Veli veliQuery ->
+            veliQuery
                 |> ObjectSimulator.compute
                     { config = session.componentConfig
                     , db = session.db

--- a/src/Views/Page.elm
+++ b/src/Views/Page.elm
@@ -38,7 +38,7 @@ type ActivePage
     | Auth
     | Editorial String
     | Explore
-    | FoodBuilder
+    | Food
     | Home
     | Object Scope
     | Other
@@ -113,7 +113,13 @@ termsNotice session =
 commonNotices : (App.Msg -> msg) -> ActivePage -> Html msg
 commonNotices msg activePage =
     case activePage of
-        FoodBuilder ->
+        Food ->
+            Notice.info
+                [ Icon.info
+                , Markdown.simple [] "**Cette version est en cours de développement.**"
+                ]
+
+        Object Scope.Food2 ->
             Notice.info
                 [ Icon.info
                 , Markdown.simple [] "**Cette version est en cours de développement.**"
@@ -236,7 +242,7 @@ mainMenuLinks { enabledSections } =
         , addRouteIf enabledSections.textile <|
             Internal "Textile" Route.TextileSimulatorHome TextileSimulator
         , addRouteIf enabledSections.food <|
-            Internal "Alimentaire" Route.FoodBuilderHome FoodBuilder
+            Internal "Alimentaire" Route.FoodBuilderHome Food
         , addRouteIf enabledSections.objects <|
             Internal "Objets" (Route.ObjectSimulatorHome Scope.Object) (Object Scope.Object)
         , addRouteIf enabledSections.veli <|
@@ -256,6 +262,7 @@ secondaryMenuLinks =
     , External "Code source" Env.githubUrl
     , External "CGU" Env.cguUrl
     , Internal "Admin" (Route.Admin AdminSection.ComponentSection) Admin
+    , Internal "Alimentaire²" (Route.ObjectSimulatorHome Scope.Food2) (Object Scope.Food2)
     ]
 
 
@@ -273,8 +280,8 @@ headerMenuLinks session =
             ]
 
 
-footerMenuLinks : Session -> List MenuLink
-footerMenuLinks session =
+mobileMenuLinks : Session -> List MenuLink
+mobileMenuLinks session =
     mainMenuLinks session
         ++ [ External "Documentation" Env.gitbookUrl
            , External "Communauté" Env.communityUrl
@@ -651,7 +658,7 @@ mobileNavigation { activePage, session, toMsg } =
                     []
                 ]
             , div [ class "offcanvas-body" ]
-                [ footerMenuLinks session
+                [ mobileMenuLinks session
                     |> List.map (viewNavigationLink activePage)
                     |> div [ class "nav nav-pills flex-column" ]
                 , h4 [ class "h6 mt-3" ] [ text "Versions" ]


### PR DESCRIPTION
## :wrench: Problem

Partially addresses #1828 by introducing a new `Food2` scope to leverage the generic component system to migrate food on top of it.

## :cake: Solution

Add a new `Food2` scope and calculator to prepare migrating current food to the generic component system.

The new food2 calculator is reachable using the `/#/food2/simulator` url, and a direct link is available in the footer: 

<img width="1834" height="749" alt="image" src="https://github.com/user-attachments/assets/3f4932fc-ad7b-4672-a71b-c0b0de415eb2" />

## :rotating_light:  Points to watch/comments

Data need to be added for this patch to be actually useful:

- Food2 processes should be scoped as `food2`
- Food2 examples and components should be contributed

## :desert_island: How to test

We'll need data in order to actually be able to test the new food2 calculator, but maybe we can land the patch first so this isn't blocked by these data requirements?