### PR TITLE
style(generic,ui): improve element edit modal ux

### DIFF
--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -92,6 +92,7 @@ module Data.Component exposing
     , sumLifeCycleImpacts
     , targetElementToString
     , toSearchableString
+    , transformListToString
     , tryMapItems
     , updateConsumptionAmount
     , updateDistribution
@@ -1900,6 +1901,22 @@ toSearchableString db component =
         , component.comment |> Maybe.withDefault ""
         , component |> elementsToString db |> Result.withDefault ""
         ]
+
+
+transformListToString : List ExpandedTransform -> String
+transformListToString =
+    List.map
+        (\{ country, process } ->
+            Process.getDisplayName process
+                ++ (case country of
+                        Just { code } ->
+                            " (" ++ Country.codeToString code ++ ")"
+
+                        Nothing ->
+                            ""
+                   )
+        )
+        >> String.join ", "
 
 
 {-| Update a list of component items that may fail

--- a/src/Page/Object.elm
+++ b/src/Page/Object.elm
@@ -1081,7 +1081,7 @@ modalView session ({ modals } as model) modal =
 
         EditElementModal { name } targetElement ->
             ModalView.view
-                { size = ModalView.CustomPercentWidth 70
+                { size = ModalView.ExtraLarge
                 , close = SetModals (List.drop 1 modals)
                 , noOp = NoOp
                 , title = "Modifier l'élément #" ++ String.fromInt (Tuple.second targetElement + 1)

--- a/src/Page/Object.elm
+++ b/src/Page/Object.elm
@@ -1081,7 +1081,7 @@ modalView session ({ modals } as model) modal =
 
         EditElementModal { name } targetElement ->
             ModalView.view
-                { size = ModalView.ExtraLarge
+                { size = ModalView.CustomPercentWidth 70
                 , close = SetModals (List.drop 1 modals)
                 , noOp = NoOp
                 , title = "Modifier l'élément #" ++ String.fromInt (Tuple.second targetElement + 1)

--- a/src/Page/Object.elm
+++ b/src/Page/Object.elm
@@ -1081,7 +1081,7 @@ modalView session ({ modals } as model) modal =
 
         EditElementModal { name } targetElement ->
             ModalView.view
-                { size = ModalView.Large
+                { size = ModalView.ExtraLarge
                 , close = SetModals (List.drop 1 modals)
                 , noOp = NoOp
                 , title = "Modifier l'élément #" ++ String.fromInt (Tuple.second targetElement + 1)

--- a/src/Page/Object.elm
+++ b/src/Page/Object.elm
@@ -1084,8 +1084,8 @@ modalView session ({ modals } as model) modal =
                 { size = ModalView.Large
                 , close = SetModals (List.drop 1 modals)
                 , noOp = NoOp
-                , title = "Modifier l'élément #" ++ String.fromInt (Tuple.second targetElement + 1) ++ " du composant “" ++ name ++ "”"
-                , subTitle = Nothing
+                , title = "Modifier l'élément #" ++ String.fromInt (Tuple.second targetElement + 1)
+                , subTitle = Just <| "du composant “" ++ name ++ "”"
                 , formAction = Nothing
                 , content =
                     [ ComponentView.elementEditModalView

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -708,12 +708,14 @@ elementView config (( component, _ ) as targetItem) elementIndex { amount, mater
                     [ button
                         [ type_ "button"
                         , class "btn btn-outline-secondary"
+                        , attribute "aria-label" "Modifier l’élément"
                         , onClick (config.openEditElementModal component ( targetItem, elementIndex ))
                         ]
                         [ Icon.pencil ]
                     , button
                         [ type_ "button"
                         , class "btn btn-outline-secondary"
+                        , attribute "aria-label" "Supprimer l’élément"
                         , onClick (config.removeElement ( targetItem, elementIndex ))
                         ]
                         [ Icon.trash ]

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -922,7 +922,7 @@ elementTransformsView config targetElement transformsResults transforms =
                 [ td [] []
                 , td [ class "text-end align-middle text-nowrap" ] []
                 , td
-                    [ class "text-truncate align-middle w-100 cursor-help"
+                    [ class "text-truncate align-middle w-66 cursor-help "
 
                     -- Note: allows truncated ellipsis in table cells https://stackoverflow.com/a/11877033/330911
                     , style "max-width" "0"
@@ -933,7 +933,7 @@ elementTransformsView config targetElement transformsResults transforms =
                     ]
                 , td [ class "text-end align-middle text-nowrap" ]
                     [ transformCountrySelector
-                        { attributes = [ style "min-width" "68px" ]
+                        { attributes = []
                         , countries = config.db.countries
                         , domId =
                             "transform-country-"
@@ -1005,7 +1005,7 @@ transformCountrySelector config =
                     [ text <|
                         case maybeCode of
                             Just code ->
-                                Country.codeToString code ++ " - " ++ name
+                                name ++ " (" ++ Country.codeToString code ++ ")"
 
                             Nothing ->
                                 "---"

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -665,14 +665,6 @@ countrySelector config =
             ]
 
 
-iconifiedLine : Html msg -> String -> Html msg
-iconifiedLine icon content =
-    span [ class "d-flex align-items-center gap-1" ]
-        [ span [ class "ComponentElementIcon me-0" ] [ icon ]
-        , text content
-        ]
-
-
 elementView : Config db msg -> TargetItem -> Index -> ExpandedElement -> Results -> Html msg
 elementView config (( component, _ ) as targetItem) elementIndex { amount, material, transforms } elementResults =
     tbody []
@@ -694,15 +686,13 @@ elementView config (( component, _ ) as targetItem) elementIndex { amount, mater
                         [ span [ class "ComponentElementIcon" ] [ Icon.material ]
                         , text <| Process.getDisplayName material
                         ]
-                    , small [ class "text-muted" ]
-                        [ iconifiedLine Icon.transform <|
-                            if List.isEmpty transforms then
-                                "aucune transformation"
+                    , div [ class "d-flex align-items-center gap-1 text-muted" ]
+                        [ span [ class "ComponentElementIcon me-0" ] [ Icon.transform ]
+                        , if List.isEmpty transforms then
+                            text "Aucune transformation"
 
-                            else
-                                transforms
-                                    |> List.map (.process >> Process.getDisplayName)
-                                    |> String.join ", "
+                          else
+                            text <| Component.transformListToString transforms
                         ]
                     ]
                 ]

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -686,7 +686,14 @@ elementView config (( component, _ ) as targetItem) elementIndex { amount, mater
                 , style "max-width" "10vw"
                 ]
                 [ div [ class "d-flex flex-column" ]
-                    [ iconifiedLine Icon.material <| Process.getDisplayName material
+                    [ button
+                        [ type_ "button"
+                        , class "btn btn-sm btn-link text-decoration-none p-0 text-start"
+                        , onClick (config.openEditElementModal component ( targetItem, elementIndex ))
+                        ]
+                        [ span [ class "ComponentElementIcon" ] [ Icon.material ]
+                        , text <| Process.getDisplayName material
+                        ]
                     , small [ class "text-muted" ]
                         [ iconifiedLine Icon.transform <|
                             if List.isEmpty transforms then

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -930,7 +930,7 @@ elementTransformsView config targetElement transformsResults transforms =
                     ]
                 , td [ class "text-end align-middle text-nowrap" ]
                     [ transformCountrySelector
-                        { attributes = []
+                        { attributes = [ style "min-width" "230px" ]
                         , countries = config.db.countries
                         , domId =
                             "transform-country-"

--- a/src/Views/Modal.elm
+++ b/src/Views/Modal.elm
@@ -61,24 +61,22 @@ view config =
                 , attribute "aria-modal" "true"
                 ]
                 [ modalContentTag
-                    [ div [ class "modal-header" ]
-                        [ h5 [ class "modal-title lh-sm d-flex justify-content-between align-items-center" ]
-                            [ span [ class "me-2", attribute "aria-hidden" "true" ] [ text "→" ]
-                            , div []
-                                [ text config.title
-                                , case config.subTitle of
-                                    Just subTitle ->
-                                        small [ class "text-muted fs-7 fw-normal ps-2" ] [ text subTitle ]
+                    [ div [ class "modal-header d-flex justify-content-between align-items-center gap-2" ]
+                        [ span [ class "h5 mb-0", attribute "aria-hidden" "true" ] [ text "→" ]
+                        , div [ class "d-flex flex-column gap-1" ]
+                            [ h5 [ class "modal-title lh-sm" ] [ text config.title ]
+                            , case config.subTitle of
+                                Just subTitle ->
+                                    div [ class "text-muted fs-7 fw-normal" ] [ text subTitle ]
 
-                                    Nothing ->
-                                        text ""
-                                ]
+                                Nothing ->
+                                    text ""
                             ]
                         , button
                             [ type_ "button"
                             , class "btn-close"
-                            , onClick config.close
                             , attribute "aria-label" "Fermer"
+                            , onClick config.close
                             ]
                             []
                         ]

--- a/src/Views/Modal.elm
+++ b/src/Views/Modal.elm
@@ -19,8 +19,7 @@ type alias Config msg =
 
 
 type Size
-    = CustomPercentWidth Int
-    | ExtraLarge
+    = ExtraLarge
     | Large
     | Small
     | Standard
@@ -53,26 +52,14 @@ view config =
                 )
             ]
             [ div
-                ([ class "modal-dialog modal-dialog-centered modal-dialog-scrollable"
-                 , attribute "aria-modal" "true"
-                 ]
-                    ++ (case config.size of
-                            CustomPercentWidth width ->
-                                [ class "modal-xl", style "width" (String.fromInt width ++ "%") ]
-
-                            ExtraLarge ->
-                                [ class "modal-xl" ]
-
-                            Large ->
-                                [ class "modal-lg" ]
-
-                            Small ->
-                                [ class "modal-sm" ]
-
-                            Standard ->
-                                []
-                       )
-                )
+                [ class "modal-dialog modal-dialog-centered modal-dialog-scrollable"
+                , classList
+                    [ ( "modal-xl", config.size == ExtraLarge )
+                    , ( "modal-lg", config.size == Large )
+                    , ( "modal-sm", config.size == Small )
+                    ]
+                , attribute "aria-modal" "true"
+                ]
                 [ modalContentTag
                     [ div [ class "modal-header d-flex justify-content-between align-items-center gap-2" ]
                         [ span [ class "h5 mb-0", attribute "aria-hidden" "true" ] [ text "→" ]

--- a/src/Views/Modal.elm
+++ b/src/Views/Modal.elm
@@ -19,7 +19,8 @@ type alias Config msg =
 
 
 type Size
-    = ExtraLarge
+    = CustomPercentWidth Int
+    | ExtraLarge
     | Large
     | Small
     | Standard
@@ -52,14 +53,26 @@ view config =
                 )
             ]
             [ div
-                [ class "modal-dialog modal-dialog-centered modal-dialog-scrollable"
-                , classList
-                    [ ( "modal-xl", config.size == ExtraLarge )
-                    , ( "modal-lg", config.size == Large )
-                    , ( "modal-sm", config.size == Small )
-                    ]
-                , attribute "aria-modal" "true"
-                ]
+                ([ class "modal-dialog modal-dialog-centered modal-dialog-scrollable"
+                 , attribute "aria-modal" "true"
+                 ]
+                    ++ (case config.size of
+                            CustomPercentWidth width ->
+                                [ class "modal-xl", style "width" (String.fromInt width ++ "%") ]
+
+                            ExtraLarge ->
+                                [ class "modal-xl" ]
+
+                            Large ->
+                                [ class "modal-lg" ]
+
+                            Small ->
+                                [ class "modal-sm" ]
+
+                            Standard ->
+                                []
+                       )
+                )
                 [ modalContentTag
                     [ div [ class "modal-header d-flex justify-content-between align-items-center gap-2" ]
                         [ span [ class "h5 mb-0", attribute "aria-hidden" "true" ] [ text "→" ]

--- a/src/Views/Modal.elm
+++ b/src/Views/Modal.elm
@@ -62,15 +62,17 @@ view config =
                 ]
                 [ modalContentTag
                     [ div [ class "modal-header" ]
-                        [ h5 [ class "modal-title lh-sm" ]
+                        [ h5 [ class "modal-title lh-sm d-flex justify-content-between align-items-center" ]
                             [ span [ class "me-2", attribute "aria-hidden" "true" ] [ text "→" ]
-                            , text config.title
-                            , case config.subTitle of
-                                Just subTitle ->
-                                    small [ class "text-muted fs-7 fw-normal ps-2" ] [ text subTitle ]
+                            , div []
+                                [ text config.title
+                                , case config.subTitle of
+                                    Just subTitle ->
+                                        small [ class "text-muted fs-7 fw-normal ps-2" ] [ text subTitle ]
 
-                                Nothing ->
-                                    text ""
+                                    Nothing ->
+                                        text ""
+                                ]
                             ]
                         , button
                             [ type_ "button"


### PR DESCRIPTION
This patch improves the component element edit modal in the generic simulators.

<img width="2709" height="1745" alt="image" src="https://github.com/user-attachments/assets/ecd5c018-c638-4fab-81f9-770ed0c87d3c" />
