### PR TITLE
chore(stable): upgrade node deps, 2026-04-27

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,20 +10,20 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@sentry/browser": "^10.48.0",
-        "@sentry/node": "^10.48.0",
-        "@sentry/profiling-node": "^10.48.0",
+        "@sentry/browser": "^10.50.0",
+        "@sentry/node": "^10.50.0",
+        "@sentry/profiling-node": "^10.50.0",
         "@sentry/tracing": "^7.120.4",
         "cors": "^2.8.6",
         "dotenv": "^17.4.2",
         "express": "^5.2.1",
         "express-body-parser-error-handler": "^1.0.9",
-        "express-rate-limit": "^8.3.2",
+        "express-rate-limit": "^8.4.1",
         "helmet": "^8.1.0",
         "js-yaml": "^4.1.1",
         "piwik": "^1.0.10",
-        "posthog-js": "^1.369.0",
-        "posthog-node": "^5.29.2"
+        "posthog-js": "^1.372.2",
+        "posthog-node": "^5.30.5"
       },
       "devDependencies": {
         "@apidevtools/swagger-cli": "^4.0.4",
@@ -45,7 +45,7 @@
         "jest": "^30.3.0",
         "maildev": "^2.2.1",
         "nodemon": "^3.1.14",
-        "npm-check-updates": "^21.0.0",
+        "npm-check-updates": "^22.0.1",
         "parcel": "^2.16.4",
         "prettier": "^3.8.3",
         "prettier-plugin-sort-json": "^4.2.0",
@@ -53,7 +53,7 @@
         "rimraf": "^6.1.3",
         "supertest": "^7.2.2",
         "svgo": "^4.0.1",
-        "uuid": "^13.0.0"
+        "uuid": "^14.0.0"
       },
       "engines": {
         "node": "22.x"
@@ -1965,18 +1965,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/@opentelemetry/context-async-hooks": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.6.1.tgz",
-      "integrity": "sha512-XHzhwRNkBpeP8Fs/qjGrAf9r9PRv67wkJQ/7ZPaBQQ68DYlTBBx5MF9LvPx7mhuXcDessKK2b+DcxqwpgkcivQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
     "node_modules/@opentelemetry/core": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
@@ -2388,23 +2376,6 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/instrumentation-undici": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.24.0.tgz",
-      "integrity": "sha512-oKzZ3uvqP17sV0EsoQcJgjEfIp0kiZRbYu/eD8p13Cbahumf8lb/xpYeNr/hfAJ4owzEtIDcGIjprfLcYbIKBQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "^2.0.0",
-        "@opentelemetry/instrumentation": "^0.214.0",
-        "@opentelemetry/semantic-conventions": "^1.24.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.7.0"
-      }
-    },
     "node_modules/@opentelemetry/otlp-exporter-base": {
       "version": "0.208.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.208.0.tgz",
@@ -2527,12 +2498,12 @@
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.1.tgz",
-      "integrity": "sha512-lID/vxSuKWXM55XhAKNoYXu9Cutoq5hFdkbTdI/zDKQktXzcWBVhNsOkiZFTMU9UtEWuGRNe0HUgmsFldIdxVA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.0.tgz",
+      "integrity": "sha512-K+oi0hNMv94EpZbnW3eyu2X6SGVpD3O5DhG2NIp65Hc7lhAj9brRXTAVzh3wB82+q3ThakEf7Zd7RsFUqcTc7A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/core": "2.7.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -2540,6 +2511,21 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.0.tgz",
+      "integrity": "sha512-DT12SXVwV2eoJrGf4nnsvZojxxeQo+LlNAsoYGRRObPWTeN6APiqZ2+nqDCQDvQX40eLi1AePONS0onoASp3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/sdk-logs": {
@@ -2650,13 +2636,13 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.1.tgz",
-      "integrity": "sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.0.tgz",
+      "integrity": "sha512-Yg9zEXJB50DLVLpsKPk7NmNqlPlS+OvqhJGh0A8oawIOTPOwlm4eXs9BMJV7L79lvEwI+dWtAj+YjTyddV336A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.6.1",
-        "@opentelemetry/resources": "2.6.1",
+        "@opentelemetry/core": "2.7.0",
+        "@opentelemetry/resources": "2.7.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -2664,6 +2650,21 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.0.tgz",
+      "integrity": "sha512-DT12SXVwV2eoJrGf4nnsvZojxxeQo+LlNAsoYGRRObPWTeN6APiqZ2+nqDCQDvQX40eLi1AePONS0onoASp3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
@@ -4497,15 +4498,18 @@
       }
     },
     "node_modules/@posthog/core": {
-      "version": "1.25.2",
-      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.25.2.tgz",
-      "integrity": "sha512-h2FO7ut/BbfwpAXWpwdDHTzQgUo9ibDFEs6ZO+3cI3KPWQt5XwczK1OLAuPprcjm8T/jl0SH8jSFo5XdU4RbTg==",
-      "license": "MIT"
+      "version": "1.27.6",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.27.6.tgz",
+      "integrity": "sha512-FjvgPdORywAjgjtgkZJ2/x9ED52jtOJym/RVldY4Oa7wzmlY49rxZm8gvOlocEnjP90bSbj3ko7qVjXNhftFvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/types": "1.372.2"
+      }
     },
     "node_modules/@posthog/types": {
-      "version": "1.369.0",
-      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.369.0.tgz",
-      "integrity": "sha512-iFkLrg/+QRQHc8KSjO9parN6H3rftM2ld2sCJ/GeBRRO9MJYCdc6jXSFRgF7aGJPzb79syqksz+CrnBzdZnBKg==",
+      "version": "1.372.2",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.372.2.tgz",
+      "integrity": "sha512-dx+WImdDg2NDqaDowTmW+BMNalUfPKngR+g1Iom8ULSav+fGacxexv6fSOl0uSVBwYZsDFe7qNUu0NB/rwGjEw==",
       "license": "MIT"
     },
     "node_modules/@prisma/instrumentation": {
@@ -4626,24 +4630,24 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@sentry-internal/browser-utils": {
-      "version": "10.48.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.48.0.tgz",
-      "integrity": "sha512-SCiTLBXzugFKxev6NoKYBIhQoDk0gUh0AVVVepCBqfCJiWBG01Zvv0R5tCVohr4cWRllkQ8mlBdNQd/I7s9tdA==",
+      "version": "10.50.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.50.0.tgz",
+      "integrity": "sha512-42bxyRTxnCmYlWnvz4CxikuQNanw8UNma2WJrtxJ0f1MAJV2GhQGSHDLnA+lvFlmiz6qct3pfen/NXGyOTegTA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.48.0"
+        "@sentry/core": "10.50.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/feedback": {
-      "version": "10.48.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.48.0.tgz",
-      "integrity": "sha512-tGkEyOM1HDS9qebDphUMEnyk3qq/50AnuTBiFmMJyjNzowylVGmRRk0sr3xkmbVHCDXQCiYnDmSVlJ2x4SDMrQ==",
+      "version": "10.50.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.50.0.tgz",
+      "integrity": "sha512-0k9XZF0wn86f77mIO2U3gNNyDZooy139CnEanRzHinrN106vVzvBZ6TUEQoHtoO1fqQxr+nWWVrqV/PXUqk47w==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.48.0"
+        "@sentry/core": "10.50.0"
       },
       "engines": {
         "node": ">=18"
@@ -4673,26 +4677,26 @@
       }
     },
     "node_modules/@sentry-internal/replay": {
-      "version": "10.48.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.48.0.tgz",
-      "integrity": "sha512-sevRTePfuk4PNuz9KAKpmTZEomAU0aLXyIhOwA0OnUDdxPhkY8kq5lwDbuxTHv6DQUjUX3YgFbY45VH1JEqHKA==",
+      "version": "10.50.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.50.0.tgz",
+      "integrity": "sha512-51FYNfnvVLAWw1rrEWPFfwHuMRb9mkVCFGA4J9/un7SpeGBsQDziGB0Di4fsCxI7+EdSBpfLHPF0csKtCCw0oQ==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/browser-utils": "10.48.0",
-        "@sentry/core": "10.48.0"
+        "@sentry-internal/browser-utils": "10.50.0",
+        "@sentry/core": "10.50.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/replay-canvas": {
-      "version": "10.48.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.48.0.tgz",
-      "integrity": "sha512-9nWuN2z4O+iwbTfuYV5ZmngBgJU/ZxfOo47A5RJP3Nu/kl59aJ1lUhILYOKyeNOIC/JyeERmpIcTxnlPXQzZ3Q==",
+      "version": "10.50.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.50.0.tgz",
+      "integrity": "sha512-jx6RKBmcJSWdI92qDGS/sBv1w+7Cww879Z/moX7bw7ipHa/Ts3iDcB3rgZwvhmi17U+mvYsbJeL2DXkPo3TjPw==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/replay": "10.48.0",
-        "@sentry/core": "10.48.0"
+        "@sentry-internal/replay": "10.50.0",
+        "@sentry/core": "10.50.0"
       },
       "engines": {
         "node": ">=18"
@@ -4726,39 +4730,38 @@
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "10.48.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.48.0.tgz",
-      "integrity": "sha512-4jt2zX2ExgFcNe2x+W+/k81fmDUsOrquGtt028CiGuDuma6kEsWBI4JbooT1jhj2T+eeUxe3YGbM23Zhh7Ghhw==",
+      "version": "10.50.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.50.0.tgz",
+      "integrity": "sha512-1f6rAvET6myiTaSeYqvaaBwvq1LfxqWjAPIoAW/NVC9bPMkeEcuvgDajHrnZMrBeWoJ81NMyoLkyX+iOc7MoFA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/browser-utils": "10.48.0",
-        "@sentry-internal/feedback": "10.48.0",
-        "@sentry-internal/replay": "10.48.0",
-        "@sentry-internal/replay-canvas": "10.48.0",
-        "@sentry/core": "10.48.0"
+        "@sentry-internal/browser-utils": "10.50.0",
+        "@sentry-internal/feedback": "10.50.0",
+        "@sentry-internal/replay": "10.50.0",
+        "@sentry-internal/replay-canvas": "10.50.0",
+        "@sentry/core": "10.50.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/core": {
-      "version": "10.48.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.48.0.tgz",
-      "integrity": "sha512-h8F+fXVwYC9ro5ZaO8V+v3vqc0awlXHGblEAuVxSGgh4IV/oFX+QVzXeDTTrFOFS6v/Vn5vAyu240eJrJAS6/g==",
+      "version": "10.50.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.50.0.tgz",
+      "integrity": "sha512-J4A+vzUO3adl0TkFCjaN1+4miamrjHiEIYuLHiuu1lmAjq5WIVw32ObvAh4yMwNtxyaEMosTrrh5M6f12XSJFg==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/node": {
-      "version": "10.48.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.48.0.tgz",
-      "integrity": "sha512-MzyLJyYmr0Qg60K6NJ2EdwJUX1OuAYXs9tyYxnqVO3nJ8MyYwIcuN4FCYEnXkG6Jiy/4q7OuZgXWnfdQJVcaqw==",
+      "version": "10.50.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.50.0.tgz",
+      "integrity": "sha512-TvwzFQu8MGKzMQ2/tqxcNzFA8UG2kKTB+GDmA4uOzx3+GT849YZRRSJzEXCmYhk1teVd2fbmgqyYY2nyLF5a+Q==",
       "license": "MIT",
       "dependencies": {
         "@fastify/otel": "0.18.0",
         "@opentelemetry/api": "^1.9.1",
-        "@opentelemetry/context-async-hooks": "^2.6.1",
         "@opentelemetry/core": "^2.6.1",
         "@opentelemetry/instrumentation": "^0.214.0",
         "@opentelemetry/instrumentation-amqplib": "0.61.0",
@@ -4781,14 +4784,12 @@
         "@opentelemetry/instrumentation-pg": "0.66.0",
         "@opentelemetry/instrumentation-redis": "0.62.0",
         "@opentelemetry/instrumentation-tedious": "0.33.0",
-        "@opentelemetry/instrumentation-undici": "0.24.0",
-        "@opentelemetry/resources": "^2.6.1",
         "@opentelemetry/sdk-trace-base": "^2.6.1",
         "@opentelemetry/semantic-conventions": "^1.40.0",
         "@prisma/instrumentation": "7.6.0",
-        "@sentry/core": "10.48.0",
-        "@sentry/node-core": "10.48.0",
-        "@sentry/opentelemetry": "10.48.0",
+        "@sentry/core": "10.50.0",
+        "@sentry/node-core": "10.50.0",
+        "@sentry/opentelemetry": "10.50.0",
         "import-in-the-middle": "^3.0.0"
       },
       "engines": {
@@ -4796,13 +4797,13 @@
       }
     },
     "node_modules/@sentry/node-core": {
-      "version": "10.48.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.48.0.tgz",
-      "integrity": "sha512-D1TnPhN6vhrRqJ+bN+rdXDM+INibI6lNBm0eGx45zz7DBx9ouq2e9gm/DPx+y/hAkYYq0qTd6x84cGxtVZbKLw==",
+      "version": "10.50.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.50.0.tgz",
+      "integrity": "sha512-Eb1BYf4Lc7ZYmdX3acKP6SgyGikrBA370gbGHaWI5jRu7G7vig8sIu1ghPmY5AlvqBPOetado7GniXr6fAXbTw==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.48.0",
-        "@sentry/opentelemetry": "10.48.0",
+        "@sentry/core": "10.50.0",
+        "@sentry/opentelemetry": "10.50.0",
         "import-in-the-middle": "^3.0.0"
       },
       "engines": {
@@ -4810,19 +4811,14 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.9.0",
-        "@opentelemetry/context-async-hooks": "^1.30.1 || ^2.1.0",
         "@opentelemetry/core": "^1.30.1 || ^2.1.0",
         "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1",
         "@opentelemetry/instrumentation": ">=0.57.1 <1",
-        "@opentelemetry/resources": "^1.30.1 || ^2.1.0",
         "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
         "@opentelemetry/semantic-conventions": "^1.39.0"
       },
       "peerDependenciesMeta": {
         "@opentelemetry/api": {
-          "optional": true
-        },
-        "@opentelemetry/context-async-hooks": {
           "optional": true
         },
         "@opentelemetry/core": {
@@ -4834,9 +4830,6 @@
         "@opentelemetry/instrumentation": {
           "optional": true
         },
-        "@opentelemetry/resources": {
-          "optional": true
-        },
         "@opentelemetry/sdk-trace-base": {
           "optional": true
         },
@@ -4846,33 +4839,32 @@
       }
     },
     "node_modules/@sentry/opentelemetry": {
-      "version": "10.48.0",
-      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.48.0.tgz",
-      "integrity": "sha512-Tn6Y0PZjRJ7OW8loK1ntK7wnJnIINnCfSpnwuqow0FMblaDmu5jDVOYq0U1SJBoBcMD5j9aSqrwyj6zqKwjc0A==",
+      "version": "10.50.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.50.0.tgz",
+      "integrity": "sha512-axn3pgDPveGdaMUC0abMCmFN7ux2pA5ebPufCef4lMIsyg7BBQvaEJ+vE19wjstMaBCAJGsdZlL3eeP2rtgRMw==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.48.0"
+        "@sentry/core": "10.50.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.9.0",
-        "@opentelemetry/context-async-hooks": "^1.30.1 || ^2.1.0",
         "@opentelemetry/core": "^1.30.1 || ^2.1.0",
         "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
         "@opentelemetry/semantic-conventions": "^1.39.0"
       }
     },
     "node_modules/@sentry/profiling-node": {
-      "version": "10.48.0",
-      "resolved": "https://registry.npmjs.org/@sentry/profiling-node/-/profiling-node-10.48.0.tgz",
-      "integrity": "sha512-eX+z1x4PPdooOfDz94c2cPrdh4rK/uxOACgpHf8qIjyiUcz1sw3l5+rNL7Ak7NZC4Ti8IvdDa7/9pH1ic+JaKw==",
+      "version": "10.50.0",
+      "resolved": "https://registry.npmjs.org/@sentry/profiling-node/-/profiling-node-10.50.0.tgz",
+      "integrity": "sha512-fKavmoOJdst07/Mf8Zvz8QEbn8RDM10I1tdwSTmC8n77zm5IEQll7eYHP8e77VWuXHXggfVn5WNQfG2uDrECaA==",
       "license": "MIT",
       "dependencies": {
         "@sentry-internal/node-cpu-profiler": "^2.2.0",
-        "@sentry/core": "10.48.0",
-        "@sentry/node": "10.48.0"
+        "@sentry/core": "10.50.0",
+        "@sentry/node": "10.50.0"
       },
       "bin": {
         "sentry-prune-profiler-binaries": "scripts/prune-profiler-binaries.js"
@@ -8115,9 +8107,9 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
-      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
+      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
       "license": "MIT",
       "dependencies": {
         "ip-address": "10.1.0"
@@ -11724,9 +11716,9 @@
       }
     },
     "node_modules/npm-check-updates": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-21.0.0.tgz",
-      "integrity": "sha512-iGFLoW1QWsEDLR6Cnklyk+iHTf20hS84o79idR6AKhjSwk0whMdCd5FS0bTgEe6gMrRnJ0fGr2P6BEZ2zOelYg==",
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-22.0.1.tgz",
+      "integrity": "sha512-K8PDu7l9v7UKIwDSxLnqA9LHT76Mu4eCjGjp0JwSeSsyKWmX/YZY+AoBxw4oVdKwQLthWbzg1g+OKysHYGQCjQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -12347,9 +12339,9 @@
       }
     },
     "node_modules/posthog-js": {
-      "version": "1.369.0",
-      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.369.0.tgz",
-      "integrity": "sha512-fOJzwpCb/TWxJBsUNKJ5PhHNl0+X7zRrVTuUrIH+EfsIfxJGSkOa0lWPJJGr3xzg810JHCUpuhn5sFBBxfHqIQ==",
+      "version": "1.372.2",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.372.2.tgz",
+      "integrity": "sha512-FS+vKDXB1vghrVch3EDi3IRcoH5OnLQYxchHWi+8U4D4PzWQZnZLo5vyMRL1+ZUHNEZ2v599uX3UKhRZv2z6Cg==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
@@ -12357,8 +12349,8 @@
         "@opentelemetry/exporter-logs-otlp-http": "^0.208.0",
         "@opentelemetry/resources": "^2.2.0",
         "@opentelemetry/sdk-logs": "^0.208.0",
-        "@posthog/core": "1.25.2",
-        "@posthog/types": "1.369.0",
+        "@posthog/core": "1.27.6",
+        "@posthog/types": "1.372.2",
         "core-js": "^3.38.1",
         "dompurify": "^3.3.2",
         "fflate": "^0.4.8",
@@ -12380,12 +12372,12 @@
       }
     },
     "node_modules/posthog-node": {
-      "version": "5.29.2",
-      "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-5.29.2.tgz",
-      "integrity": "sha512-rI7kkF0XqDc0G1qjx+Hb4iuY9NAlL+XQNoGOpnEpRNTUcXvjY6WlsRGZ9m2whgc39emrrYdszi/YT8wZkr2xsg==",
+      "version": "5.30.5",
+      "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-5.30.5.tgz",
+      "integrity": "sha512-TlxyX+Yip2cChU1YLDWbCEVOlDEbTsO3f5ujMqR94dRLUeQw0wBCXMgjDcnxhVisdzXFTzcBoWvf0LXDWZqo8A==",
       "license": "MIT",
       "dependencies": {
-        "@posthog/core": "1.25.2"
+        "@posthog/core": "1.27.6"
       },
       "engines": {
         "node": "^20.20.0 || >=22.22.0"
@@ -14394,9 +14386,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",

--- a/package.json
+++ b/package.json
@@ -55,20 +55,20 @@
     "test": "npm run test:client && npm run test:jslib && npm run test:backend && npm run test:server"
   },
   "dependencies": {
-    "@sentry/browser": "^10.48.0",
-    "@sentry/node": "^10.48.0",
-    "@sentry/profiling-node": "^10.48.0",
+    "@sentry/browser": "^10.50.0",
+    "@sentry/node": "^10.50.0",
+    "@sentry/profiling-node": "^10.50.0",
     "@sentry/tracing": "^7.120.4",
     "cors": "^2.8.6",
     "dotenv": "^17.4.2",
     "express": "^5.2.1",
     "express-body-parser-error-handler": "^1.0.9",
-    "express-rate-limit": "^8.3.2",
+    "express-rate-limit": "^8.4.1",
     "helmet": "^8.1.0",
     "js-yaml": "^4.1.1",
     "piwik": "^1.0.10",
-    "posthog-js": "^1.369.0",
-    "posthog-node": "^5.29.2"
+    "posthog-js": "^1.372.2",
+    "posthog-node": "^5.30.5"
   },
   "devDependencies": {
     "@apidevtools/swagger-cli": "^4.0.4",
@@ -90,7 +90,7 @@
     "jest": "^30.3.0",
     "maildev": "^2.2.1",
     "nodemon": "^3.1.14",
-    "npm-check-updates": "^21.0.0",
+    "npm-check-updates": "^22.0.1",
     "parcel": "^2.16.4",
     "prettier": "^3.8.3",
     "prettier-plugin-sort-json": "^4.2.0",
@@ -98,7 +98,7 @@
     "rimraf": "^6.1.3",
     "supertest": "^7.2.2",
     "svgo": "^4.0.1",
-    "uuid": "^13.0.0"
+    "uuid": "^14.0.0"
   },
   "cacheDirectories": [
     "elm-stuff",


### PR DESCRIPTION
```
 @sentry/browser         ^10.48.0  →  ^10.50.0
 @sentry/node            ^10.48.0  →  ^10.50.0
 @sentry/profiling-node  ^10.48.0  →  ^10.50.0
 express-rate-limit        ^8.3.2  →    ^8.4.1
 npm-check-updates        ^21.0.0  →   ^22.0.1
 posthog-js              ^1.369.0  →  ^1.372.2
 posthog-node             ^5.29.2  →   ^5.30.5
 uuid                     ^13.0.0  →   ^14.0.0
```
