### PR TITLE
chore(security): update dependabot config to handle branches and ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,34 @@
 version: 2
+
 updates:
+  # master (current version)
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     cooldown:
       default-days: 7
+    target-branch: "master"
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 7
+    target-branch: "master"
+
+  # stable/textile (regulatory version)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 7
+    target-branch: "stable/textile"
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 7
+    target-branch: "stable/textile"


### PR DESCRIPTION
This patch enables dependabot on stable/textile branch and support for uv/pip packages. This will allow getting update PRs for all this, ease maintenance and improve security.