### PR TITLE
chore(elm): move to core.extra, upgrade deps

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -16,9 +16,9 @@
             "dillonkearns/elm-markdown": "7.0.1",
             "elm/browser": "1.0.2",
             "elm/core": "1.0.5",
-            "elm/html": "1.0.0",
+            "elm/html": "1.0.1",
             "elm/http": "2.0.0",
-            "elm/json": "1.1.3",
+            "elm/json": "1.1.4",
             "elm/regex": "1.0.0",
             "elm/time": "1.0.0",
             "elm/url": "1.0.0",
@@ -29,7 +29,7 @@
             "ianmackenzie/elm-units": "2.10.0",
             "krisajenkins/remotedata": "6.1.0",
             "kuon/elm-string-normalize": "1.0.6",
-            "miniBill/elm-diff": "1.1.0",
+            "miniBill/elm-diff": "1.1.1",
             "ohanhi/remotedata-http": "4.0.0",
             "truqu/elm-base64": "2.0.4",
             "turboMaCk/any-dict": "2.6.0"
@@ -41,19 +41,19 @@
             "elm/bytes": "1.0.8",
             "elm/file": "1.0.5",
             "elm/parser": "1.1.0",
-            "elm/virtual-dom": "1.0.4",
+            "elm/virtual-dom": "1.0.5",
             "jinjor/elm-debounce": "3.0.0",
             "myrho/elm-round": "1.0.5",
             "robinheghan/murmur3": "1.0.0",
             "rtfeldman/elm-css": "17.1.1",
             "rtfeldman/elm-hex": "1.0.0",
             "rtfeldman/elm-iso8601-date-strings": "1.1.4",
-            "wolfadex/elm-ansi": "3.0.0"
+            "wolfadex/elm-ansi": "3.0.1"
         }
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "2.2.0"
+            "elm-explorations/test": "2.2.1"
         },
         "indirect": {
             "elm/random": "1.0.0"


### PR DESCRIPTION
## :wrench: Problem

Fixes #1951

## ⚠️ Caveat

Also upgrades minor/patch Elm packages:

```
-- PACKAGE UPGRADES FOUND ------------------------------------------------------

I want to make some changes to your direct dependencies

- [CHG] elm/html 1.0.0 -> 1.0.1
- [CHG] elm/json 1.1.3 -> 1.1.4
- [CHG] miniBill/elm-diff 1.1.0 -> 1.1.1

I want to make some changes to your indirect dependencies

- [CHG] elm/virtual-dom 1.0.4 -> 1.0.5
- [CHG] wolfadex/elm-ansi 3.0.0 -> 3.0.1

I want to make some changes to your direct test dependencies

- [CHG] elm-explorations/test 2.2.0 -> 2.2.1
```

## :desert_island: How to test

Build should be green.