### PR TITLE
fix: complements json keys

### DIFF
--- a/src/Data/Complement.elm
+++ b/src/Data/Complement.elm
@@ -55,6 +55,10 @@ type alias ComplementsLabels =
     AbstractComplements String
 
 
+type alias ComplementsIdentifiers =
+    AbstractComplements String
+
+
 type alias ComplementsResultsImpacts =
     AbstractComplements (Maybe Impacts)
 
@@ -187,7 +191,7 @@ impactsWithComplements complementsImpacts impacts =
         |> Impact.insertWithoutAggregateComputation Definition.Ecs ecsWithComplements
 
 
-identifiers : ComplementsLabels
+identifiers : ComplementsIdentifiers
 identifiers =
     { cropDiversity = "cropDiversity"
     , forest = "forest"


### PR DESCRIPTION
## :wrench: Problem

In the API response labels are used as json keys instead of the standard `camelCase` notation.

## :cake: Solution

Use camelCase json labels

## :desert_island: How to test

Test the textile simulator/detailed endpoint in the API tab and the `complementsImpacts` key should have those values

```json
  "complementsImpacts": {
    "microfibers": 63.4328,
    "outOfEuropeEOL": 62.1642
  },
```

and not

```json
  "complementsImpacts": {
    "Microfibres": 63.4328,
    "Export hors-Europe": 62.1642
  },
```
