### PR TITLE
feat: display ingredient alias in explorer

### DIFF
--- a/src/Data/Food/Ingredient.elm
+++ b/src/Data/Food/Ingredient.elm
@@ -37,7 +37,7 @@ import Length
 
 
 type alias Ingredient =
-    { aliasName : String
+    { alias : String
     , categories : List IngredientCategory.Category
     , cropGroup : CropGroup
     , defaultOrigin : Origin
@@ -141,7 +141,6 @@ decodeIngredient : List Process -> Decoder Ingredient
 decodeIngredient processes =
     Decode.succeed Ingredient
         |> Pipe.required "alias" Decode.string
-        -- aliasName as alias is a keyword in elm
         |> Pipe.required "categories" (Decode.list IngredientCategory.decode)
         |> Pipe.optional "cropGroup" CropGroup.decode CropGroup.empty
         |> Pipe.required "defaultOrigin" Origin.decode
@@ -236,7 +235,7 @@ transportCoolingToString v =
 toSearchableString : Ingredient -> String
 toSearchableString ingredient =
     String.join " "
-        [ ingredient.aliasName
+        [ ingredient.alias
         , ingredient.categories |> List.map IngredientCategory.toLabel |> String.join " "
         , ingredient.cropGroup |> CropGroup.toLabel
         , ingredient.defaultOrigin |> Origin.toLabel

--- a/src/Page/Explore/FoodIngredients.elm
+++ b/src/Page/Explore/FoodIngredients.elm
@@ -45,8 +45,8 @@ table { detailed, scope } =
           , toCell = .name >> text
           }
         , { label = "Alias"
-          , toValue = Table.StringValue .aliasName
-          , toCell = \ingredient -> code [] [ text ingredient.aliasName ]
+          , toValue = Table.StringValue .alias
+          , toCell = \ingredient -> code [] [ text ingredient.alias ]
           }
         , { label = "Catégories"
           , toValue = Table.StringValue <| .categories >> List.map IngredientCategory.toLabel >> String.join ","


### PR DESCRIPTION
## :wrench: Problem

ingredient alias is useful to communicate between method and product team for debugging ingredients, but it's not displayed currently in the explorer

Exemple : 

Identifiant	`d8c8a918-a11a-502f-a5cf-90052d96c133`
Nom d'affichage	`Ail Origine Inconnue`
Alias	`garlic-default`

 
## :cake: Solution

display it in the explorer
