### PR TITLE
fix: batch commit in load_processes_fixtures

### DIFF
--- a/backend/src/app/cli/commands.py
+++ b/backend/src/app/cli/commands.py
@@ -30,7 +30,6 @@ from app.domain.components.schemas import (
 )
 from app.domain.processes.deps import provide_processes_service
 from rich import get_console
-from sqlalchemy.orm import joinedload, selectinload
 from structlog import get_logger
 
 
@@ -383,7 +382,7 @@ async def load_processes_fixtures(
     if processes_to_add:
         await processes_service.create_many(
             data=processes_to_add,
-            auto_commit=True,
+            auto_commit=False,
         )
 
     if processes_to_update:
@@ -391,20 +390,17 @@ async def load_processes_fixtures(
             await processes_service.update(
                 item_id=process_to_update["id"],
                 data=process_to_update,
-                auto_commit=True,
-                auto_refresh=True,
-                load=[
-                    selectinload(m.Process.process_categories).options(
-                        joinedload(m.ProcessCategory.processes, innerjoin=True),
-                    ),
-                ],
+                auto_commit=False,
+                auto_refresh=False,
             )
 
     if processes_ids_to_delete:
         await processes_service.delete_many(
             item_ids=processes_ids_to_delete,
-            auto_commit=True,
+            auto_commit=False,
         )
+
+    await db_session.commit()
 
     await logger.ainfo(f"Loaded {len(processes_data)} processes fixtures")
     await logger.ainfo(f"Added: {len(processes_to_add)}")


### PR DESCRIPTION
## :wrench: Problem

Deployment on Scalingo is stuck for ~2h in the postdeploy hook (load-fixtures.sh), during process loading (load_processes_fixtures).                                                                                                        
     
## :cake: Solution

This is an unconfirmed hypothesis:
                                                                                                                                                                                                                                         
  The function updates each existing process individually, with each one requiring: an UPDATE, a COMMIT, a REFRESH (re-read from DB) and eager loading (selectinload/joinedload). On a remote DB, each cycle takes ~2-3 seconds.              
                                                                                                                                                                                                                                              
  This code was introduced in #1453 (Oct 2025) when there were ~490 processes — it took ~8 minutes, which was tolerable. The process count has since grown steadily, and two recent PRs pushed it past the breaking point:                    
                                                                                                                                                                                                                                              
  - #2005 
  - #2082
                                                                                                                                                                                                                                              
  At 2287 processes, the deployment takes ~1h40 and times out.

So ;

- Set all operations (create, update, delete) to auto_commit=False
- Remove auto_refresh=True and the load=[...] from individual updates (we don't need to re-read data after each update)
- Perform a single await db_session.commit() at the end          
                                                                                 
Goes from ~2500 individual transactions to a single one. 

### Points to watch

See the previous comments on this topic on: #1453

## :desert_island: How to test

- Run integration tests
- Deploy and verify the postdeploy hook completes in seconds instead of ~2h
- Check in the back-office that processes are present and up to date after deployment