### PR TITLE
chore(textile): remove picking data from textile products explorer

### DIFF
--- a/src/Data/Textile/Formula.elm
+++ b/src/Data/Textile/Formula.elm
@@ -1,6 +1,5 @@
 module Data.Textile.Formula exposing
-    ( computePicking
-    , computeThreadDensity
+    ( computeThreadDensity
     , dyeingImpacts
     , endOfLifeImpacts
     , finishingImpacts

--- a/src/Page/Explore/TextileProducts.elm
+++ b/src/Page/Explore/TextileProducts.elm
@@ -17,7 +17,6 @@ import Duration
 import Energy
 import Html exposing (..)
 import Html.Attributes exposing (..)
-import Mass
 import Page.Explore.Table as Table exposing (Table)
 import Route
 import Views.Format as Format
@@ -110,16 +109,6 @@ table { db } { detailed, scope } =
         , { label = "Étoffe*"
           , toValue = Table.StringValue (.fabric >> Fabric.toLabel)
           , toCell = .fabric >> Fabric.toLabel >> text
-          }
-        , let
-            -- Compute picking per kg of end product
-            picking { surfaceMass, yarnSize } =
-                Unit.surfaceMassToSurface surfaceMass Mass.kilogram
-                    |> Formula.computePicking (Formula.computeThreadDensity surfaceMass yarnSize)
-          in
-          { label = "Duites.m pour (1kg)**"
-          , toValue = Table.FloatValue <| picking >> Unit.pickPerMeterToFloat
-          , toCell = picking >> Format.picking
           }
         , { label = "Stocks dormants"
           , toValue = Table.FloatValue (Split.toPercent Env.defaultDeadStock |> always)

--- a/src/Page/Explore/TextileProducts.elm
+++ b/src/Page/Explore/TextileProducts.elm
@@ -10,19 +10,15 @@ import Data.Split as Split
 import Data.Textile.Economics as Economics
 import Data.Textile.Fabric as Fabric
 import Data.Textile.Formula as Formula
-import Data.Textile.LifeCycle as LifeCycle
 import Data.Textile.MakingComplexity as MakingComplexity
 import Data.Textile.Product as Product exposing (Product)
-import Data.Textile.Query as TextileQuery
-import Data.Textile.Simulator as Simulator
-import Data.Textile.Stage.Label as Label
 import Data.Unit as Unit
 import Duration
 import Energy
 import Html exposing (..)
 import Html.Attributes exposing (..)
+import Mass
 import Page.Explore.Table as Table exposing (Table)
-import Quantity
 import Route
 import Views.Format as Format
 import Volume
@@ -34,7 +30,7 @@ withTitle str =
 
 
 table : Session -> { detailed : Bool, scope : Scope } -> Table Product String msg
-table { componentConfig, db } { detailed, scope } =
+table { db } { detailed, scope } =
     { filename = "products"
     , toId = .id >> Product.idToString
     , toRoute = .id >> Just >> Dataset.TextileProducts >> Route.Explore scope
@@ -116,36 +112,14 @@ table { componentConfig, db } { detailed, scope } =
           , toCell = .fabric >> Fabric.toLabel >> text
           }
         , let
-            picking product surfaceMass ys =
-                let
-                    outputMass =
-                        TextileQuery.default
-                            |> TextileQuery.updateProduct product
-                            |> Simulator.compute db componentConfig
-                            |> Result.map (.lifeCycle >> LifeCycle.getStageProp Label.Fabric .outputMass Quantity.zero)
-                            |> Result.withDefault Quantity.zero
-
-                    outputSurface =
-                        Unit.surfaceMassToSurface surfaceMass outputMass
-
-                    threadDensity =
-                        Formula.computeThreadDensity surfaceMass ys
-                in
-                outputSurface
-                    |> Formula.computePicking threadDensity
+            -- Compute picking per kg of end product
+            picking { surfaceMass, yarnSize } =
+                Unit.surfaceMassToSurface surfaceMass Mass.kilogram
+                    |> Formula.computePicking (Formula.computeThreadDensity surfaceMass yarnSize)
           in
-          { label = "Duites.m**"
-          , toValue =
-                Table.FloatValue <|
-                    \({ surfaceMass, yarnSize } as product) ->
-                        picking product surfaceMass yarnSize
-                            |> Unit.pickPerMeterToFloat
-          , toCell =
-                \({ surfaceMass, yarnSize } as product) ->
-                    div [ classList [ ( "text-center", not detailed ) ] ]
-                        [ picking product surfaceMass yarnSize
-                            |> Format.picking
-                        ]
+          { label = "Duites.m pour (1kg)**"
+          , toValue = Table.FloatValue <| picking >> Unit.pickPerMeterToFloat
+          , toCell = picking >> Format.picking
           }
         , { label = "Stocks dormants"
           , toValue = Table.FloatValue (Split.toPercent Env.defaultDeadStock |> always)

--- a/src/Views/Format.elm
+++ b/src/Views/Format.elm
@@ -20,7 +20,6 @@ module Views.Format exposing
     , megajoules
     , minutes
     , percent
-    , picking
     , priceInEUR
     , splitAsFloat
     , splitAsPercentage
@@ -267,11 +266,6 @@ surfaceMass =
 threadDensity : Unit.ThreadDensity -> Html msg
 threadDensity (Unit.ThreadDensity density_) =
     density_ |> formatRichFloat 0 "#/cm"
-
-
-picking : Unit.PickPerMeter -> Html msg
-picking =
-    Unit.pickPerMeterToFloat >> formatRichFloat 0 "duites.m"
 
 
 yarnSize : Unit.YarnSize -> Html msg


### PR DESCRIPTION
[context](https://mattermost.incubateur.net/fabnum-mte/pl/mb8xtewxhty8mdhjdcsmkh1tfr)

### Décision

> Sachant que le calcul des duites.m apparait explicitement dans la doc gitbook, et reste visible dans le mode exploratoire de la calculette, je suis pour l'enlever de l'explorateur. 
je comprends le point de faire apparaitre des duites.m même pour un tricot, dans la mesure où l'on peut changer pour du tissage en mode exploratoire. Néanmoins dans l'explorateur on "fixe" le procédé étoffe, donc ça reste un non sens pour moi.
> — @PierreMatte 

Le patch supprime donc la colonne exposant les Duites.m et le code mobilisé pour produire ces valeurs.