### PR TITLE
chore: standardize hashbang

### DIFF
--- a/bin/build-specific-app-version.sh
+++ b/bin/build-specific-app-version.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 COMMIT_OR_TAG=$1
 ECOBALYSE_DATA_DIR_COMMIT=$2
 

--- a/bin/check-ecobalyse-data-sync.sh
+++ b/bin/check-ecobalyse-data-sync.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 set -euo pipefail
 
 # Directory where files will be downloaded

--- a/bin/reset-docker-db.sh
+++ b/bin/reset-docker-db.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 $SCRIPT_DIR/check-db.sh


### PR DESCRIPTION
## :wrench: Problem

Some hashbangs in the script are missing or incorrects

## :cake: Solution

Use `!#/usr/bin/env` eveywhere

