### PR TITLE
feat(explorer): add lightweight faceted search

### DIFF
--- a/index.js
+++ b/index.js
@@ -165,7 +165,6 @@ app.ports.scrollTo.subscribe((pos) => {
 
 app.ports.scrollIntoView.subscribe((selector) => {
   let node = document.querySelector(selector);
-  console.log("scrollIntoView", selector, node);
   node?.scrollIntoView({ behavior: "smooth", block: "end", inline: "nearest" });
 });
 

--- a/index.js
+++ b/index.js
@@ -163,9 +163,10 @@ app.ports.scrollTo.subscribe((pos) => {
   window.scrollTo(pos.x, pos.y);
 });
 
-app.ports.scrollIntoView.subscribe((id) => {
-  let node = document.getElementById(id);
-  node?.scrollIntoView({ behavior: "smooth" });
+app.ports.scrollIntoView.subscribe((selector) => {
+  let node = document.querySelector(selector);
+  console.log("scrollIntoView", selector, node);
+  node?.scrollIntoView({ behavior: "smooth", block: "end", inline: "nearest" });
 });
 
 // Ensure session is refreshed when it changes in another tab/window

--- a/src/Data/Text.elm
+++ b/src/Data/Text.elm
@@ -1,6 +1,6 @@
 module Data.Text exposing
     ( search
-    , sortStrings
+    , sortI18nStrings
     , toWords
     , yesNo
     )
@@ -59,10 +59,10 @@ search { minQueryLength, query, toString } elements =
         exactWordsMatches ++ partialWordsMatches
 
 
-{-| Sort strings the case and accent insensitive way (useful for non-US alphabets).
+{-| Sort strings in a case and accent insensitive manner (useful for non-US alphabets).
 -}
-sortStrings : List String -> List String
-sortStrings =
+sortI18nStrings : List String -> List String
+sortI18nStrings =
     List.sortBy (String.toLower >> Normalize.removeDiacritics)
 
 

--- a/src/Data/Text.elm
+++ b/src/Data/Text.elm
@@ -1,6 +1,7 @@
 module Data.Text exposing
     ( search
     , toWords
+    , yesNo
     )
 
 import Regex
@@ -65,3 +66,12 @@ toWords =
             (Regex.fromString "[\\W_]+"
                 |> Maybe.withDefault Regex.never
             )
+
+
+yesNo : Bool -> String
+yesNo bool =
+    if bool then
+        "Oui"
+
+    else
+        "Non"

--- a/src/Data/Text.elm
+++ b/src/Data/Text.elm
@@ -1,5 +1,6 @@
 module Data.Text exposing
     ( search
+    , sortStrings
     , toWords
     , yesNo
     )
@@ -56,6 +57,13 @@ search { minQueryLength, query, toString } elements =
                         )
         in
         exactWordsMatches ++ partialWordsMatches
+
+
+{-| Sort strings the case and accent insensitive way (useful for non-US alphabets).
+-}
+sortStrings : List String -> List String
+sortStrings =
+    List.sortBy (String.toLower >> Normalize.removeDiacritics)
 
 
 toWords : String -> List String

--- a/src/Page/Admin/Account.elm
+++ b/src/Page/Admin/Account.elm
@@ -9,6 +9,7 @@ module Page.Admin.Account exposing
 
 import App exposing (Msg, PageUpdate)
 import Data.Session exposing (Session)
+import Data.Text as Text
 import Data.User as User exposing (User)
 import Html exposing (..)
 import Html.Attributes as Attr exposing (..)
@@ -99,21 +100,12 @@ filterAccounts filters accounts =
         |> List.filter (\account -> filters.termsAccepted |> Maybe.map ((==) account.profile.termsAccepted) |> Maybe.withDefault True)
 
 
-yesNo : Bool -> String
-yesNo bool =
-    if bool then
-        "Oui"
-
-    else
-        "Non"
-
-
 booleanColumn : String -> (User -> Bool) -> SortableTable.Column User Msg
 booleanColumn name getter =
     SortableTable.customColumn
         { name = name
-        , viewData = getter >> yesNo
-        , sorter = SortableTable.increasingOrDecreasingBy (getter >> yesNo)
+        , viewData = getter >> Text.yesNo
+        , sorter = SortableTable.increasingOrDecreasingBy (getter >> Text.yesNo)
         }
 
 
@@ -204,7 +196,7 @@ viewFilters filters =
             |> List.filterMap
                 (\( field, ( getter, setter ) ) ->
                     getter filters
-                        |> Maybe.map (\v -> ( field, yesNo v, setter ))
+                        |> Maybe.map (\v -> ( field, Text.yesNo v, setter ))
                 )
             |> List.map
                 (\( field, value, setter ) ->

--- a/src/Page/Explore.elm
+++ b/src/Page/Explore.elm
@@ -184,18 +184,14 @@ update session msg model =
         SetTableState tableState ->
             createPageUpdate session { model | tableState = tableState }
 
-        ToggleFacetValue facetKey facetValue checked ->
-            createPageUpdate session
-                { model
-                    | facetValues =
-                        model.facetValues
-                            |> Table.updateFacets facetKey facetValue checked
-                }
+        ToggleFacetValue key value checked ->
+            { model | facetValues = model.facetValues |> Table.updateFacets key value checked }
+                |> createPageUpdate session
                 |> App.withCmds
                     [ if checked then
                         -- scroll the facet card DOM element to top when it is checked
-                        "[data-scroll-id={facetKey}] label:first-child"
-                            |> String.replace "{facetKey}" facetKey
+                        "[data-scroll-id={key}] label:first-child"
+                            |> String.replace "{key}" key
                             |> Ports.scrollIntoView
 
                       else

--- a/src/Page/Explore.elm
+++ b/src/Page/Explore.elm
@@ -210,23 +210,22 @@ update session msg model =
 updateFacets : String -> String -> Bool -> Table.Facets -> Table.Facets
 updateFacets facetKey facetValue checked facetValues =
     let
-        selectedValues =
+        newSelectedValues =
             facetValues
                 |> Dict.get facetKey
                 |> Maybe.withDefault Set.empty
+                |> (if checked then
+                        Set.insert facetValue
 
-        nextSelectedValues =
-            if checked then
-                Set.insert facetValue selectedValues
-
-            else
-                Set.remove facetValue selectedValues
+                    else
+                        Set.remove facetValue
+                   )
     in
-    if Set.isEmpty nextSelectedValues then
+    if Set.isEmpty newSelectedValues then
         Dict.remove facetKey facetValues
 
     else
-        Dict.insert facetKey nextSelectedValues facetValues
+        Dict.insert facetKey newSelectedValues facetValues
 
 
 {-| Create a page update preventing the body to be scrollable when one or more modals are opened.

--- a/src/Page/Explore.elm
+++ b/src/Page/Explore.elm
@@ -49,7 +49,6 @@ import Page.Explore.TextileMaterials as TextileMaterials
 import Page.Explore.TextileProducts as TextileProducts
 import Ports
 import Route exposing (Route)
-import Set
 import Static.Db exposing (Db)
 import Table as SortableTable exposing (defaultCustomizations)
 import Views.Alert as Alert
@@ -190,7 +189,7 @@ update session msg model =
                 { model
                     | facetValues =
                         model.facetValues
-                            |> updateFacets facetKey facetValue checked
+                            |> Table.updateFacets facetKey facetValue checked
                 }
                 |> App.withCmds
                     [ if checked then
@@ -205,27 +204,6 @@ update session msg model =
 
         UpdateSearch search ->
             createPageUpdate session { model | search = search }
-
-
-updateFacets : String -> String -> Bool -> Table.Facets -> Table.Facets
-updateFacets facetKey facetValue checked facetValues =
-    let
-        newSelectedValues =
-            facetValues
-                |> Dict.get facetKey
-                |> Maybe.withDefault Set.empty
-                |> (if checked then
-                        Set.insert facetValue
-
-                    else
-                        Set.remove facetValue
-                   )
-    in
-    if Set.isEmpty newSelectedValues then
-        Dict.remove facetKey facetValues
-
-    else
-        Dict.insert facetKey newSelectedValues facetValues
 
 
 {-| Create a page update preventing the body to be scrollable when one or more modals are opened.

--- a/src/Page/Explore.elm
+++ b/src/Page/Explore.elm
@@ -190,7 +190,7 @@ update session msg model =
                 |> App.withCmds
                     [ if checked then
                         -- scroll the facet card DOM element to top when it is checked
-                        "[data-scroll-id={key}] label:first-child"
+                        """[data-scroll-id="{key}"] label:first-child"""
                             |> String.replace "{key}" key
                             |> Ports.scrollIntoView
 

--- a/src/Page/Explore.elm
+++ b/src/Page/Explore.elm
@@ -32,6 +32,7 @@ import Data.Textile.Query as TextileQuery
 import Data.Textile.Simulator as Simulator
 import Data.Unit as Unit
 import Data.Uuid exposing (Uuid)
+import Dict
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (..)
@@ -48,6 +49,7 @@ import Page.Explore.TextileMaterials as TextileMaterials
 import Page.Explore.TextileProducts as TextileProducts
 import Ports
 import Route exposing (Route)
+import Set
 import Static.Db exposing (Db)
 import Table as SortableTable exposing (defaultCustomizations)
 import Views.Alert as Alert
@@ -57,6 +59,7 @@ import Views.Modal as ModalView
 
 type alias Model =
     { dataset : Dataset
+    , facetValues : Table.Facets
     , scope : Scope
     , search : String
     , tableState : SortableTable.State
@@ -69,6 +72,7 @@ type Msg
     | OpenDetail Route
     | ScopeChange Scope
     | SetTableState SortableTable.State
+    | ToggleFacetValue String String Bool
     | UpdateSearch String
 
 
@@ -112,6 +116,7 @@ init scope dataset session =
     in
     createPageUpdate session
         { dataset = dataset
+        , facetValues = Dict.empty
         , scope = scope
         , search = ""
         , tableState = SortableTable.initialSort initialSort
@@ -143,7 +148,8 @@ update session msg model =
                     ]
 
         ScopeChange scope ->
-            createPageUpdate session { model | scope = scope }
+            { model | facetValues = Dict.empty, scope = scope }
+                |> createPageUpdate session
                 |> App.withCmds
                     [ (case model.dataset of
                         -- Try selecting the most appropriate tab when switching scope.
@@ -179,8 +185,38 @@ update session msg model =
         SetTableState tableState ->
             createPageUpdate session { model | tableState = tableState }
 
+        ToggleFacetValue facetKey facetValue checked ->
+            createPageUpdate session
+                { model
+                    | facetValues =
+                        model.facetValues
+                            |> updateFacets facetKey facetValue checked
+                }
+
         UpdateSearch search ->
             createPageUpdate session { model | search = search }
+
+
+updateFacets : String -> String -> Bool -> Table.Facets -> Table.Facets
+updateFacets facetKey facetValue checked facetValues =
+    let
+        selectedValues =
+            facetValues
+                |> Dict.get facetKey
+                |> Maybe.withDefault Set.empty
+
+        nextSelectedValues =
+            if checked then
+                Set.insert facetValue selectedValues
+
+            else
+                Set.remove facetValue selectedValues
+    in
+    if Set.isEmpty nextSelectedValues then
+        Dict.remove facetKey facetValues
+
+    else
+        Dict.insert facetKey nextSelectedValues facetValues
 
 
 {-| Create a page update preventing the body to be scrollable when one or more modals are opened.
@@ -693,12 +729,14 @@ getTextileScorePer100g { componentConfig, db } { query } =
 
 
 exploreView : Session -> Model -> List (Html Msg)
-exploreView ({ db } as session) { scope, dataset, tableState, search } =
+exploreView ({ db } as session) { facetValues, scope, dataset, tableState, search } =
     let
         tableConfig =
             { toId = always "" -- Placeholder
             , toMsg = SetTableState
+            , onFacetToggle = ToggleFacetValue
             , search = search
+            , selectedFacets = facetValues
             , columns = []
             , customizations =
                 { defaultCustomizations

--- a/src/Page/Explore.elm
+++ b/src/Page/Explore.elm
@@ -192,6 +192,16 @@ update session msg model =
                         model.facetValues
                             |> updateFacets facetKey facetValue checked
                 }
+                |> App.withCmds
+                    [ if checked then
+                        -- scroll the facet card DOM element to top when it is checked
+                        "[data-scroll-id={facetKey}] label:first-child"
+                            |> String.replace "{facetKey}" facetKey
+                            |> Ports.scrollIntoView
+
+                      else
+                        Cmd.none
+                    ]
 
         UpdateSearch search ->
             createPageUpdate session { model | search = search }

--- a/src/Page/Explore/Components.elm
+++ b/src/Page/Explore/Components.elm
@@ -23,6 +23,7 @@ table ({ db } as session) { detailed, scope } =
     , toId = .id >> Maybe.map Component.idToString >> Maybe.withDefault ""
     , toRoute = .id >> Dataset.Components scope >> Route.Explore scope
     , toSearchableString = Component.toSearchableString db
+    , facets = []
     , legend = []
     , columns =
         [ { label = "Identifiant"

--- a/src/Page/Explore/Countries.elm
+++ b/src/Page/Explore/Countries.elm
@@ -24,7 +24,16 @@ table distances countries { detailed, scope } =
     , toId = .code >> Country.codeToString
     , toRoute = .code >> Just >> Dataset.Countries >> Route.Explore scope
     , toSearchableString = Country.toSearchableString
-    , facets = []
+    , facets =
+        [ Table.Facet "Mix électrique" (.electricityProcess >> Process.getDisplayName >> List.singleton)
+        , Table.Facet "Chaleur" (.heatProcess >> Process.getDisplayName >> List.singleton)
+        , Table.Facet "Taux de pollution aquatique"
+            (.aquaticPollutionScenario
+                >> Country.getAquaticPollutionRatio
+                >> Split.toPercentString 0
+                >> (\p -> [ p ++ "%" ])
+            )
+        ]
     , legend = []
     , columns =
         List.filterMap identity

--- a/src/Page/Explore/Countries.elm
+++ b/src/Page/Explore/Countries.elm
@@ -24,6 +24,7 @@ table distances countries { detailed, scope } =
     , toId = .code >> Country.codeToString
     , toRoute = .code >> Just >> Dataset.Countries >> Route.Explore scope
     , toSearchableString = Country.toSearchableString
+    , facets = []
     , legend = []
     , columns =
         List.filterMap identity

--- a/src/Page/Explore/FoodExamples.elm
+++ b/src/Page/Explore/FoodExamples.elm
@@ -22,6 +22,7 @@ table { maxScore, maxPer100g } { detailed, scope } =
     , toId = Tuple.first >> .id >> Uuid.toString
     , toRoute = Tuple.first >> .id >> Just >> Dataset.FoodExamples >> Route.Explore scope
     , toSearchableString = Tuple.first >> Example.toSearchableString
+    , facets = []
     , legend = []
     , columns =
         [ { label = "Nom"

--- a/src/Page/Explore/FoodIngredients.elm
+++ b/src/Page/Explore/FoodIngredients.elm
@@ -27,6 +27,7 @@ table { detailed, scope } =
     , toId = .id >> Ingredient.idToString
     , toRoute = .id >> Just >> Dataset.FoodIngredients >> Route.Explore scope
     , toSearchableString = Ingredient.toSearchableString
+    , facets = []
     , legend = []
     , columns =
         [ { label = "Identifiant"

--- a/src/Page/Explore/Impacts.elm
+++ b/src/Page/Explore/Impacts.elm
@@ -19,6 +19,7 @@ table { detailed, scope } =
     , toId = .trigram >> Definition.toString
     , toRoute = .trigram >> Just >> Dataset.Impacts >> Route.Explore scope
     , toSearchableString = Definition.toSearchableString
+    , facets = []
     , legend = []
     , columns =
         [ { label = "Code"

--- a/src/Page/Explore/Impacts.elm
+++ b/src/Page/Explore/Impacts.elm
@@ -19,7 +19,9 @@ table { detailed, scope } =
     , toId = .trigram >> Definition.toString
     , toRoute = .trigram >> Just >> Dataset.Impacts >> Route.Explore scope
     , toSearchableString = Definition.toSearchableString
-    , facets = []
+    , facets =
+        [ Table.Facet "Unité" (.unit >> List.singleton)
+        ]
     , legend = []
     , columns =
         [ { label = "Code"

--- a/src/Page/Explore/ObjectExamples.elm
+++ b/src/Page/Explore/ObjectExamples.elm
@@ -43,6 +43,7 @@ table { maxScore } { detailed, scope } =
                )
             >> Route.Explore scope
     , toSearchableString = Tuple.first >> Example.toSearchableString
+    , facets = []
     , legend = []
     , columns =
         [ { label = "Nom"

--- a/src/Page/Explore/Processes.elm
+++ b/src/Page/Explore/Processes.elm
@@ -1,6 +1,7 @@
 module Page.Explore.Processes exposing (table)
 
 import Data.Complement as Complement
+import Data.Country as Country
 import Data.Dataset as Dataset
 import Data.Impact as Impact
 import Data.Impact.Definition as Definition exposing (Definitions)
@@ -27,7 +28,21 @@ table session { detailed, scope } =
     , facets =
         [ Table.Facet "Catégories" (.categories >> List.map ProcessCategory.toLabel)
         , Table.Facet "Unités" (.unit >> Process.unitToString >> List.singleton)
-        , Table.Facet "Région" (.location >> Maybe.withDefault "N/A" >> List.singleton)
+        , Table.Facet "Région"
+            (.location
+                >> Maybe.map
+                    (\location ->
+                        -- attempt decoding the region string as a an existing country code in the shared db
+                        case session.db.countries |> Country.findByCode (Country.codeFromString location) of
+                            Err _ ->
+                                location
+
+                            Ok { name } ->
+                                name ++ " (" ++ location ++ ")"
+                    )
+                >> Maybe.withDefault "N/A"
+                >> List.singleton
+            )
         ]
     , legend = []
     , columns = baseColumns detailed scope ++ impactsColumns session ++ complementsColumns session

--- a/src/Page/Explore/Processes.elm
+++ b/src/Page/Explore/Processes.elm
@@ -24,6 +24,11 @@ table session { detailed, scope } =
     , toId = .id >> Process.idToString
     , toRoute = .id >> Just >> Dataset.Processes scope >> Route.Explore scope
     , toSearchableString = Process.toSearchableString
+    , facets =
+        [ Table.Facet "Catégories" (.categories >> List.map ProcessCategory.toLabel)
+        , Table.Facet "Unités" (.unit >> Process.unitToString >> List.singleton)
+        , Table.Facet "Région" (.location >> Maybe.withDefault "N/A" >> List.singleton)
+        ]
     , legend = []
     , columns = baseColumns detailed scope ++ impactsColumns session ++ complementsColumns session
     }

--- a/src/Page/Explore/Table.elm
+++ b/src/Page/Explore/Table.elm
@@ -259,12 +259,21 @@ viewFacet { selectedFacets, onFacetToggle } items { key, toValues } =
 
              else
                 availableValues
+                    -- selected facet values first
+                    |> List.sortBy
+                        (\value ->
+                            if Set.member value selectedValues then
+                                0
+
+                            else
+                                1
+                        )
                     |> List.map
                         (\value ->
                             Html.label [ class "form-check d-flex align-items-start gap-2 cursor-pointer", title value ]
                                 [ input
                                     [ type_ "checkbox"
-                                    , class "form-check-input mt-1"
+                                    , class "form-check-input mt-1 no-outline"
                                     , checked (Set.member value selectedValues)
                                     , onCheck (onFacetToggle key value)
                                     ]

--- a/src/Page/Explore/Table.elm
+++ b/src/Page/Explore/Table.elm
@@ -5,6 +5,7 @@ module Page.Explore.Table exposing
     , Facets
     , Table
     , Value(..)
+    , updateFacets
     , viewDetails
     , viewList
     )
@@ -330,6 +331,27 @@ toCSV { columns } items =
                         |> List.map (.toValue >> valueToString item)
                 )
     }
+
+
+updateFacets : String -> String -> Bool -> Facets -> Facets
+updateFacets facetKey facetValue checked facetValues =
+    let
+        newSelectedValues =
+            facetValues
+                |> Dict.get facetKey
+                |> Maybe.withDefault Set.empty
+                |> (if checked then
+                        Set.insert facetValue
+
+                    else
+                        Set.remove facetValue
+                   )
+    in
+    if Set.isEmpty newSelectedValues then
+        Dict.remove facetKey facetValues
+
+    else
+        Dict.insert facetKey newSelectedValues facetValues
 
 
 valueToString : data -> Value comparable data -> String

--- a/src/Page/Explore/Table.elm
+++ b/src/Page/Explore/Table.elm
@@ -211,7 +211,7 @@ viewList routeToMsg defaultConfig tableState scope createTable items =
                         [ text "Télécharger ces données au format CSV" ]
                     ]
                 ]
-            , viewFacetsSidebar defaultConfig facets toSearchableString items
+            , viewFacetsSidebar defaultConfig facets items
             ]
 
 
@@ -221,8 +221,8 @@ applyFiltersAndSearch config facets toSearchableString =
         >> searchItems config toSearchableString
 
 
-viewFacet : Config data msg -> List (Facet data) -> (data -> String) -> List data -> Facet data -> Html msg
-viewFacet ({ selectedFacets } as config) facets toSearchableString items { key, toValues } =
+viewFacet : Config data msg -> List data -> Facet data -> Html msg
+viewFacet ({ selectedFacets } as config) items { key, toValues } =
     let
         selectedValues =
             Dict.get key selectedFacets
@@ -255,20 +255,20 @@ viewFacet ({ selectedFacets } as config) facets toSearchableString items { key, 
 
              else
                 List.concat
-                    [ selectedOptions |> List.map (viewFacetOption config True facets toSearchableString items key)
+                    [ selectedOptions |> List.map (viewFacetOption config True key)
                     , if not (List.isEmpty selectedOptions) then
                         [ div [ class "FacetCardSeparator border-bottom" ] [] ]
 
                       else
                         []
-                    , availableOptions |> List.map (viewFacetOption config False facets toSearchableString items key)
+                    , availableOptions |> List.map (viewFacetOption config False key)
                     ]
             )
         ]
 
 
-viewFacetOption : Config data msg -> Bool -> List (Facet data) -> (data -> String) -> List data -> String -> String -> Html msg
-viewFacetOption config isSelected facets toSearchableString items key value =
+viewFacetOption : Config data msg -> Bool -> String -> String -> Html msg
+viewFacetOption config isSelected key value =
     label
         [ class "form-check d-flex align-items-start gap-2 cursor-pointer"
         , classList [ ( "fw-semibold", isSelected ) ]
@@ -279,26 +279,21 @@ viewFacetOption config isSelected facets toSearchableString items key value =
             , class "form-check-input mt-1 no-outline"
             , checked isSelected
             , onCheck (config.onFacetToggle key value)
-            , items
-                |> hasFacetResults config facets toSearchableString key value
-                |> (||) isSelected
-                |> not
-                |> disabled
             ]
             []
         , span [ class "form-check-label text-truncate" ] [ text value ]
         ]
 
 
-viewFacetsSidebar : Config data msg -> List (Facet data) -> (data -> String) -> List data -> Html msg
-viewFacetsSidebar config facets toSearchableString items =
+viewFacetsSidebar : Config data msg -> List (Facet data) -> List data -> Html msg
+viewFacetsSidebar config facets items =
     if List.isEmpty facets then
         text ""
 
     else
         div [ class "col-xxl-2 col-xl-3 col-lg-3 col-md-12 col-sm-12" ]
             [ facets
-                |> List.map (viewFacet config facets toSearchableString items)
+                |> List.map (viewFacet config items)
                 |> div [ class "d-flex flex-column gap-2 sticky-top", style "top" "10px" ]
             ]
 
@@ -368,16 +363,6 @@ updateFacets key value checked =
                )
             >> Just
         )
-
-
-hasFacetResults : Config data msg -> List (Facet data) -> (data -> String) -> String -> String -> List data -> Bool
-hasFacetResults ({ selectedFacets } as config) facets toSearchableString key value =
-    applyFiltersAndSearch
-        { config | selectedFacets = selectedFacets |> updateFacets key value True }
-        facets
-        toSearchableString
-        >> List.isEmpty
-        >> not
 
 
 valueToString : data -> Value comparable data -> String

--- a/src/Page/Explore/Table.elm
+++ b/src/Page/Explore/Table.elm
@@ -159,9 +159,7 @@ viewList routeToMsg defaultConfig tableState scope createTable items =
                 }
 
         resultItems =
-            items
-                |> filterItems defaultConfig facets
-                |> searchItems defaultConfig toSearchableString
+            items |> applyFiltersAndSearch defaultConfig facets toSearchableString
 
         csv =
             { filename = "ecobalyse-" ++ Scope.toString scope ++ "-" ++ filename ++ ".csv"
@@ -190,18 +188,17 @@ viewList routeToMsg defaultConfig tableState scope createTable items =
         div [ class "row g-3" ]
             [ div [ classList [ ( "col-xxl-10 col-xl-9 col-lg-9 col-md-12 col-sm-12", facetsEnabled ) ] ]
                 [ div [ class "DatasetTable table-responsive table-scroll position-relative" ]
-                    [ case resultItems of
-                        [] ->
-                            Alert.simple
-                                { attributes = []
-                                , close = Nothing
-                                , content = [ text "Cette recherche n’a retourné aucun résultat" ]
-                                , level = Alert.Info
-                                , title = Nothing
-                                }
+                    [ if List.isEmpty resultItems then
+                        Alert.simple
+                            { attributes = []
+                            , close = Nothing
+                            , content = [ text "Cette recherche n’a retourné aucun résultat" ]
+                            , level = Alert.Info
+                            , title = Nothing
+                            }
 
-                        nonEmptyResult ->
-                            nonEmptyResult |> SortableTable.view config tableState
+                      else
+                        resultItems |> SortableTable.view config tableState
                     , div [ class "text-muted fs-7" ] legend
                     ]
                 , div [ class "text-end pt-3" ]
@@ -213,25 +210,31 @@ viewList routeToMsg defaultConfig tableState scope createTable items =
                         [ text "Télécharger ces données au format CSV" ]
                     ]
                 ]
-            , viewFacetsSidebar defaultConfig facets items
+            , viewFacetsSidebar defaultConfig facets toSearchableString items
             ]
 
 
-viewFacetsSidebar : Config data msg -> List (Facet data) -> List data -> Html msg
-viewFacetsSidebar config facets items =
+applyFiltersAndSearch : Config data msg -> List (Facet data) -> (data -> String) -> List data -> List data
+applyFiltersAndSearch config facets toSearchableString =
+    filterItems config facets
+        >> searchItems config toSearchableString
+
+
+viewFacetsSidebar : Config data msg -> List (Facet data) -> (data -> String) -> List data -> Html msg
+viewFacetsSidebar config facets toSearchableString items =
     if List.isEmpty facets then
         text ""
 
     else
         div [ class "col-xxl-2 col-xl-3 col-lg-3 col-md-12 col-sm-12" ]
             [ facets
-                |> List.map (viewFacet config items)
+                |> List.map (viewFacet config facets toSearchableString items)
                 |> div [ class "d-flex flex-column gap-2 sticky-top", style "top" "10px" ]
             ]
 
 
-viewFacet : Config data msg -> List data -> Facet data -> Html msg
-viewFacet { selectedFacets, onFacetToggle } items { key, toValues } =
+viewFacet : Config data msg -> List (Facet data) -> (data -> String) -> List data -> Facet data -> Html msg
+viewFacet ({ selectedFacets, onFacetToggle } as config) facets toSearchableString items { key, toValues } =
     let
         selectedValues =
             Dict.get key selectedFacets
@@ -265,11 +268,20 @@ viewFacet { selectedFacets, onFacetToggle } items { key, toValues } =
                         )
                     |> List.map
                         (\value ->
+                            let
+                                isSelected =
+                                    Set.member value selectedValues
+                            in
                             Html.label [ class "form-check d-flex align-items-start gap-2 cursor-pointer", title value ]
                                 [ input
                                     [ type_ "checkbox"
                                     , class "form-check-input mt-1 no-outline"
-                                    , checked (Set.member value selectedValues)
+                                    , checked isSelected
+                                    , items
+                                        |> hasFacetResults config facets toSearchableString key value
+                                        |> (||) isSelected
+                                        |> not
+                                        |> disabled
                                     , onCheck (onFacetToggle key value)
                                     ]
                                     []
@@ -287,17 +299,10 @@ filterItems { selectedFacets } facets =
             facets
                 |> List.all
                     (\{ key, toValues } ->
-                        case Dict.get key selectedFacets of
-                            Just selectedValues ->
-                                if Set.isEmpty selectedValues then
-                                    True
-
-                                else
-                                    Set.toList selectedValues
-                                        |> List.all (\selectedValue -> toValues item |> List.member selectedValue)
-
-                            Nothing ->
-                                True
+                        selectedFacets
+                            |> Dict.get key
+                            |> Maybe.map (Set.toList >> List.all (\v -> item |> toValues |> List.member v))
+                            |> Maybe.withDefault True
                     )
         )
 
@@ -350,6 +355,16 @@ updateFacets facetKey facetValue checked facetValues =
 
     else
         Dict.insert facetKey newSelectedValues facetValues
+
+
+hasFacetResults : Config data msg -> List (Facet data) -> (data -> String) -> String -> String -> List data -> Bool
+hasFacetResults ({ selectedFacets } as config) facets toSearchableString key value =
+    applyFiltersAndSearch
+        { config | selectedFacets = selectedFacets |> updateFacets key value True }
+        facets
+        toSearchableString
+        >> List.isEmpty
+        >> not
 
 
 valueToString : data -> Value comparable data -> String

--- a/src/Page/Explore/Table.elm
+++ b/src/Page/Explore/Table.elm
@@ -1,6 +1,8 @@
 module Page.Explore.Table exposing
     ( Column
     , Config
+    , Facet
+    , Facets
     , Table
     , Value(..)
     , viewDetails
@@ -11,10 +13,12 @@ import Base64
 import Csv.Encode as EncodeCsv exposing (Csv)
 import Data.Scope as Scope exposing (Scope)
 import Data.Text as Text
+import Dict exposing (Dict)
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (..)
 import Route exposing (Route)
+import Set exposing (Set)
 import String.Normalize as Normalize
 import Table as SortableTable
 import Views.Alert as Alert
@@ -27,6 +31,7 @@ type alias Table data comparable msg =
     , toId : data -> String
     , toRoute : data -> Route
     , toSearchableString : data -> String
+    , facets : List (Facet data)
     , columns : List (Column data comparable msg)
     , legend : List (Html msg)
     }
@@ -39,6 +44,16 @@ type alias Column data comparable msg =
     }
 
 
+type alias Facet data =
+    { key : String
+    , toValues : data -> List String
+    }
+
+
+type alias Facets =
+    Dict String (Set String)
+
+
 type Value comparable data
     = FloatValue (data -> Float)
     | IntValue (data -> Int)
@@ -49,8 +64,10 @@ type Value comparable data
 type alias Config data msg =
     { toId : data -> String
     , toMsg : SortableTable.State -> msg
+    , onFacetToggle : String -> String -> Bool -> msg
     , columns : List (SortableTable.Column data msg)
     , customizations : SortableTable.Customizations data msg
+    , selectedFacets : Facets
     , search : String
     }
 
@@ -91,7 +108,7 @@ viewList :
     -> Html msg
 viewList routeToMsg defaultConfig tableState scope createTable items =
     let
-        ({ filename, toId, toRoute, toSearchableString, columns, legend } as table) =
+        ({ filename, toId, toRoute, toSearchableString, facets, columns, legend } as table) =
             createTable { detailed = False, scope = scope }
 
         { customizations } =
@@ -143,6 +160,7 @@ viewList routeToMsg defaultConfig tableState scope createTable items =
 
         resultItems =
             items
+                |> filterItems facets defaultConfig.selectedFacets
                 |> searchItems defaultConfig toSearchableString
 
         csv =
@@ -152,6 +170,9 @@ viewList routeToMsg defaultConfig tableState scope createTable items =
                     |> toCSV table
                     |> EncodeCsv.toString
             }
+
+        facetsEnabled =
+            not (List.isEmpty facets)
     in
     if List.isEmpty items then
         Alert.simple
@@ -166,35 +187,93 @@ viewList routeToMsg defaultConfig tableState scope createTable items =
             }
 
     else
-        div []
-            [ div [ class "DatasetTable table-responsive table-scroll position-relative" ]
-                [ case resultItems of
-                    [] ->
-                        Alert.simple
-                            { attributes = []
-                            , close = Nothing
-                            , content =
-                                [ "Aucun résultat pour la recherche *«{search}»*"
-                                    |> String.replace "{search}" defaultConfig.search
-                                    |> Markdown.simple []
-                                ]
-                            , level = Alert.Info
-                            , title = Nothing
-                            }
+        div [ class "row g-3" ]
+            [ div [ classList [ ( "col-xxl-10 col-xl-9 col-lg-9 col-md-12 col-sm-12", facetsEnabled ) ] ]
+                [ div [ class "DatasetTable table-responsive table-scroll position-relative" ]
+                    [ case resultItems of
+                        [] ->
+                            Alert.simple
+                                { attributes = []
+                                , close = Nothing
+                                , content =
+                                    [ "Aucun résultat pour la recherche *«{search}»*"
+                                        |> String.replace "{search}" defaultConfig.search
+                                        |> Markdown.simple []
+                                    ]
+                                , level = Alert.Info
+                                , title = Nothing
+                                }
 
-                    nonEmptyResult ->
-                        nonEmptyResult |> SortableTable.view config tableState
-                , div [ class "text-muted fs-7" ] legend
-                ]
-            , div [ class "text-end pt-3" ]
-                [ a
-                    [ class "btn btn-secondary"
-                    , href <| "data:text/csv;base64," ++ Base64.encode csv.content
-                    , download csv.filename
+                        nonEmptyResult ->
+                            nonEmptyResult |> SortableTable.view config tableState
+                    , div [ class "text-muted fs-7" ] legend
                     ]
-                    [ text "Télécharger ces données au format CSV" ]
+                , div [ class "text-end pt-3" ]
+                    [ a
+                        [ class "btn btn-secondary"
+                        , href <| "data:text/csv;base64," ++ Base64.encode csv.content
+                        , download csv.filename
+                        ]
+                        [ text "Télécharger ces données au format CSV" ]
+                    ]
                 ]
+            , viewFacetsSidebar defaultConfig facets items
             ]
+
+
+viewFacetsSidebar : Config data msg -> List (Facet data) -> List data -> Html msg
+viewFacetsSidebar config facets items =
+    if List.isEmpty facets then
+        text ""
+
+    else
+        div [ class "col-xxl-2 col-xl-3 col-lg-3 col-md-12 col-sm-12" ]
+            [ facets
+                |> List.map (viewFacet config items)
+                |> div [ class "d-flex flex-column gap-2 sticky-top", style "top" "10px" ]
+            ]
+
+
+viewFacet : Config data msg -> List data -> Facet data -> Html msg
+viewFacet { selectedFacets, onFacetToggle } items { key, toValues } =
+    let
+        selectedValues =
+            Dict.get key selectedFacets
+                |> Maybe.withDefault Set.empty
+
+        availableValues =
+            items
+                |> List.concatMap toValues
+                |> Set.fromList
+                |> Set.toList
+    in
+    div [ class "card fs-8" ]
+        [ div [ class "card-header fw-semibold py-2" ] [ text key ]
+        , div
+            [ class "card-body d-flex flex-column gap-1 p-2"
+            , style "max-height" "200px"
+            , style "overflow-y" "auto"
+            ]
+            (if List.isEmpty availableValues then
+                [ em [ class "text-muted small" ] [ text "Aucune valeur disponible" ] ]
+
+             else
+                availableValues
+                    |> List.map
+                        (\value ->
+                            Html.label [ class "form-check d-flex align-items-start gap-2 cursor-pointer", title value ]
+                                [ input
+                                    [ type_ "checkbox"
+                                    , class "form-check-input mt-1"
+                                    , checked (Set.member value selectedValues)
+                                    , onCheck (onFacetToggle key value)
+                                    ]
+                                    []
+                                , span [ class "form-check-label text-truncate" ] [ text value ]
+                                ]
+                        )
+            )
+        ]
 
 
 searchItems : Config data msg -> (data -> String) -> List data -> List data
@@ -204,6 +283,28 @@ searchItems { search } toSearchableString =
         , query = search
         , toString = toSearchableString
         }
+
+
+filterItems : List (Facet data) -> Facets -> List data -> List data
+filterItems facets selectedFacets =
+    List.filter
+        (\item ->
+            facets
+                |> List.all
+                    (\{ key, toValues } ->
+                        case Dict.get key selectedFacets of
+                            Just selectedValues ->
+                                if Set.isEmpty selectedValues then
+                                    True
+
+                                else
+                                    Set.toList selectedValues
+                                        |> List.all (\selectedValue -> toValues item |> List.member selectedValue)
+
+                            Nothing ->
+                                True
+                    )
+        )
 
 
 toCSV : Table data comparable msg -> List data -> Csv

--- a/src/Page/Explore/Table.elm
+++ b/src/Page/Explore/Table.elm
@@ -18,6 +18,7 @@ import Dict exposing (Dict)
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (..)
+import List.Extra as LE
 import Route exposing (Route)
 import Set exposing (Set)
 import String.Normalize as Normalize
@@ -243,13 +244,21 @@ viewFacet ({ selectedFacets, onFacetToggle } as config) facets toSearchableStrin
         availableValues =
             items
                 |> List.concatMap toValues
-                |> Set.fromList
-                |> Set.toList
+                |> LE.unique
+                -- selected facet values first
+                |> List.sortBy
+                    (\value ->
+                        if Set.member value selectedValues then
+                            0
+
+                        else
+                            1
+                    )
     in
     div [ class "card FacetCard" ]
         [ div [ class "card-header fw-bold py-2" ] [ text key ]
         , div
-            [ class "card-body d-flex flex-column gap-1 p-2"
+            [ class "card-body d-flex flex-column gap-1 p-2 no-scroll-chaining"
             , attribute "data-scroll-id" key
             ]
             (if List.isEmpty availableValues then
@@ -257,15 +266,6 @@ viewFacet ({ selectedFacets, onFacetToggle } as config) facets toSearchableStrin
 
              else
                 availableValues
-                    -- selected facet values first
-                    |> List.sortBy
-                        (\value ->
-                            if Set.member value selectedValues then
-                                0
-
-                            else
-                                1
-                        )
                     |> List.map
                         (\value ->
                             let
@@ -337,24 +337,24 @@ toCSV { columns } items =
 
 
 updateFacets : String -> String -> Bool -> Facets -> Facets
-updateFacets facetKey facetValue checked facetValues =
+updateFacets key value checked values =
     let
         newSelectedValues =
-            facetValues
-                |> Dict.get facetKey
+            values
+                |> Dict.get key
                 |> Maybe.withDefault Set.empty
                 |> (if checked then
-                        Set.insert facetValue
+                        Set.insert value
 
                     else
-                        Set.remove facetValue
+                        Set.remove value
                    )
     in
     if Set.isEmpty newSelectedValues then
-        Dict.remove facetKey facetValues
+        Dict.remove key values
 
     else
-        Dict.insert facetKey newSelectedValues facetValues
+        Dict.insert key newSelectedValues values
 
 
 hasFacetResults : Config data msg -> List (Facet data) -> (data -> String) -> String -> String -> List data -> Bool

--- a/src/Page/Explore/Table.elm
+++ b/src/Page/Explore/Table.elm
@@ -221,6 +221,75 @@ applyFiltersAndSearch config facets toSearchableString =
         >> searchItems config toSearchableString
 
 
+viewFacet : Config data msg -> List (Facet data) -> (data -> String) -> List data -> Facet data -> Html msg
+viewFacet ({ selectedFacets } as config) facets toSearchableString items { key, toValues } =
+    let
+        selectedValues =
+            Dict.get key selectedFacets
+                |> Maybe.withDefault Set.empty
+
+        -- group values to have selected first, available last
+        ( selectedOptions, availableOptions ) =
+            items
+                |> List.concatMap toValues
+                |> LE.unique
+                |> List.foldl
+                    (\value ( selected, available ) ->
+                        if Set.member value selectedValues then
+                            ( value :: selected, available )
+
+                        else
+                            ( selected, value :: available )
+                    )
+                    ( [], [] )
+                |> Tuple.mapBoth List.sort List.sort
+    in
+    div [ class "FacetCard card" ]
+        [ div [ class "card-header fw-bold py-2" ] [ text key ]
+        , div
+            [ class "FacetCardBody card-body d-flex flex-column gap-1 p-2 no-scroll-chaining"
+            , attribute "data-scroll-id" key
+            ]
+            (if List.isEmpty (selectedOptions ++ availableOptions) then
+                [ em [ class "text-muted small" ] [ text "Aucune valeur disponible" ] ]
+
+             else
+                List.concat
+                    [ selectedOptions |> List.map (viewFacetOption config True facets toSearchableString items key)
+                    , if not (List.isEmpty selectedOptions) then
+                        [ div [ class "FacetCardSeparator border-bottom" ] [] ]
+
+                      else
+                        []
+                    , availableOptions |> List.map (viewFacetOption config False facets toSearchableString items key)
+                    ]
+            )
+        ]
+
+
+viewFacetOption : Config data msg -> Bool -> List (Facet data) -> (data -> String) -> List data -> String -> String -> Html msg
+viewFacetOption config isSelected facets toSearchableString items key value =
+    label
+        [ class "form-check d-flex align-items-start gap-2 cursor-pointer"
+        , classList [ ( "fw-semibold", isSelected ) ]
+        , title value
+        ]
+        [ input
+            [ type_ "checkbox"
+            , class "form-check-input mt-1 no-outline"
+            , checked isSelected
+            , onCheck (config.onFacetToggle key value)
+            , items
+                |> hasFacetResults config facets toSearchableString key value
+                |> (||) isSelected
+                |> not
+                |> disabled
+            ]
+            []
+        , span [ class "form-check-label text-truncate" ] [ text value ]
+        ]
+
+
 viewFacetsSidebar : Config data msg -> List (Facet data) -> (data -> String) -> List data -> Html msg
 viewFacetsSidebar config facets toSearchableString items =
     if List.isEmpty facets then
@@ -232,64 +301,6 @@ viewFacetsSidebar config facets toSearchableString items =
                 |> List.map (viewFacet config facets toSearchableString items)
                 |> div [ class "d-flex flex-column gap-2 sticky-top", style "top" "10px" ]
             ]
-
-
-viewFacet : Config data msg -> List (Facet data) -> (data -> String) -> List data -> Facet data -> Html msg
-viewFacet ({ selectedFacets, onFacetToggle } as config) facets toSearchableString items { key, toValues } =
-    let
-        selectedValues =
-            Dict.get key selectedFacets
-                |> Maybe.withDefault Set.empty
-
-        availableValues =
-            items
-                |> List.concatMap toValues
-                |> LE.unique
-                -- selected facet values first
-                |> List.sortBy
-                    (\value ->
-                        if Set.member value selectedValues then
-                            0
-
-                        else
-                            1
-                    )
-    in
-    div [ class "card FacetCard" ]
-        [ div [ class "card-header fw-bold py-2" ] [ text key ]
-        , div
-            [ class "card-body d-flex flex-column gap-1 p-2 no-scroll-chaining"
-            , attribute "data-scroll-id" key
-            ]
-            (if List.isEmpty availableValues then
-                [ em [ class "text-muted small" ] [ text "Aucune valeur disponible" ] ]
-
-             else
-                availableValues
-                    |> List.map
-                        (\value ->
-                            let
-                                isSelected =
-                                    Set.member value selectedValues
-                            in
-                            Html.label [ class "form-check d-flex align-items-start gap-2 cursor-pointer", title value ]
-                                [ input
-                                    [ type_ "checkbox"
-                                    , class "form-check-input mt-1 no-outline"
-                                    , checked isSelected
-                                    , items
-                                        |> hasFacetResults config facets toSearchableString key value
-                                        |> (||) isSelected
-                                        |> not
-                                        |> disabled
-                                    , onCheck (onFacetToggle key value)
-                                    ]
-                                    []
-                                , span [ class "form-check-label text-truncate" ] [ text value ]
-                                ]
-                        )
-            )
-        ]
 
 
 filterItems : Config data msg -> List (Facet data) -> List data -> List data

--- a/src/Page/Explore/Table.elm
+++ b/src/Page/Explore/Table.elm
@@ -211,7 +211,11 @@ viewList routeToMsg defaultConfig tableState scope createTable items =
                         [ text "Télécharger ces données au format CSV" ]
                     ]
                 ]
-            , viewFacetsSidebar defaultConfig facets items
+            , div
+                [ class "col-xxl-2 col-xl-3 col-lg-3 col-md-12 col-sm-12 overflow-y-scroll sticky-top"
+                ]
+                [ viewFacetsSidebar defaultConfig facets items
+                ]
             ]
 
 
@@ -287,15 +291,9 @@ viewFacetOption config isSelected key value =
 
 viewFacetsSidebar : Config data msg -> List (Facet data) -> List data -> Html msg
 viewFacetsSidebar config facets items =
-    if List.isEmpty facets then
-        text ""
-
-    else
-        div [ class "col-xxl-2 col-xl-3 col-lg-3 col-md-12 col-sm-12" ]
-            [ facets
-                |> List.map (viewFacet config items)
-                |> div [ class "d-flex flex-column gap-2 sticky-top", style "top" "10px" ]
-            ]
+    facets
+        |> List.map (viewFacet config items)
+        |> div [ class "d-flex flex-column gap-2" ]
 
 
 filterItems : Config data msg -> List (Facet data) -> List data -> List data

--- a/src/Page/Explore/Table.elm
+++ b/src/Page/Explore/Table.elm
@@ -160,7 +160,7 @@ viewList routeToMsg defaultConfig tableState scope createTable items =
 
         resultItems =
             items
-                |> filterItems facets defaultConfig.selectedFacets
+                |> filterItems defaultConfig facets
                 |> searchItems defaultConfig toSearchableString
 
         csv =
@@ -280,17 +280,8 @@ viewFacet { selectedFacets, onFacetToggle } items { key, toValues } =
         ]
 
 
-searchItems : Config data msg -> (data -> String) -> List data -> List data
-searchItems { search } toSearchableString =
-    Text.search
-        { minQueryLength = 2
-        , query = search
-        , toString = toSearchableString
-        }
-
-
-filterItems : List (Facet data) -> Facets -> List data -> List data
-filterItems facets selectedFacets =
+filterItems : Config data msg -> List (Facet data) -> List data -> List data
+filterItems { selectedFacets } facets =
     List.filter
         (\item ->
             facets
@@ -309,6 +300,15 @@ filterItems facets selectedFacets =
                                 True
                     )
         )
+
+
+searchItems : Config data msg -> (data -> String) -> List data -> List data
+searchItems { search } toSearchableString =
+    Text.search
+        { minQueryLength = 2
+        , query = search
+        , toString = toSearchableString
+        }
 
 
 toCSV : Table data comparable msg -> List data -> Csv

--- a/src/Page/Explore/Table.elm
+++ b/src/Page/Explore/Table.elm
@@ -243,12 +243,10 @@ viewFacet { selectedFacets, onFacetToggle } items { key, toValues } =
                 |> Set.fromList
                 |> Set.toList
     in
-    div [ class "card fs-8" ]
-        [ div [ class "card-header fw-semibold py-2" ] [ text key ]
+    div [ class "card FacetCard" ]
+        [ div [ class "card-header fw-bold py-2" ] [ text key ]
         , div
             [ class "card-body d-flex flex-column gap-1 p-2"
-            , style "max-height" "200px"
-            , style "overflow-y" "auto"
             , attribute "data-scroll-id" key
             ]
             (if List.isEmpty availableValues then

--- a/src/Page/Explore/Table.elm
+++ b/src/Page/Explore/Table.elm
@@ -22,7 +22,6 @@ import Set exposing (Set)
 import String.Normalize as Normalize
 import Table as SortableTable
 import Views.Alert as Alert
-import Views.Markdown as Markdown
 import Views.Table as TableView
 
 
@@ -249,6 +248,7 @@ viewFacet { selectedFacets, onFacetToggle } items { key, toValues } =
             [ class "card-body d-flex flex-column gap-1 p-2"
             , style "max-height" "200px"
             , style "overflow-y" "auto"
+            , attribute "data-scroll-id" key
             ]
             (if List.isEmpty availableValues then
                 [ em [ class "text-muted small" ] [ text "Aucune valeur disponible" ] ]

--- a/src/Page/Explore/Table.elm
+++ b/src/Page/Explore/Table.elm
@@ -242,7 +242,7 @@ viewFacet ({ selectedFacets } as config) items { key, toValues } =
                             ( selected, value :: available )
                     )
                     ( [], [] )
-                |> Tuple.mapBoth Text.sortStrings Text.sortStrings
+                |> Tuple.mapBoth Text.sortI18nStrings Text.sortI18nStrings
     in
     div [ class "FacetCard card" ]
         [ div [ class "card-header fw-bold py-2" ] [ text key ]

--- a/src/Page/Explore/Table.elm
+++ b/src/Page/Explore/Table.elm
@@ -195,11 +195,7 @@ viewList routeToMsg defaultConfig tableState scope createTable items =
                             Alert.simple
                                 { attributes = []
                                 , close = Nothing
-                                , content =
-                                    [ "Aucun résultat pour la recherche *«{search}»*"
-                                        |> String.replace "{search}" defaultConfig.search
-                                        |> Markdown.simple []
-                                    ]
+                                , content = [ text "Cette recherche n’a retourné aucun résultat" ]
                                 , level = Alert.Info
                                 , title = Nothing
                                 }

--- a/src/Page/Explore/Table.elm
+++ b/src/Page/Explore/Table.elm
@@ -337,24 +337,17 @@ toCSV { columns } items =
 
 
 updateFacets : String -> String -> Bool -> Facets -> Facets
-updateFacets key value checked values =
-    let
-        newSelectedValues =
-            values
-                |> Dict.get key
-                |> Maybe.withDefault Set.empty
-                |> (if checked then
-                        Set.insert value
+updateFacets key value checked =
+    Dict.update key
+        (Maybe.withDefault Set.empty
+            >> (if checked then
+                    Set.insert value
 
-                    else
-                        Set.remove value
-                   )
-    in
-    if Set.isEmpty newSelectedValues then
-        Dict.remove key values
-
-    else
-        Dict.insert key newSelectedValues values
+                else
+                    Set.remove value
+               )
+            >> Just
+        )
 
 
 hasFacetResults : Config data msg -> List (Facet data) -> (data -> String) -> String -> String -> List data -> Bool

--- a/src/Page/Explore/Table.elm
+++ b/src/Page/Explore/Table.elm
@@ -242,7 +242,7 @@ viewFacet ({ selectedFacets } as config) facets toSearchableString items { key, 
                             ( selected, value :: available )
                     )
                     ( [], [] )
-                |> Tuple.mapBoth List.sort List.sort
+                |> Tuple.mapBoth Text.sortStrings Text.sortStrings
     in
     div [ class "FacetCard card" ]
         [ div [ class "card-header fw-bold py-2" ] [ text key ]

--- a/src/Page/Explore/Table.elm
+++ b/src/Page/Explore/Table.elm
@@ -312,7 +312,16 @@ filterItems { selectedFacets } facets =
                     (\{ key, toValues } ->
                         selectedFacets
                             |> Dict.get key
-                            |> Maybe.map (Set.toList >> List.all (\v -> item |> toValues |> List.member v))
+                            |> Maybe.map
+                                (\selectedValues ->
+                                    if Set.isEmpty selectedValues then
+                                        True
+
+                                    else
+                                        selectedValues
+                                            |> Set.toList
+                                            |> List.any (\value -> item |> toValues |> List.member value)
+                                )
                             |> Maybe.withDefault True
                     )
         )

--- a/src/Page/Explore/TextileExamples.elm
+++ b/src/Page/Explore/TextileExamples.elm
@@ -27,6 +27,7 @@ table { db } { maxScore, maxPer100g } { detailed, scope } =
     , toId = Tuple.first >> .id >> Uuid.toString
     , toRoute = Tuple.first >> .id >> Just >> Dataset.TextileExamples >> Route.Explore scope
     , toSearchableString = Tuple.first >> Example.toSearchableString
+    , facets = []
     , legend = []
     , columns =
         [ { label = "Nom"

--- a/src/Page/Explore/TextileExamples.elm
+++ b/src/Page/Explore/TextileExamples.elm
@@ -27,7 +27,9 @@ table { db } { maxScore, maxPer100g } { detailed, scope } =
     , toId = Tuple.first >> .id >> Uuid.toString
     , toRoute = Tuple.first >> .id >> Just >> Dataset.TextileExamples >> Route.Explore scope
     , toSearchableString = Tuple.first >> Example.toSearchableString
-    , facets = []
+    , facets =
+        [ Table.Facet "Catégorie" (Tuple.first >> .category >> List.singleton)
+        ]
     , legend = []
     , columns =
         [ { label = "Nom"

--- a/src/Page/Explore/TextileMaterials.elm
+++ b/src/Page/Explore/TextileMaterials.elm
@@ -50,6 +50,7 @@ table db { detailed, scope } =
     , toId = .id >> Material.idToString
     , toRoute = .id >> Just >> Dataset.TextileMaterials >> Route.Explore scope
     , toSearchableString = Material.toSearchableString db.countries
+    , facets = []
     , legend = []
     , columns =
         [ { label = "Identifiant"

--- a/src/Page/Explore/TextileMaterials.elm
+++ b/src/Page/Explore/TextileMaterials.elm
@@ -52,7 +52,7 @@ table db { detailed, scope } =
     , toSearchableString = Material.toSearchableString db.countries
     , facets =
         [ Table.Facet "Origine de la matière" (.origin >> Origin.toLabel >> List.singleton)
-        , Table.Facet "\tOrigine géographique" (.geographicOrigin >> List.singleton)
+        , Table.Facet "Origine géographique" (.geographicOrigin >> List.singleton)
         , Table.Facet "Recyclage" (.recycledFrom >> recycledToString >> List.singleton)
         , Table.Facet "Pays de production et de filature par défaut"
             (.defaultCountry

--- a/src/Page/Explore/TextileMaterials.elm
+++ b/src/Page/Explore/TextileMaterials.elm
@@ -23,8 +23,8 @@ import Views.Link as Link
 
 
 recycledToString : Maybe Id -> String
-recycledToString maybeMaterialID =
-    Text.yesNo (Maybe.isJust maybeMaterialID)
+recycledToString =
+    Maybe.isJust >> Text.yesNo
 
 
 getRecycledProcess : List Material -> Material -> Maybe Process.Process
@@ -53,11 +53,7 @@ table db { detailed, scope } =
     , facets =
         [ Table.Facet "Origine de la matière" (.origin >> Origin.toLabel >> List.singleton)
         , Table.Facet "\tOrigine géographique" (.geographicOrigin >> List.singleton)
-        , Table.Facet "Recyclage"
-            (.recycledFrom
-                >> recycledToString
-                >> List.singleton
-            )
+        , Table.Facet "Recyclage" (.recycledFrom >> recycledToString >> List.singleton)
         , Table.Facet "Pays de production et de filature par défaut"
             (.defaultCountry
                 >> (\code -> Country.findByCode code db.countries)

--- a/src/Page/Explore/TextileMaterials.elm
+++ b/src/Page/Explore/TextileMaterials.elm
@@ -6,6 +6,7 @@ import Data.Gitbook as Gitbook
 import Data.Process as Process
 import Data.Scope exposing (Scope)
 import Data.Split as Split
+import Data.Text as Text
 import Data.Textile.Material as Material exposing (Id, Material)
 import Data.Textile.Material.Origin as Origin
 import Data.Unit as Unit
@@ -23,9 +24,7 @@ import Views.Link as Link
 
 recycledToString : Maybe Id -> String
 recycledToString maybeMaterialID =
-    maybeMaterialID
-        |> Maybe.map (always "oui")
-        |> Maybe.withDefault "non"
+    Text.yesNo (Maybe.isJust maybeMaterialID)
 
 
 getRecycledProcess : List Material -> Material -> Maybe Process.Process
@@ -56,15 +55,8 @@ table db { detailed, scope } =
         , Table.Facet "\tOrigine géographique" (.geographicOrigin >> List.singleton)
         , Table.Facet "Recyclage"
             (.recycledFrom
-                >> Maybe.isJust
-                >> (\value ->
-                        [ if value then
-                            "oui"
-
-                          else
-                            "non"
-                        ]
-                   )
+                >> recycledToString
+                >> List.singleton
             )
         , Table.Facet "Pays de production et de filature par défaut"
             (.defaultCountry

--- a/src/Page/Explore/TextileMaterials.elm
+++ b/src/Page/Explore/TextileMaterials.elm
@@ -11,6 +11,7 @@ import Data.Textile.Material.Origin as Origin
 import Data.Unit as Unit
 import Html exposing (..)
 import Html.Attributes exposing (..)
+import Maybe.Extra as Maybe
 import Page.Explore.Table as Table exposing (Table)
 import Route
 import Static.Db exposing (Db)
@@ -50,7 +51,29 @@ table db { detailed, scope } =
     , toId = .id >> Material.idToString
     , toRoute = .id >> Just >> Dataset.TextileMaterials >> Route.Explore scope
     , toSearchableString = Material.toSearchableString db.countries
-    , facets = []
+    , facets =
+        [ Table.Facet "Origine de la matière" (.origin >> Origin.toLabel >> List.singleton)
+        , Table.Facet "\tOrigine géographique" (.geographicOrigin >> List.singleton)
+        , Table.Facet "Recyclage"
+            (.recycledFrom
+                >> Maybe.isJust
+                >> (\value ->
+                        [ if value then
+                            "oui"
+
+                          else
+                            "non"
+                        ]
+                   )
+            )
+        , Table.Facet "Pays de production et de filature par défaut"
+            (.defaultCountry
+                >> (\code -> Country.findByCode code db.countries)
+                >> Result.map .name
+                >> Result.withDefault "N/A"
+                >> List.singleton
+            )
+        ]
     , legend = []
     , columns =
         [ { label = "Identifiant"

--- a/src/Page/Explore/TextileMaterials.elm
+++ b/src/Page/Explore/TextileMaterials.elm
@@ -57,7 +57,7 @@ table db { detailed, scope } =
         , Table.Facet "Pays de production et de filature par défaut"
             (.defaultCountry
                 >> (\code -> Country.findByCode code db.countries)
-                >> Result.map .name
+                >> Result.map (\{ code, name } -> name ++ " (" ++ Country.codeToString code ++ ")")
                 >> Result.withDefault "N/A"
                 >> List.singleton
             )

--- a/src/Page/Explore/TextileProducts.elm
+++ b/src/Page/Explore/TextileProducts.elm
@@ -39,7 +39,11 @@ table { componentConfig, db } { detailed, scope } =
     , toId = .id >> Product.idToString
     , toRoute = .id >> Just >> Dataset.TextileProducts >> Route.Explore scope
     , toSearchableString = Product.toSearchableString
-    , facets = []
+    , facets =
+        [ Table.Facet "Confection (complexité)" (.making >> .complexity >> MakingComplexity.toLabel >> List.singleton)
+        , Table.Facet "Étoffe" (.fabric >> Fabric.toLabel >> List.singleton)
+        , Table.Facet "Jours de portée" (.use >> .daysOfWear >> Duration.inDays >> String.fromFloat >> List.singleton)
+        ]
     , legend =
         [ ul [ class "list-unstyled text-muted p-2 m-0" ]
             [ li [] [ strong [] [ text "*" ], text " Modifié au changement de catégorie de produit" ]

--- a/src/Page/Explore/TextileProducts.elm
+++ b/src/Page/Explore/TextileProducts.elm
@@ -39,6 +39,7 @@ table { componentConfig, db } { detailed, scope } =
     , toId = .id >> Product.idToString
     , toRoute = .id >> Just >> Dataset.TextileProducts >> Route.Explore scope
     , toSearchableString = Product.toSearchableString
+    , facets = []
     , legend =
         [ ul [ class "list-unstyled text-muted p-2 m-0" ]
             [ li [] [ strong [] [ text "*" ], text " Modifié au changement de catégorie de produit" ]

--- a/src/Page/Food.elm
+++ b/src/Page/Food.elm
@@ -365,7 +365,7 @@ update ({ db, queries } as session) msg model =
 
         OnStageClick stageId ->
             createPageUpdate session model
-                |> App.withCmds [ Ports.scrollIntoView stageId ]
+                |> App.withCmds [ Ports.scrollIntoView <| "#" ++ stageId ]
 
         OpenComparator ->
             { model | modal = ComparatorModal }

--- a/src/Page/Textile.elm
+++ b/src/Page/Textile.elm
@@ -423,7 +423,7 @@ update ({ db, queries, navKey } as session) msg model =
 
         ( OnStageClick stageId, _ ) ->
             createPageUpdate session model
-                |> App.withCmds [ Ports.scrollIntoView stageId ]
+                |> App.withCmds [ Ports.scrollIntoView <| "#" ++ stageId ]
 
         ( RemoveMaterial materialId, _ ) ->
             createPageUpdate session model

--- a/styles.scss
+++ b/styles.scss
@@ -876,6 +876,17 @@ q {
   }
 }
 
+.Facet {
+  &Card {
+    font-size: 0.85rem;
+
+    .card-body {
+      max-height: 200px;
+      overflow-y: auto;
+    }
+  }
+}
+
 .Footer {
   border-top: 3px solid $primary;
   &InstitutionLink {

--- a/styles.scss
+++ b/styles.scss
@@ -880,13 +880,18 @@ q {
   &Card {
     font-size: 0.85rem;
 
-    .card-body {
+    &Body {
       max-height: 200px;
       overflow-y: auto;
 
       input[type="checkbox"]:not(:checked) {
         border-color: $text-dark !important;
       }
+    }
+
+    &Separator {
+      height: 1px;
+      margin-top: -5px;
     }
   }
 }

--- a/styles.scss
+++ b/styles.scss
@@ -883,6 +883,10 @@ q {
     .card-body {
       max-height: 200px;
       overflow-y: auto;
+
+      input[type="checkbox"]:not(:checked) {
+        border-color: $text-dark !important;
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes #1612 and beyond.

This patch implements a simple faceted-like search mechanism, allowing adding filtering capabilities to the current explorer list views.

I've added facets to the processes list view:

<img width="2642" height="1725" alt="image" src="https://github.com/user-attachments/assets/50d7f2d6-c16a-494f-bc6b-af73a9f1850c" />

And the textile materials one:

<img width="2660" height="1521" alt="image" src="https://github.com/user-attachments/assets/b91db997-9525-4c24-930b-11f165a6d3f8" />

The introduced API is super dumb and generic enough to allow adding more filters whenever needed.