### PR TITLE
feat(generic): compute element transports

### DIFF
--- a/public/data/object/examples.json
+++ b/public/data/object/examples.json
@@ -23,14 +23,30 @@
     "id": "ce3c8c63-aef7-4090-bbab-479e826fe4b9",
     "name": "Boite plastique 45L (Chine)",
     "query": {
+      "durability": 1,
       "components": [
         {
-          "country": "CN",
           "id": "10e199b6-7e5f-47d9-bc85-9959c4e9ee62",
-          "quantity": 1
+          "quantity": 1,
+          "custom": {
+            "elements": [
+              {
+                "amount": 1.26,
+                "material": {
+                  "country": "CN",
+                  "id": "01d21ed5-9fc6-4d36-a0ea-cfea8035385b"
+                },
+                "transforms": [
+                  {
+                    "country": "CN",
+                    "id": "85b74ce2-2cbc-4d73-a5a2-5c5ffde16319"
+                  }
+                ]
+              }
+            ]
+          }
         }
-      ],
-      "durability": 1
+      ]
     },
     "scope": "object"
   },
@@ -39,14 +55,30 @@
     "id": "6ab8769d-24d9-4990-8f00-ae1b5823946e",
     "name": "Boite plastique 45L (France)",
     "query": {
+      "durability": 1,
       "components": [
         {
-          "country": "FR",
           "id": "10e199b6-7e5f-47d9-bc85-9959c4e9ee62",
-          "quantity": 1
+          "quantity": 1,
+          "custom": {
+            "elements": [
+              {
+                "amount": 1.26,
+                "material": {
+                  "country": "FR",
+                  "id": "01d21ed5-9fc6-4d36-a0ea-cfea8035385b"
+                },
+                "transforms": [
+                  {
+                    "country": "FR",
+                    "id": "85b74ce2-2cbc-4d73-a5a2-5c5ffde16319"
+                  }
+                ]
+              }
+            ]
+          }
         }
-      ],
-      "durability": 1
+      ]
     },
     "scope": "object"
   },

--- a/src/CheckDb.elm
+++ b/src/CheckDb.elm
@@ -98,7 +98,7 @@ checkComponentsProcessIds knownProcessStringIds db =
                     |> List.concatMap
                         (\{ material, transforms } ->
                             []
-                                |> (++) (material |> checkProcessId knownProcessStringIds component "element.material")
+                                |> (++) (material.id |> checkProcessId knownProcessStringIds component "element.material")
                                 |> (++) (transforms |> List.map .id |> List.concatMap (checkProcessId knownProcessStringIds component "element.transforms"))
                         )
             )
@@ -157,7 +157,7 @@ checkComponentScopeMismatch processes example component =
                 |> List.concatMap
                     (\{ material, transforms } ->
                         []
-                            |> (++) (material |> checkComponentProcessScope processes component example "element.material")
+                            |> (++) (material.id |> checkComponentProcessScope processes component example "element.material")
                             |> (++) (transforms |> List.map .id |> List.concatMap (checkComponentProcessScope processes component example "element.transforms"))
                     )
     in

--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -17,7 +17,7 @@ module Data.Component exposing
     , Query
     , Requirements
     , Results(..)
-    , Stage
+    , Stage(..)
     , TargetElement
     , TargetItem
     , addElement
@@ -99,6 +99,7 @@ module Data.Component exposing
     , updateDurability
     , updateElement
     , updateElementAmount
+    , updateElementMaterialCountry
     , updateElementTransformCountry
     , updateItem
     , updateItemCustomName
@@ -127,6 +128,7 @@ import Data.Uuid as Uuid exposing (Uuid)
 import Dict.Any as AnyDict
 import Energy
 import Json.Decode as Decode exposing (Decoder)
+import Json.Decode.Extra as DE
 import Json.Decode.Pipeline as Decode
 import Json.Encode as Encode
 import List.Extra as LE
@@ -198,8 +200,7 @@ type DistributionProcessError
 and optional overrides, typically used for queries
 -}
 type alias Item =
-    { country : Maybe Country.Code
-    , custom : Maybe Custom
+    { custom : Maybe Custom
     , id : Maybe Id
     , quantity : Quantity
     }
@@ -207,7 +208,6 @@ type alias Item =
 
 type alias ExpandedItem =
     { component : Component
-    , country : Maybe Country
     , elements : List ExpandedElement
     , quantity : Quantity
     }
@@ -235,15 +235,19 @@ type alias DataContainer db =
 -}
 type alias Element =
     { amount : Amount
-    , material : Process.Id
-    , transforms : List Transform
+    , material : Material
+    , transforms : List LocalizedProcess
     }
 
 
-type alias Transform =
+type alias LocalizedProcess =
     { country : Maybe Country.Code
     , id : Process.Id
     }
+
+
+type alias Material =
+    LocalizedProcess
 
 
 {-| A full representation of an amount of material and optional transformations of it
@@ -253,8 +257,7 @@ Note: the `country` field is propagated from the parent component item, for conv
 -}
 type alias ExpandedElement =
     { amount : Amount
-    , country : Maybe Country
-    , material : Process
+    , material : ExpandedMaterial
     , transforms : List ExpandedTransform
     }
 
@@ -263,6 +266,10 @@ type alias ExpandedTransform =
     { country : Maybe Country
     , process : Process
     }
+
+
+type alias ExpandedMaterial =
+    ExpandedTransform
 
 
 type alias Index =
@@ -344,6 +351,7 @@ type Results
 -}
 type Stage
     = MaterialStage
+    | TransportStage
     | TransformStage
 
 
@@ -368,7 +376,7 @@ addElement targetItem material items =
                     { custom
                         | elements =
                             custom.elements
-                                ++ [ { amount = Amount.fromFloat 1, material = material.id, transforms = [] } ]
+                                ++ [ { amount = Amount.fromFloat 1, material = defaultMaterial material.id, transforms = [] } ]
                     }
                 )
             |> Ok
@@ -483,25 +491,77 @@ applyTransform transform (Results { amount, label, impacts, items, mass, complem
         }
 
 
+applyTransportLeg : Requirements db -> Mass -> Maybe Country -> Maybe Country -> Results -> Results
+applyTransportLeg { config, db } mass maybeFrom maybeTo (Results results) =
+    let
+        legTransport =
+            case ( maybeFrom, maybeTo ) of
+                ( Just from, Just to ) ->
+                    db.distances
+                        |> Transport.getTransportBetween Impact.empty from.code to.code
+                        |> Transport.applyTransportRatios Split.zero
+                        |> Transport.computeImpacts config.transports.modeProcesses mass
+
+                _ ->
+                    config.transports.defaultDistance
+                        |> Transport.applyTransportRatios Split.zero
+                        |> Transport.computeImpacts config.transports.modeProcesses mass
+
+        transportImpacts =
+            legTransport.impacts
+    in
+    Results
+        { results
+            | impacts = Impact.sumImpacts [ results.impacts, transportImpacts ]
+            , items =
+                results.items
+                    ++ [ Results
+                            { amount = results.amount
+                            , complementsImpacts = Complement.emptyComplementsResultsImpacts
+                            , impacts = transportImpacts
+                            , items = []
+                            , label = Just "Transport"
+                            , mass = mass
+                            , materialType = Nothing
+                            , quantity = 1
+                            , stage = Just TransportStage
+                            }
+                       ]
+        }
+
+
 {-| Sequencially apply transforms to existing Results (typically, from material ones).
 
 Energy mix impacts are computed at the transform step level: each step can optionally
 specify a country to use its electricity/heat mixes, or fallback to config defaults when absent.
 
 -}
-applyTransforms : Config -> Process.Unit -> List ExpandedTransform -> Results -> Result String Results
-applyTransforms config unit transforms materialResults =
+applyTransforms : Requirements db -> Maybe Country -> Process.Unit -> List ExpandedTransform -> Results -> Result String Results
+applyTransforms requirements initialCountry unit transforms materialResults =
     checkTransformsUnit unit transforms
         |> Result.andThen
-            (List.foldl
-                (\{ country, process } ->
-                    Result.andThen
-                        (\results ->
-                            loadEnergyMixes config country
-                                |> Result.map (applyTransform process results)
+            (\validTransforms ->
+                validTransforms
+                    |> List.foldl
+                        (\{ country, process } acc ->
+                            acc
+                                |> Result.andThen
+                                    (\( previousCountry, results ) ->
+                                        loadEnergyMixes requirements.config country
+                                            |> Result.map
+                                                (\mixes ->
+                                                    let
+                                                        transportAppliedResults =
+                                                            applyTransportLeg requirements (extractMass results) previousCountry country results
+                                                    in
+                                                    ( country
+                                                    , applyTransform process transportAppliedResults mixes
+                                                    )
+                                                )
+                                    )
                         )
-                )
-                (Ok materialResults)
+                        (Ok ( initialCountry, materialResults ))
+                    |> Result.map Tuple.second
             )
 
 
@@ -599,18 +659,18 @@ computeDistributionImpacts ({ config } as requirements) query ({ distribution, p
                 }
 
 
-computeElementResults : Requirements db -> Maybe Country.Code -> Element -> Result String Results
-computeElementResults requirements maybeCountry =
-    expandElement requirements.db maybeCountry
+computeElementResults : Requirements db -> Element -> Result String Results
+computeElementResults requirements =
+    expandElement requirements.db
         >> Result.andThen
             (\{ amount, material, transforms } ->
                 amount
                     |> computeInitialAmount (List.map (.process >> .waste) transforms)
                     |> Result.andThen
                         (\initialAmount ->
-                            material
+                            material.process
                                 |> computeMaterialResults initialAmount
-                                |> applyTransforms requirements.config material.unit transforms
+                                |> applyTransforms requirements material.country material.process.unit transforms
                         )
             )
 
@@ -646,13 +706,13 @@ computeInitialAmount wastes amount =
 computeImpacts : Requirements db -> Component -> Result String Results
 computeImpacts requirements =
     .elements
-        >> List.map (computeElementResults requirements Nothing)
+        >> List.map (computeElementResults requirements)
         >> RE.combine
         >> Result.map (List.foldr addResults emptyResults)
 
 
 computeItemResults : Requirements db -> Item -> Result String Results
-computeItemResults requirements { country, custom, id, quantity } =
+computeItemResults requirements { custom, id, quantity } =
     let
         component_ =
             case id of
@@ -667,7 +727,7 @@ computeItemResults requirements { country, custom, id, quantity } =
             (\component ->
                 custom
                     |> customElements component
-                    |> List.map (computeElementResults requirements country)
+                    |> List.map (computeElementResults requirements)
                     |> RE.combine
             )
         |> Result.map (List.foldr addResults emptyResults)
@@ -704,25 +764,86 @@ computeItemResults requirements { country, custom, id, quantity } =
             )
 
 
-computeItemTransportToAssembly : Requirements db -> Maybe Country -> ExpandedItem -> Results -> ( String, Transport )
-computeItemTransportToAssembly { config, db } assemblyCountry item itemResults =
-    let
-        ( label, itemTransport ) =
-            case ( item.country, assemblyCountry ) of
-                ( Just from, Just to ) ->
-                    ( from.name ++ " → " ++ to.name
-                    , db.distances
-                        |> Transport.getTransportBetween Impact.empty from.code to.code
-                    )
+computeLocalizedTransport : Requirements db -> Maybe Country -> Maybe Country -> Transport
+computeLocalizedTransport { config, db } maybeFrom maybeTo =
+    case ( maybeFrom, maybeTo ) of
+        ( Just from, Just to ) ->
+            db.distances
+                |> Transport.getTransportBetween Impact.empty from.code to.code
 
-                _ ->
-                    ( "Trajet inconnu majoré", config.transports.defaultDistance )
+        _ ->
+            config.transports.defaultDistance
+
+
+computeLocalizedTransportImpacts : Requirements db -> Mass -> Maybe Country -> Maybe Country -> Transport
+computeLocalizedTransportImpacts ({ config } as requirements) mass maybeFrom maybeTo =
+    computeLocalizedTransport requirements maybeFrom maybeTo
+        |> Transport.applyTransportRatios Split.zero
+        |> Transport.computeImpacts config.transports.modeProcesses mass
+
+
+computeItemTransportToAssembly : Requirements db -> Maybe Country -> ExpandedItem -> Results -> ( String, Transport )
+computeItemTransportToAssembly requirements assemblyCountry item itemResults =
+    let
+        origins =
+            item.elements
+                |> List.map getElementFinalCountry
+
+        defaultOrigin =
+            origins
+                |> List.head
+                |> Maybe.withDefault Nothing
+
+        label =
+            case assemblyCountry of
+                Nothing ->
+                    "Trajet inconnu majoré"
+
+                Just { name } ->
+                    if List.all (\origin -> origin == defaultOrigin) origins then
+                        (origins
+                            |> List.head
+                            |> Maybe.andThen identity
+                            |> Maybe.map .name
+                            |> Maybe.withDefault "Trajet inconnu majoré"
+                        )
+                            ++ " → "
+                            ++ name
+
+                    else
+                        "Origines multiples → " ++ name
+
+        itemTransport =
+            List.map2
+                (\element elementResults ->
+                    computeLocalizedTransportImpacts
+                        requirements
+                        (extractMass elementResults)
+                        (getElementFinalCountry element)
+                        assemblyCountry
+                )
+                item.elements
+                (extractItems itemResults)
+                |> Transport.sum
     in
     ( label
     , itemTransport
-        |> Transport.applyTransportRatios Split.zero
-        |> Transport.computeImpacts config.transports.modeProcesses (extractMass itemResults)
     )
+
+
+computeItemTransportToDistribution : Requirements db -> ExpandedItem -> Results -> Transport
+computeItemTransportToDistribution ({ config } as requirements) item itemResults =
+    List.map2
+        (\element elementResults ->
+            computeLocalizedTransportImpacts
+                requirements
+                (extractMass elementResults)
+                (getElementFinalCountry element)
+                (Just config.distribution.country)
+        )
+        item.elements
+        (extractItems itemResults)
+        |> Transport.sum
 
 
 applyComplementsResultsImpacts : Amount -> Impacts -> Complement.ComplementsImpacts -> ComplementsResultsImpacts
@@ -852,10 +973,24 @@ computeTransports ({ config, db } as req) query lifeCycle =
                         else
                             Transport.default Impact.empty
                     , toDistribution =
-                        expandedItems
-                            |> computeDistributionTransports req maybeAssemblyCountry
-                            |> Transport.applyTransportRatios Split.zero
-                            |> Transport.computeImpacts config.transports.modeProcesses (extractMass lifeCycle.production)
+                        case maybeAssemblyCountry of
+                            Just _ ->
+                                expandedItems
+                                    |> computeDistributionTransports req maybeAssemblyCountry
+                                    |> Transport.applyTransportRatios Split.zero
+                                    |> Transport.computeImpacts config.transports.modeProcesses (extractMass lifeCycle.production)
+
+                            Nothing ->
+                                expandedItems
+                                    |> List.indexedMap
+                                        (\index item ->
+                                            lifeCycle.production
+                                                |> extractItems
+                                                |> LE.getAt index
+                                                |> Maybe.map (computeItemTransportToDistribution req item)
+                                        )
+                                    |> List.filterMap identity
+                                    |> Transport.sum
                     }
             }
         )
@@ -868,29 +1003,29 @@ of production or country of assembly to France (the only possible distribution d
 -}
 computeDistributionTransports : Requirements db -> Maybe Country -> List ExpandedItem -> Transport
 computeDistributionTransports { config, db } maybeAssemblyCountry items =
+    let
+        toDistributionTransport maybeFromCountry =
+            case maybeFromCountry of
+                Just { code } ->
+                    db.distances
+                        |> Transport.getTransportBetween Impact.empty code config.distribution.country.code
+
+                Nothing ->
+                    config.transports.defaultDistance
+    in
     case ( items, maybeAssemblyCountry ) of
-        -- No items at all
         ( [], _ ) ->
             Transport.default Impact.empty
 
-        -- Single item, no possible assembly country
-        ( [ { country } ], _ ) ->
-            country
-                |> Maybe.map
-                    (\{ code } ->
-                        db.distances
-                            |> Transport.getTransportBetween Impact.empty code config.distribution.country.code
-                    )
-                |> Maybe.withDefault config.transports.defaultDistance
-
-        -- Many items, assembly country specified
         ( _, Just { code } ) ->
             db.distances
                 |> Transport.getTransportBetween Impact.empty code config.distribution.country.code
 
-        -- Many items, no assembly country specified
         ( _, Nothing ) ->
-            config.transports.defaultDistance
+            items
+                |> List.concatMap .elements
+                |> List.map (getElementFinalCountry >> toDistributionTransport)
+                |> Transport.sum
 
 
 computeUseImpacts : Requirements db -> Query -> LifeCycle -> Result String LifeCycle
@@ -914,8 +1049,7 @@ computeUseImpacts { config, db } { consumptions } lifeCycle =
 
 createItem : Maybe Id -> Item
 createItem maybeId =
-    { country = Nothing
-    , custom = Nothing
+    { custom = Nothing
     , id = maybeId
     , quantity = quantityFromInt 1
     }
@@ -975,18 +1109,31 @@ decodeElement : Decoder Element
 decodeElement =
     Decode.succeed Element
         |> Decode.required "amount" Amount.decode
-        |> Decode.required "material" Process.decodeId
+        |> Decode.required "material" decodeMaterial
         |> Decode.optional "transforms" decodeTransforms []
 
 
-decodeTransform : Decoder Transform
-decodeTransform =
-    Decode.succeed Transform
+decodeLocalizedProcess : Decoder LocalizedProcess
+decodeLocalizedProcess =
+    Decode.succeed (\country id -> { country = country, id = id })
         |> DU.strictOptional "country" Country.decodeCode
         |> Decode.required "id" Process.decodeId
 
 
-decodeTransforms : Decoder (List Transform)
+decodeMaterial : Decoder Material
+decodeMaterial =
+    Decode.oneOf
+        [ decodeLocalizedProcess
+        , Process.decodeId |> Decode.map defaultMaterial
+        ]
+
+
+decodeTransform : Decoder LocalizedProcess
+decodeTransform =
+    decodeLocalizedProcess
+
+
+decodeTransforms : Decoder (List LocalizedProcess)
 decodeTransforms =
     Decode.oneOf
         [ Decode.list decodeTransform
@@ -998,8 +1145,13 @@ decodeTransforms =
 
 decodeItem : Decoder Item
 decodeItem =
+    decodeItemWithLegacyCountry
+        |> Decode.map mapLegacyCountryToItem
+
+
+decodeItemBase : Decoder Item
+decodeItemBase =
     Decode.succeed Item
-        |> DU.strictOptional "country" Country.decodeCode
         |> DU.strictOptional "custom" decodeCustom
         |> DU.strictOptional "id" (Decode.map Id Uuid.decoder)
         |> Decode.required "quantity" decodeQuantity
@@ -1037,7 +1189,39 @@ decodeQuery =
         |> Decode.optional "consumptions" (Decode.list decodeConsumption) []
         |> DU.strictOptional "distribution" Process.decodeId
         |> DU.strictOptional "durability" Unit.decodeRatio
-        |> Decode.required "components" (Decode.list decodeItem)
+        |> Decode.required "components" decodeItemsWithLegacyCountry
+
+
+decodeItemsWithLegacyCountry : Decoder (List Item)
+decodeItemsWithLegacyCountry =
+    Decode.list decodeItem
+
+
+decodeItemWithLegacyCountry : Decoder ( Maybe Country.Code, Item )
+decodeItemWithLegacyCountry =
+    Decode.map2 Tuple.pair
+        (DE.optionalNullableField "country" Country.decodeCode)
+        decodeItemBase
+
+
+mapLegacyCountryToItem : ( Maybe Country.Code, Item ) -> Item
+mapLegacyCountryToItem ( maybeCountryCode, item ) =
+    let
+        mapElement element =
+            { element
+                | material =
+                    if element.material.country == Nothing then
+                        { country = maybeCountryCode, id = element.material.id }
+
+                    else
+                        element.material
+            }
+    in
+    { item
+        | custom =
+            item.custom
+                |> Maybe.map (\custom -> { custom | elements = List.map mapElement custom.elements })
+    }
 
 
 {-| Proxified for convenience
@@ -1057,15 +1241,25 @@ defaultExpandedTransform process =
     { country = Nothing, process = process }
 
 
-defaultTransform : Process.Id -> Transform
-defaultTransform id =
+defaultLocalizedProcess : Process.Id -> LocalizedProcess
+defaultLocalizedProcess id =
     { country = Nothing, id = id }
+
+
+defaultMaterial : Process.Id -> Material
+defaultMaterial =
+    defaultLocalizedProcess
+
+
+defaultTransform : Process.Id -> LocalizedProcess
+defaultTransform id =
+    defaultLocalizedProcess id
 
 
 elementToString : List Process -> Element -> Result String String
 elementToString processes element =
     processes
-        |> Process.findById element.material
+        |> Process.findById element.material.id
         |> Result.map
             (\process ->
                 Format.formatFloat 5 (Amount.toFloat element.amount)
@@ -1193,17 +1387,22 @@ encodeElement : Element -> Encode.Value
 encodeElement element =
     Encode.object
         [ ( "amount", Amount.encode element.amount )
-        , ( "material", Process.encodeId element.material )
+        , ( "material", encodeLocalizedProcess element.material )
         , ( "transforms", element.transforms |> Encode.list encodeTransform )
         ]
 
 
-encodeTransform : Transform -> Encode.Value
-encodeTransform transform =
+encodeLocalizedProcess : LocalizedProcess -> Encode.Value
+encodeLocalizedProcess localizedProcess =
     EU.optionalPropertiesObject
-        [ ( "country", transform.country |> Maybe.map Country.encodeCode )
-        , ( "id", transform.id |> Process.encodeId |> Just )
+        [ ( "country", localizedProcess.country |> Maybe.map Country.encodeCode )
+        , ( "id", localizedProcess.id |> Process.encodeId |> Just )
         ]
+
+
+encodeTransform : LocalizedProcess -> Encode.Value
+encodeTransform transform =
+    encodeLocalizedProcess transform
 
 
 encodeId : Id -> Encode.Value
@@ -1216,7 +1415,6 @@ encodeItem item =
     EU.optionalPropertiesObject
         [ ( "id", item.id |> Maybe.map (idToString >> Encode.string) )
         , ( "quantity", item.quantity |> quantityToInt |> Encode.int |> Just )
-        , ( "country", item.country |> Maybe.map Country.encodeCode )
         , ( "custom", item.custom |> Maybe.map encodeCustom )
         ]
 
@@ -1340,66 +1538,62 @@ expandConsumptions processes =
 
 {-| Turn an Element to an ExpandedElement
 -}
-expandElement : DataContainer db -> Maybe Country.Code -> Element -> Result String ExpandedElement
-expandElement ({ countries, processes } as db) maybeCountry { amount, material, transforms } =
+expandElement : DataContainer db -> Element -> Result String ExpandedElement
+expandElement ({ countries, processes } as db) { amount, material, transforms } =
     Ok (ExpandedElement amount)
-        |> RE.andMap (Country.resolveMaybe maybeCountry countries)
-        |> RE.andMap (Process.findById material processes)
+        |> RE.andMap
+            (Ok (\country process -> { country = country, process = process })
+                |> RE.andMap (Country.resolveMaybe material.country countries)
+                |> RE.andMap (Process.findById material.id processes)
+            )
         |> RE.andMap (expandTransforms db transforms)
 
 
 {-| Take a list of elements and resolve them with fully qualified processes
 -}
-expandElements : DataContainer db -> Maybe Country.Code -> List Element -> Result String (List ExpandedElement)
-expandElements db maybeCountry =
-    RE.combineMap (expandElement db maybeCountry)
+expandElements : DataContainer db -> List Element -> Result String (List ExpandedElement)
+expandElements db =
+    RE.combineMap (expandElement db)
 
 
 expandItem : DataContainer db -> Item -> Result String ExpandedItem
-expandItem db { country, custom, id, quantity } =
+expandItem db { custom, id, quantity } =
     case id of
         Just id_ ->
             db.components
                 |> findById id_
-                |> Result.andThen (expandExistingItem db country custom quantity)
+                |> Result.andThen (expandExistingItem db custom quantity)
 
         Nothing ->
-            expandNewItem db country custom quantity
+            expandNewItem db custom quantity
 
 
-expandExistingItem : DataContainer db -> Maybe Country.Code -> Maybe Custom -> Quantity -> Component -> Result String ExpandedItem
-expandExistingItem db country custom quantity component =
-    db.countries
-        |> Country.resolveMaybe country
-        |> Result.andThen
-            (\maybeCountry ->
-                custom
-                    |> customElements component
-                    |> expandElements db country
-                    |> Result.map
-                        (\expandedElements ->
-                            { component = custom |> componentFromCustom (Just component)
-                            , country = maybeCountry
-                            , elements = expandedElements
-                            , quantity = quantity
-                            }
-                        )
+expandExistingItem : DataContainer db -> Maybe Custom -> Quantity -> Component -> Result String ExpandedItem
+expandExistingItem db custom quantity component =
+    custom
+        |> customElements component
+        |> expandElements db
+        |> Result.map
+            (\expandedElements ->
+                { component = custom |> componentFromCustom (Just component)
+                , elements = expandedElements
+                , quantity = quantity
+                }
             )
 
 
-expandNewItem : DataContainer db -> Maybe Country.Code -> Maybe Custom -> Quantity -> Result String ExpandedItem
-expandNewItem db country custom quantity =
+expandNewItem : DataContainer db -> Maybe Custom -> Quantity -> Result String ExpandedItem
+expandNewItem db custom quantity =
     let
         newComponent =
             custom |> componentFromCustom Nothing
     in
     Ok ExpandedItem
         |> RE.andMap (Ok newComponent)
-        |> RE.andMap (Country.resolveMaybe country db.countries)
         |> RE.andMap
             (custom
                 |> customElements newComponent
-                |> expandElements db country
+                |> expandElements db
             )
         |> RE.andMap (Ok quantity)
 
@@ -1413,7 +1607,7 @@ expandItems db =
 
 {-| Turn a list of Transform into a list of ExpandedTransform
 -}
-expandTransforms : DataContainer db -> List Transform -> Result String (List ExpandedTransform)
+expandTransforms : DataContainer db -> List LocalizedProcess -> Result String (List ExpandedTransform)
 expandTransforms { countries, processes } =
     List.map
         (\{ country, id } ->
@@ -1445,6 +1639,15 @@ getTotalImpacts (Results { impacts, complementsImpacts }) =
         [ impacts
         , complementsImpacts |> Complement.mergeComplementsResultsImpacts
         ]
+
+
+getElementFinalCountry : ExpandedElement -> Maybe Country
+getElementFinalCountry { material, transforms } =
+    transforms
+        |> List.reverse
+        |> List.head
+        |> Maybe.map .country
+        |> Maybe.withDefault material.country
 
 
 extractItems : Results -> List Results
@@ -1810,7 +2013,7 @@ setElementMaterial targetElement material items =
             |> updateElement targetElement
                 (\el ->
                     { el
-                        | material = material.id
+                        | material = defaultMaterial material.id
 
                         -- Note: always reset the transforms when replacing a material for consistency
                         , transforms = []
@@ -1852,6 +2055,9 @@ stagesImpacts lifeCycle =
                     Just TransformStage ->
                         { acc | transform = acc.transform |> Maybe.map (\i -> Impact.sumImpacts [ i, impacts ]) }
 
+                    Just TransportStage ->
+                        { acc | transports = acc.transports |> Maybe.map (\i -> Impact.sumImpacts [ i, impacts ]) }
+
                     Nothing ->
                         acc
             )
@@ -1871,6 +2077,9 @@ stageToString stage =
     case stage of
         MaterialStage ->
             "material"
+
+        TransportStage ->
+            "transport"
 
         TransformStage ->
             "transformation"
@@ -2000,6 +2209,12 @@ updateElementAmount : TargetElement -> Amount -> List Item -> List Item
 updateElementAmount targetElement amount =
     updateElement targetElement <|
         \el -> { el | amount = amount }
+
+
+updateElementMaterialCountry : TargetElement -> Maybe Country.Code -> List Item -> List Item
+updateElementMaterialCountry targetElement maybeCountryCode =
+    updateElement targetElement <|
+        \({ material } as el) -> { el | material = { material | country = maybeCountryCode } }
 
 
 updateItemCustom : TargetItem -> (Custom -> Custom) -> List Item -> List Item

--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -655,39 +655,6 @@ computeDistributionImpacts ({ config } as requirements) query ({ distribution, p
                 }
 
 
-{-| Computes transports of components from the number of shipped items, and either their respective country
-of production or country of assembly to configured distribution destination country.
-
-Note: this only computes the transport distances, not the impacts (as a transported mass would be required)
-
--}
-computeDistributionTransports : Requirements db -> Maybe Country -> Mass -> List ExpandedItem -> Transport
-computeDistributionTransports ({ config, db } as requirements) maybeAssemblyCountry mass items =
-    case ( items, maybeAssemblyCountry ) of
-        -- no items to distribute
-        ( [], _ ) ->
-            Transport.default Impact.empty
-
-        -- ship items from a specific assembly country
-        ( _, Just { code } ) ->
-            db.distances
-                |> Transport.getTransportBetween Impact.empty code config.distribution.country.code
-                -- Note: air transport is not handled for now
-                |> Transport.applyTransportRatios Split.zero
-                |> Transport.computeImpacts config.transports.modeProcesses mass
-
-        -- no assembly country specified, sum transports from all elements origins to the distribution country
-        ( _, Nothing ) ->
-            items
-                |> List.concatMap .elements
-                |> List.map
-                    (getElementFinalCountry
-                        >> computeTransportDistance requirements (Just config.distribution.country)
-                    )
-                |> Transport.sum
-                |> Transport.computeImpacts config.transports.modeProcesses mass
-
-
 computeElementResults : Requirements db -> Element -> Result String Results
 computeElementResults requirements =
     expandElement requirements.db
@@ -837,22 +804,6 @@ computeItemTransportToAssembly requirements assemblyCountry item itemResults =
     )
 
 
-{-| Compute item transport impacts of all its elements to the configured distribution country.
--}
-computeItemTransportToDistribution : Requirements db -> ExpandedItem -> Results -> Transport
-computeItemTransportToDistribution ({ config } as requirements) item itemResults =
-    extractItems itemResults
-        |> List.map2
-            (\element itemResult ->
-                extractMass itemResult
-                    |> computeTransportedMassImpacts requirements
-                        (getElementFinalCountry element)
-                        (Just config.distribution.country)
-            )
-            item.elements
-        |> Transport.sum
-
-
 computeMaterialResults : Amount -> Process -> Results
 computeMaterialResults amount process =
     let
@@ -968,25 +919,8 @@ computeTransportedMassImpacts ({ config } as requirements) maybeFrom maybeTo mas
         |> Transport.computeImpacts config.transports.modeProcesses mass
 
 
-computeToDistributionTransport : Requirements db -> Maybe Country -> LifeCycle -> List ExpandedItem -> Transport
-computeToDistributionTransport requirements maybeAssemblyCountry { production } expandedItems =
-    case maybeAssemblyCountry of
-        Just assemblyCountry ->
-            expandedItems
-                |> computeDistributionTransports requirements (Just assemblyCountry) (extractMass production)
-
-        Nothing ->
-            expandedItems
-                |> List.indexedMap
-                    (\index ->
-                        mapIndexedItemResult production index (computeItemTransportToDistribution requirements)
-                    )
-                |> List.filterMap identity
-                |> Transport.sum
-
-
 computeTransports : Requirements db -> Query -> LifeCycle -> Result String LifeCycle
-computeTransports ({ db } as requirements) query lifeCycle =
+computeTransports ({ config, db } as requirements) query lifeCycle =
     Result.map2
         (\expandedItems assemblyCountry ->
             { lifeCycle
@@ -997,9 +931,13 @@ computeTransports ({ db } as requirements) query lifeCycle =
                         if List.length query.items > 1 then
                             expandedItems
                                 |> List.indexedMap
-                                    (\index ->
-                                        mapIndexedItemResult lifeCycle.production index (computeItemTransportToAssembly requirements assemblyCountry)
-                                            >> Maybe.map Tuple.second
+                                    (\index expandedItem ->
+                                        extractItems lifeCycle.production
+                                            |> LE.getAt index
+                                            |> Maybe.map
+                                                (Tuple.second
+                                                    << computeItemTransportToAssembly requirements assemblyCountry expandedItem
+                                                )
                                     )
                                 |> List.filterMap identity
                                 |> Transport.sum
@@ -1007,7 +945,8 @@ computeTransports ({ db } as requirements) query lifeCycle =
                         else
                             Transport.default Impact.empty
                     , toDistribution =
-                        computeToDistributionTransport requirements assemblyCountry lifeCycle expandedItems
+                        extractMass lifeCycle.production
+                            |> computeTransportedMassImpacts requirements assemblyCountry (Just config.distribution.country)
                     }
             }
         )
@@ -1850,13 +1789,6 @@ loadEnergyMixes config =
                 , heat = config.production.defaultHeatProcess
                 }
             )
-
-
-mapIndexedItemResult : Results -> Int -> (ExpandedItem -> Results -> a) -> ExpandedItem -> Maybe a
-mapIndexedItemResult results index fn item =
-    extractItems results
-        |> LE.getAt index
-        |> Maybe.map (fn item)
 
 
 mapItems : (List Item -> List Item) -> Query -> Query

--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -42,8 +42,6 @@ module Data.Component exposing
     , decodeQuery
     , defaultConfig
     , defaultDurability
-    , defaultExpandedLocalizedProcess
-    , defaultTransform
     , elementTransforms
     , elementsToString
     , emptyComponent
@@ -78,6 +76,8 @@ module Data.Component exposing
     , itemsToString
     , loadEnergyMixes
     , mapItems
+    , nonExpandedLocalizedProcess
+    , nonLocalizedProcess
     , parseBase64Query
     , parseConfig
     , quantityFromInt
@@ -368,7 +368,11 @@ addElement targetItem material items =
                     { custom
                         | elements =
                             custom.elements
-                                ++ [ { amount = Amount.fromFloat 1, material = defaultMaterial material.id, transforms = [] } ]
+                                ++ [ { amount = Amount.fromFloat 1
+                                     , material = nonLocalizedProcess material.id
+                                     , transforms = []
+                                     }
+                                   ]
                     }
                 )
             |> Ok
@@ -382,7 +386,7 @@ addElementTransform targetElement transform items =
     else
         items
             |> updateElement targetElement
-                (\el -> { el | transforms = el.transforms ++ [ defaultTransform transform.id ] })
+                (\el -> { el | transforms = el.transforms ++ [ nonLocalizedProcess transform.id ] })
             |> Ok
 
 
@@ -448,8 +452,8 @@ applyDurability maybeDurability =
            )
 
 
-applyTransform : Process -> Results -> EnergyMixes -> Results
-applyTransform transform (Results { amount, label, impacts, items, mass, complementsImpacts }) { elec, heat } =
+applyTransform : Process -> EnergyMixes -> Results -> Results
+applyTransform transform { elec, heat } (Results { amount, label, impacts, items, mass, complementsImpacts }) =
     let
         transformImpacts =
             [ transform.impacts
@@ -495,34 +499,51 @@ applyTransform transform (Results { amount, label, impacts, items, mass, complem
         }
 
 
-applyTransportLeg : Requirements db -> Mass -> Maybe Country -> Maybe Country -> Results -> Results
-applyTransportLeg { config, db } mass maybeFrom maybeTo (Results results) =
+{-| Sequencially apply transforms to existing Results (typically, from material ones).
+
+Transported mass impacts and energy mixes use ones are computed at the transform step level: each step can optionally
+specify a country to use its electricity/heat mixes, or fallback to config defaults when absent.
+
+-}
+applyTransforms : Requirements db -> Maybe Country -> Process.Unit -> List ExpandedLocalizedProcess -> Results -> Result String Results
+applyTransforms requirements initialCountry unit transforms materialResults =
+    checkTransformsUnit unit transforms
+        |> Result.andThen
+            (Result.map Tuple.second
+                << List.foldl
+                    (\{ country, process } ->
+                        Result.andThen
+                            (\( previousCountry, results ) ->
+                                loadEnergyMixes requirements.config country
+                                    |> Result.map
+                                        (\mixes ->
+                                            ( country
+                                            , results
+                                                |> applyTransportedMassImpacts requirements (extractMass results) previousCountry country
+                                                |> applyTransform process mixes
+                                            )
+                                        )
+                            )
+                    )
+                    (Ok ( initialCountry, materialResults ))
+            )
+
+
+applyTransportedMassImpacts : Requirements db -> Mass -> Maybe Country -> Maybe Country -> Results -> Results
+applyTransportedMassImpacts requirements mass maybeFrom maybeTo (Results results) =
     let
-        legTransport =
-            case ( maybeFrom, maybeTo ) of
-                ( Just from, Just to ) ->
-                    db.distances
-                        |> Transport.getTransportBetween Impact.empty from.code to.code
-                        |> Transport.applyTransportRatios Split.zero
-                        |> Transport.computeImpacts config.transports.modeProcesses mass
-
-                _ ->
-                    config.transports.defaultDistance
-                        |> Transport.applyTransportRatios Split.zero
-                        |> Transport.computeImpacts config.transports.modeProcesses mass
-
-        transportImpacts =
-            legTransport.impacts
+        transport =
+            computeTransportedMassImpacts requirements maybeFrom maybeTo mass
     in
     Results
         { results
-            | impacts = Impact.sumImpacts [ results.impacts, transportImpacts ]
+            | impacts = Impact.sumImpacts [ results.impacts, transport.impacts ]
             , items =
                 results.items
                     ++ [ Results
                             { amount = results.amount
                             , complementsImpacts = Complement.emptyComplementsResultsImpacts
-                            , impacts = transportImpacts
+                            , impacts = transport.impacts
                             , items = []
                             , label = Just "Transport"
                             , mass = mass
@@ -532,41 +553,6 @@ applyTransportLeg { config, db } mass maybeFrom maybeTo (Results results) =
                             }
                        ]
         }
-
-
-{-| Sequencially apply transforms to existing Results (typically, from material ones).
-
-Energy mix impacts are computed at the transform step level: each step can optionally
-specify a country to use its electricity/heat mixes, or fallback to config defaults when absent.
-
--}
-applyTransforms : Requirements db -> Maybe Country -> Process.Unit -> List ExpandedLocalizedProcess -> Results -> Result String Results
-applyTransforms requirements initialCountry unit transforms materialResults =
-    checkTransformsUnit unit transforms
-        |> Result.andThen
-            (\validTransforms ->
-                validTransforms
-                    |> List.foldl
-                        (\{ country, process } acc ->
-                            acc
-                                |> Result.andThen
-                                    (\( previousCountry, results ) ->
-                                        loadEnergyMixes requirements.config country
-                                            |> Result.map
-                                                (\mixes ->
-                                                    let
-                                                        transportAppliedResults =
-                                                            applyTransportLeg requirements (extractMass results) previousCountry country results
-                                                    in
-                                                    ( country
-                                                    , applyTransform process transportAppliedResults mixes
-                                                    )
-                                                )
-                                    )
-                        )
-                        (Ok ( initialCountry, materialResults ))
-                    |> Result.map Tuple.second
-            )
 
 
 applyWaste : Split -> Amount -> Amount
@@ -768,25 +754,6 @@ computeItemResults requirements { custom, id, quantity } =
             )
 
 
-computeLocalizedTransport : Requirements db -> Maybe Country -> Maybe Country -> Transport
-computeLocalizedTransport { config, db } maybeFrom maybeTo =
-    case ( maybeFrom, maybeTo ) of
-        ( Just from, Just to ) ->
-            db.distances
-                |> Transport.getTransportBetween Impact.empty from.code to.code
-
-        _ ->
-            config.transports.defaultDistance
-
-
-computeLocalizedTransportImpacts : Requirements db -> Maybe Country -> Maybe Country -> Mass -> Transport
-computeLocalizedTransportImpacts ({ config } as requirements) maybeFrom maybeTo mass =
-    computeLocalizedTransport requirements maybeFrom maybeTo
-        -- TODO: consider handling air transport ratio in the future
-        |> Transport.applyTransportRatios Split.zero
-        |> Transport.computeImpacts config.transports.modeProcesses mass
-
-
 computeItemTransportToAssembly : Requirements db -> Maybe Country -> ExpandedItem -> Results -> ( String, Transport )
 computeItemTransportToAssembly requirements assemblyCountry item itemResults =
     let
@@ -818,7 +785,7 @@ computeItemTransportToAssembly requirements assemblyCountry item itemResults =
     , List.map2
         (\element elementResults ->
             extractMass elementResults
-                |> computeLocalizedTransportImpacts requirements (getElementFinalCountry element) assemblyCountry
+                |> computeTransportedMassImpacts requirements (getElementFinalCountry element) assemblyCountry
         )
         item.elements
         (extractItems itemResults)
@@ -835,7 +802,7 @@ computeItemTransportToDistribution ({ config } as requirements) item itemResults
     List.map2
         (\element elementResults ->
             extractMass elementResults
-                |> computeLocalizedTransportImpacts requirements (getElementFinalCountry element) (Just destination)
+                |> computeTransportedMassImpacts requirements (getElementFinalCountry element) (Just destination)
         )
         item.elements
         (extractItems itemResults)
@@ -926,6 +893,21 @@ computeShareImpacts mass { process, split } =
                     )
             )
         |> Maybe.withDefault Impact.empty
+
+
+computeTransportedMassImpacts : Requirements db -> Maybe Country -> Maybe Country -> Mass -> Transport
+computeTransportedMassImpacts { config, db } maybeFrom maybeTo mass =
+    (case ( maybeFrom, maybeTo ) of
+        ( Just from, Just to ) ->
+            db.distances
+                |> Transport.getTransportBetween Impact.empty from.code to.code
+
+        _ ->
+            config.transports.defaultDistance
+    )
+        -- TODO: consider handling air transport ratio in the future
+        |> Transport.applyTransportRatios Split.zero
+        |> Transport.computeImpacts config.transports.modeProcesses mass
 
 
 computeTransports : Requirements db -> Query -> LifeCycle -> Result String LifeCycle
@@ -1104,7 +1086,7 @@ decodeMaterial : Decoder LocalizedProcess
 decodeMaterial =
     Decode.oneOf
         [ decodeLocalizedProcess
-        , Process.decodeId |> Decode.map defaultMaterial
+        , Process.decodeId |> Decode.map nonLocalizedProcess
         ]
 
 
@@ -1119,7 +1101,7 @@ decodeTransforms =
         [ Decode.list decodeTransform
 
         -- Backward-compatible decoder for transforms when they were just process ids
-        , Decode.list (Process.decodeId |> Decode.map defaultTransform)
+        , Decode.list (Process.decodeId |> Decode.map nonLocalizedProcess)
         ]
 
 
@@ -1214,26 +1196,6 @@ defaultConfig =
 defaultDurability : Unit.Ratio
 defaultDurability =
     Unit.ratio 1
-
-
-defaultExpandedLocalizedProcess : Process -> ExpandedLocalizedProcess
-defaultExpandedLocalizedProcess process =
-    { country = Nothing, process = process }
-
-
-defaultLocalizedProcess : Process.Id -> LocalizedProcess
-defaultLocalizedProcess id =
-    { country = Nothing, id = id }
-
-
-defaultMaterial : Process.Id -> LocalizedProcess
-defaultMaterial =
-    defaultLocalizedProcess
-
-
-defaultTransform : Process.Id -> LocalizedProcess
-defaultTransform id =
-    defaultLocalizedProcess id
 
 
 elementToString : List Process -> Element -> Result String String
@@ -1904,6 +1866,16 @@ mapItems fn query =
     setQueryItems (fn query.items) query
 
 
+nonExpandedLocalizedProcess : Process -> ExpandedLocalizedProcess
+nonExpandedLocalizedProcess process =
+    { country = Nothing, process = process }
+
+
+nonLocalizedProcess : Process.Id -> LocalizedProcess
+nonLocalizedProcess id =
+    { country = Nothing, id = id }
+
+
 parseBase64Query : Parser (Maybe Query -> a) a
 parseBase64Query =
     Parser.custom "QUERY" <|
@@ -1993,7 +1965,7 @@ setElementMaterial targetElement material items =
             |> updateElement targetElement
                 (\el ->
                     { el
-                        | material = defaultMaterial material.id
+                        | material = nonLocalizedProcess material.id
 
                         -- Note: always reset the transforms when replacing a material for consistency
                         , transforms = []

--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -240,12 +240,6 @@ type alias Element =
     }
 
 
-type alias LocalizedProcess =
-    { country : Maybe Country.Code
-    , id : Process.Id
-    }
-
-
 {-| A full representation of an amount of material and optional transformations of it
 
 Note: the `country` field is propagated from the parent component item, for convenience
@@ -258,14 +252,24 @@ type alias ExpandedElement =
     }
 
 
+type alias Index =
+    Int
+
+
+{-| A process id with an optional country
+-}
+type alias LocalizedProcess =
+    { country : Maybe Country.Code
+    , id : Process.Id
+    }
+
+
+{-| A full process with an optional country
+-}
 type alias ExpandedLocalizedProcess =
     { country : Maybe Country
     , process : Process
     }
-
-
-type alias Index =
-    Int
 
 
 {-| Index of an item element and associated source component

--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -31,7 +31,6 @@ module Data.Component exposing
     , computeImpacts
     , computeInitialAmount
     , computeItemResults
-    , computeItemTransportToAssembly
     , computeScoring
     , computeTransportedMassImpacts
     , computeVolumeFromMass
@@ -758,50 +757,6 @@ computeItemResults requirements { custom, id, quantity } =
                     , stage = Nothing
                     }
             )
-
-
-{-| Compute the transport impacts for an item and all its elements to be eventually assembled.
--}
-computeItemTransportToAssembly : Requirements db -> Maybe Country -> ExpandedItem -> Results -> ( String, Transport )
-computeItemTransportToAssembly requirements assemblyCountry item itemResults =
-    let
-        origins =
-            item.elements
-                |> List.map getFinalElementCountry
-
-        defaultOrigin =
-            origins
-                |> List.filterMap identity
-                |> List.head
-
-        unknownTransportLabel =
-            "Trajet inconnu majoré"
-    in
-    ( case assemblyCountry of
-        Just { name } ->
-            -- all items elements have the same origin
-            if origins |> List.all ((==) defaultOrigin) then
-                (defaultOrigin
-                    |> Maybe.map .name
-                    |> Maybe.withDefault unknownTransportLabel
-                )
-                    ++ " → "
-                    ++ name
-
-            else
-                "Origines multiples → " ++ name
-
-        Nothing ->
-            unknownTransportLabel
-    , extractItems itemResults
-        |> List.map2
-            (\element elementResults ->
-                extractMass elementResults
-                    |> computeTransportedMassImpacts requirements (getFinalElementCountry element) assemblyCountry
-            )
-            item.elements
-        |> Transport.sum
-    )
 
 
 computeMaterialResults : Amount -> Process -> Results

--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -33,6 +33,7 @@ module Data.Component exposing
     , computeItemResults
     , computeItemTransportToAssembly
     , computeScoring
+    , computeTransportedMassImpacts
     , computeVolumeFromMass
     , createItem
     , decode

--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -672,6 +672,8 @@ computeDistributionTransports ({ config, db } as requirements) maybeAssemblyCoun
         ( _, Just { code } ) ->
             db.distances
                 |> Transport.getTransportBetween Impact.empty code config.distribution.country.code
+                -- Note: air transport is not handled for now
+                |> Transport.applyTransportRatios Split.zero
                 |> Transport.computeImpacts config.transports.modeProcesses mass
 
         -- no assembly country specified, sum transports from all elements origins to the distribution country

--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -351,8 +351,8 @@ type Results
 -}
 type Stage
     = MaterialStage
-    | TransportStage
     | TransformStage
+    | TransportStage
 
 
 type alias Requirements db =
@@ -796,9 +796,6 @@ computeItemTransportToAssembly requirements assemblyCountry item itemResults =
 
         label =
             case assemblyCountry of
-                Nothing ->
-                    "Trajet inconnu majoré"
-
                 Just { name } ->
                     if List.all (\origin -> origin == defaultOrigin) origins then
                         (origins
@@ -812,6 +809,9 @@ computeItemTransportToAssembly requirements assemblyCountry item itemResults =
 
                     else
                         "Origines multiples → " ++ name
+
+                Nothing ->
+                    "Trajet inconnu majoré"
 
         itemTransport =
             List.map2
@@ -2078,11 +2078,11 @@ stageToString stage =
         MaterialStage ->
             "material"
 
-        TransportStage ->
-            "transport"
-
         TransformStage ->
             "transformation"
+
+        TransportStage ->
+            "transport"
 
 
 sumLifeCycleImpacts : LifeCycle -> Impacts

--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -2056,8 +2056,8 @@ transformListToString =
         (\{ country, process } ->
             Process.getDisplayName process
                 ++ (case country of
-                        Just { code } ->
-                            " (" ++ Country.codeToString code ++ ")"
+                        Just { name } ->
+                            " (" ++ name ++ ")"
 
                         Nothing ->
                             ""

--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -533,6 +533,9 @@ applyTransforms requirements initialCountry unit transforms materialResults =
         |> Result.map Tuple.second
 
 
+{-| Add transport impacts for a mass and two optional countries to a results, falling back to transport config
+defaults when both are unknown.
+-}
 applyTransportedMassImpacts : Requirements db -> Mass -> Maybe Country -> Maybe Country -> Results -> Results
 applyTransportedMassImpacts requirements mass maybeFrom maybeTo (Results results) =
     let
@@ -659,6 +662,7 @@ of production or country of assembly to configured distribution destination coun
 computeDistributionTransports : Requirements db -> Maybe Country -> List ExpandedItem -> Transport
 computeDistributionTransports ({ config, db } as requirements) maybeAssemblyCountry items =
     case ( items, maybeAssemblyCountry ) of
+        -- no items to distribute
         ( [], _ ) ->
             Transport.default Impact.empty
 
@@ -783,6 +787,8 @@ computeItemResults requirements { custom, id, quantity } =
             )
 
 
+{-| Compute the transport impacts for an item and all its elements to be eventually assembled.
+-}
 computeItemTransportToAssembly : Requirements db -> Maybe Country -> ExpandedItem -> Results -> ( String, Transport )
 computeItemTransportToAssembly requirements assemblyCountry item itemResults =
     let
@@ -791,17 +797,20 @@ computeItemTransportToAssembly requirements assemblyCountry item itemResults =
                 |> List.map getElementFinalCountry
 
         defaultOrigin =
-            List.head origins
-                |> Maybe.withDefault Nothing
+            origins
+                |> List.filterMap identity
+                |> List.head
+
+        unknownTransportLabel =
+            "Trajet inconnu majoré"
     in
     ( case assemblyCountry of
         Just { name } ->
+            -- all items elements have the same origin
             if origins |> List.all ((==) defaultOrigin) then
-                (origins
-                    |> List.head
-                    |> Maybe.andThen identity
+                (defaultOrigin
                     |> Maybe.map .name
-                    |> Maybe.withDefault "Trajet inconnu majoré"
+                    |> Maybe.withDefault unknownTransportLabel
                 )
                     ++ " → "
                     ++ name
@@ -810,20 +819,20 @@ computeItemTransportToAssembly requirements assemblyCountry item itemResults =
                 "Origines multiples → " ++ name
 
         Nothing ->
-            "Trajet inconnu majoré"
+            unknownTransportLabel
     , extractItems itemResults
         |> List.map2
             (\element elementResults ->
                 extractMass elementResults
-                    |> computeTransportedMassImpacts requirements
-                        (getElementFinalCountry element)
-                        assemblyCountry
+                    |> computeTransportedMassImpacts requirements (getElementFinalCountry element) assemblyCountry
             )
             item.elements
         |> Transport.sum
     )
 
 
+{-| Compute item transport impacts of all its elements to the configured distribution country.
+-}
 computeItemTransportToDistribution : Requirements db -> ExpandedItem -> Results -> Transport
 computeItemTransportToDistribution ({ config } as requirements) item itemResults =
     extractItems itemResults
@@ -941,15 +950,21 @@ computeTransportDistance { config, db } maybeFrom maybeTo =
 computeTransportedMassImpacts : Requirements db -> Maybe Country -> Maybe Country -> Mass -> Transport
 computeTransportedMassImpacts ({ config } as requirements) maybeFrom maybeTo mass =
     computeTransportDistance requirements maybeFrom maybeTo
-        -- TODO: consider handling air transport ratio in the future
+        -- Note: air transport is not handled for now
         |> Transport.applyTransportRatios Split.zero
         |> Transport.computeImpacts config.transports.modeProcesses mass
 
 
 computeTransports : Requirements db -> Query -> LifeCycle -> Result String LifeCycle
-computeTransports ({ config, db } as req) query lifeCycle =
+computeTransports ({ config, db } as requirements) query lifeCycle =
+    let
+        mapItemAt index fn item =
+            extractItems lifeCycle.production
+                |> LE.getAt index
+                |> Maybe.map (fn item)
+    in
     Result.map2
-        (\expandedItems maybeAssemblyCountry ->
+        (\expandedItems assemblyCountry ->
             { lifeCycle
                 | transports =
                     { toAssembly =
@@ -958,11 +973,9 @@ computeTransports ({ config, db } as req) query lifeCycle =
                         if List.length query.items > 1 then
                             expandedItems
                                 |> List.indexedMap
-                                    (\index item ->
-                                        lifeCycle.production
-                                            |> extractItems
-                                            |> LE.getAt index
-                                            |> Maybe.map (computeItemTransportToAssembly req maybeAssemblyCountry item >> Tuple.second)
+                                    (\index ->
+                                        mapItemAt index (computeItemTransportToAssembly requirements assemblyCountry)
+                                            >> Maybe.map Tuple.second
                                     )
                                 |> List.filterMap identity
                                 |> Transport.sum
@@ -970,23 +983,17 @@ computeTransports ({ config, db } as req) query lifeCycle =
                         else
                             Transport.default Impact.empty
                     , toDistribution =
-                        case maybeAssemblyCountry of
+                        case assemblyCountry of
                             Just _ ->
                                 expandedItems
-                                    |> computeDistributionTransports req maybeAssemblyCountry
-                                    -- TODO: consider handling air transport ratio in the future
+                                    |> computeDistributionTransports requirements assemblyCountry
+                                    -- Note: air transport is not handled for now
                                     |> Transport.applyTransportRatios Split.zero
                                     |> Transport.computeImpacts config.transports.modeProcesses (extractMass lifeCycle.production)
 
                             Nothing ->
                                 expandedItems
-                                    |> List.indexedMap
-                                        (\index item ->
-                                            lifeCycle.production
-                                                |> extractItems
-                                                |> LE.getAt index
-                                                |> Maybe.map (computeItemTransportToDistribution req item)
-                                        )
+                                    |> List.indexedMap (\index -> mapItemAt index (computeItemTransportToDistribution requirements))
                                     |> List.filterMap identity
                                     |> Transport.sum
                     }

--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -76,7 +76,7 @@ module Data.Component exposing
     , itemsToString
     , loadEnergyMixes
     , mapItems
-    , nonExpandedLocalizedProcess
+    , nonLocalizedExpandedProcess
     , nonLocalizedProcess
     , parseBase64Query
     , parseConfig
@@ -509,24 +509,21 @@ applyTransforms : Requirements db -> Maybe Country -> Process.Unit -> List Expan
 applyTransforms requirements initialCountry unit transforms materialResults =
     checkTransformsUnit unit transforms
         |> Result.andThen
-            (Result.map Tuple.second
-                << List.foldl
-                    (\{ country, process } ->
-                        Result.andThen
-                            (\( previousCountry, results ) ->
-                                loadEnergyMixes requirements.config country
-                                    |> Result.map
-                                        (\mixes ->
-                                            ( country
-                                            , results
-                                                |> applyTransportedMassImpacts requirements (extractMass results) previousCountry country
-                                                |> applyTransform process mixes
-                                            )
-                                        )
+            (RE.foldlWhileOk
+                (\{ country, process } ( previousCountry, results ) ->
+                    loadEnergyMixes requirements.config country
+                        |> Result.map
+                            (\mixes ->
+                                ( country
+                                , results
+                                    |> applyTransportedMassImpacts requirements (extractMass results) previousCountry country
+                                    |> applyTransform process mixes
+                                )
                             )
-                    )
-                    (Ok ( initialCountry, materialResults ))
+                )
+                ( initialCountry, materialResults )
             )
+        |> Result.map Tuple.second
 
 
 applyTransportedMassImpacts : Requirements db -> Mass -> Maybe Country -> Maybe Country -> Results -> Results
@@ -647,6 +644,31 @@ computeDistributionImpacts ({ config } as requirements) query ({ distribution, p
                         , volume = finalProductVolume
                         }
                 }
+
+
+{-| Computes transports of components from the number of shipped items, and either their respective country
+of production or country of assembly to configured distribution destination country.
+-}
+computeDistributionTransports : Requirements db -> Maybe Country -> List ExpandedItem -> Transport
+computeDistributionTransports ({ config, db } as requirements) maybeAssemblyCountry items =
+    case ( items, maybeAssemblyCountry ) of
+        ( [], _ ) ->
+            Transport.default Impact.empty
+
+        -- ship items from a specific assembly country
+        ( _, Just { code } ) ->
+            db.distances
+                |> Transport.getTransportBetween Impact.empty code config.distribution.country.code
+
+        -- no assembly country specified, sum transports from all elements origins to the distribution country
+        ( _, Nothing ) ->
+            items
+                |> List.concatMap .elements
+                |> List.map
+                    (getElementFinalCountry
+                        >> computeTransportDistance requirements (Just config.distribution.country)
+                    )
+                |> Transport.sum
 
 
 computeElementResults : Requirements db -> Element -> Result String Results
@@ -782,30 +804,30 @@ computeItemTransportToAssembly requirements assemblyCountry item itemResults =
 
         Nothing ->
             "Trajet inconnu majoré"
-    , List.map2
-        (\element elementResults ->
-            extractMass elementResults
-                |> computeTransportedMassImpacts requirements (getElementFinalCountry element) assemblyCountry
-        )
-        item.elements
-        (extractItems itemResults)
+    , extractItems itemResults
+        |> List.map2
+            (\element elementResults ->
+                extractMass elementResults
+                    |> computeTransportedMassImpacts requirements
+                        (getElementFinalCountry element)
+                        assemblyCountry
+            )
+            item.elements
         |> Transport.sum
     )
 
 
 computeItemTransportToDistribution : Requirements db -> ExpandedItem -> Results -> Transport
 computeItemTransportToDistribution ({ config } as requirements) item itemResults =
-    let
-        destination =
-            config.distribution.country
-    in
-    List.map2
-        (\element elementResults ->
-            extractMass elementResults
-                |> computeTransportedMassImpacts requirements (getElementFinalCountry element) (Just destination)
-        )
-        item.elements
-        (extractItems itemResults)
+    extractItems itemResults
+        |> List.map2
+            (\element itemResult ->
+                extractMass itemResult
+                    |> computeTransportedMassImpacts requirements
+                        (getElementFinalCountry element)
+                        (Just config.distribution.country)
+            )
+            item.elements
         |> Transport.sum
 
 
@@ -873,7 +895,10 @@ computeScoring definitions { production } =
             , extractMass production
               -- New metadata complements should always be added and not substracted as before, that’s why we negate it
               -- here to stay compatible with the current implementations for Ecosystemic Services
-            , Quantity.negate (extractComplementsImpacts production |> Complement.mergeComplementsResultsImpacts |> Impact.getImpact Definition.Ecs)
+            , extractComplementsImpacts production
+                |> Complement.mergeComplementsResultsImpacts
+                |> Impact.getImpact Definition.Ecs
+                |> Quantity.negate
             )
     in
     totalImpacts
@@ -895,16 +920,20 @@ computeShareImpacts mass { process, split } =
         |> Maybe.withDefault Impact.empty
 
 
-computeTransportedMassImpacts : Requirements db -> Maybe Country -> Maybe Country -> Mass -> Transport
-computeTransportedMassImpacts { config, db } maybeFrom maybeTo mass =
-    (case ( maybeFrom, maybeTo ) of
+computeTransportDistance : Requirements db -> Maybe Country -> Maybe Country -> Transport
+computeTransportDistance { config, db } maybeFrom maybeTo =
+    case ( maybeFrom, maybeTo ) of
         ( Just from, Just to ) ->
             db.distances
                 |> Transport.getTransportBetween Impact.empty from.code to.code
 
         _ ->
             config.transports.defaultDistance
-    )
+
+
+computeTransportedMassImpacts : Requirements db -> Maybe Country -> Maybe Country -> Mass -> Transport
+computeTransportedMassImpacts ({ config } as requirements) maybeFrom maybeTo mass =
+    computeTransportDistance requirements maybeFrom maybeTo
         -- TODO: consider handling air transport ratio in the future
         |> Transport.applyTransportRatios Split.zero
         |> Transport.computeImpacts config.transports.modeProcesses mass
@@ -958,36 +987,6 @@ computeTransports ({ config, db } as req) query lifeCycle =
         )
         (expandItems db query.items)
         (Country.resolveMaybe query.assemblyCountry db.countries)
-
-
-{-| Computes transports of components from the number of shipped items, and either their respective country
-of production or country of assembly to configured distribution destination country.
--}
-computeDistributionTransports : Requirements db -> Maybe Country -> List ExpandedItem -> Transport
-computeDistributionTransports { config, db } maybeAssemblyCountry items =
-    let
-        toDistributionTransport maybeFromCountry =
-            case maybeFromCountry of
-                Just { code } ->
-                    db.distances
-                        |> Transport.getTransportBetween Impact.empty code config.distribution.country.code
-
-                Nothing ->
-                    config.transports.defaultDistance
-    in
-    case ( items, maybeAssemblyCountry ) of
-        ( [], _ ) ->
-            Transport.default Impact.empty
-
-        ( _, Just { code } ) ->
-            db.distances
-                |> Transport.getTransportBetween Impact.empty code config.distribution.country.code
-
-        ( _, Nothing ) ->
-            items
-                |> List.concatMap .elements
-                |> List.map (getElementFinalCountry >> toDistributionTransport)
-                |> Transport.sum
 
 
 computeUseImpacts : Requirements db -> Query -> LifeCycle -> Result String LifeCycle
@@ -1086,19 +1085,16 @@ decodeMaterial : Decoder LocalizedProcess
 decodeMaterial =
     Decode.oneOf
         [ decodeLocalizedProcess
+
+        -- Backward-compatible decoder for materials when they were just process ids
         , Process.decodeId |> Decode.map nonLocalizedProcess
         ]
-
-
-decodeTransform : Decoder LocalizedProcess
-decodeTransform =
-    decodeLocalizedProcess
 
 
 decodeTransforms : Decoder (List LocalizedProcess)
 decodeTransforms =
     Decode.oneOf
-        [ Decode.list decodeTransform
+        [ Decode.list decodeLocalizedProcess
 
         -- Backward-compatible decoder for transforms when they were just process ids
         , Decode.list (Process.decodeId |> Decode.map nonLocalizedProcess)
@@ -1583,11 +1579,13 @@ getTotalImpacts (Results { impacts, complementsImpacts }) =
         ]
 
 
+{-| Get the final country of an element, which is the country of the last transform if any,
+or the country of the material otherwise.
+-}
 getElementFinalCountry : ExpandedElement -> Maybe Country
 getElementFinalCountry { material, transforms } =
     transforms
-        |> List.reverse
-        |> List.head
+        |> LE.last
         |> Maybe.map .country
         |> Maybe.withDefault material.country
 
@@ -1866,8 +1864,8 @@ mapItems fn query =
     setQueryItems (fn query.items) query
 
 
-nonExpandedLocalizedProcess : Process -> ExpandedLocalizedProcess
-nonExpandedLocalizedProcess process =
+nonLocalizedExpandedProcess : Process -> ExpandedLocalizedProcess
+nonLocalizedExpandedProcess process =
     { country = Nothing, process = process }
 
 

--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -62,6 +62,7 @@ module Data.Component exposing
     , extractImpacts
     , extractItems
     , extractMass
+    , extractStage
     , findById
     , getAvailableDistributionProcesses
     , getEndOfLifeDetailedImpacts
@@ -1602,6 +1603,11 @@ extractItems (Results { items }) =
 extractMass : Results -> Mass
 extractMass (Results { mass }) =
     mass
+
+
+extractStage : Results -> Maybe Stage
+extractStage (Results { stage }) =
+    stage
 
 
 {-| Lookup a Component from a provided Id

--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -658,9 +658,12 @@ computeDistributionImpacts ({ config } as requirements) query ({ distribution, p
 
 {-| Computes transports of components from the number of shipped items, and either their respective country
 of production or country of assembly to configured distribution destination country.
+
+Note: this only computes the transport distances, not the impacts (as a transported mass would be required)
+
 -}
-computeDistributionTransports : Requirements db -> Maybe Country -> List ExpandedItem -> Transport
-computeDistributionTransports ({ config, db } as requirements) maybeAssemblyCountry items =
+computeDistributionTransports : Requirements db -> Maybe Country -> Mass -> List ExpandedItem -> Transport
+computeDistributionTransports ({ config, db } as requirements) maybeAssemblyCountry mass items =
     case ( items, maybeAssemblyCountry ) of
         -- no items to distribute
         ( [], _ ) ->
@@ -670,6 +673,7 @@ computeDistributionTransports ({ config, db } as requirements) maybeAssemblyCoun
         ( _, Just { code } ) ->
             db.distances
                 |> Transport.getTransportBetween Impact.empty code config.distribution.country.code
+                |> Transport.computeImpacts config.transports.modeProcesses mass
 
         -- no assembly country specified, sum transports from all elements origins to the distribution country
         ( _, Nothing ) ->
@@ -680,6 +684,7 @@ computeDistributionTransports ({ config, db } as requirements) maybeAssemblyCoun
                         >> computeTransportDistance requirements (Just config.distribution.country)
                     )
                 |> Transport.sum
+                |> Transport.computeImpacts config.transports.modeProcesses mass
 
 
 computeElementResults : Requirements db -> Element -> Result String Results
@@ -936,6 +941,11 @@ computeShareImpacts mass { process, split } =
         |> Maybe.withDefault Impact.empty
 
 
+{-| Computes the transport distance between two countries.
+
+Note: this only computes the transport distances, not the impacts (as a transported mass would be required)
+
+-}
 computeTransportDistance : Requirements db -> Maybe Country -> Maybe Country -> Transport
 computeTransportDistance { config, db } maybeFrom maybeTo =
     case ( maybeFrom, maybeTo ) of
@@ -947,6 +957,8 @@ computeTransportDistance { config, db } maybeFrom maybeTo =
             config.transports.defaultDistance
 
 
+{-| Computes the transport distances and impacts from a transported mass.
+-}
 computeTransportedMassImpacts : Requirements db -> Maybe Country -> Maybe Country -> Mass -> Transport
 computeTransportedMassImpacts ({ config } as requirements) maybeFrom maybeTo mass =
     computeTransportDistance requirements maybeFrom maybeTo
@@ -955,26 +967,37 @@ computeTransportedMassImpacts ({ config } as requirements) maybeFrom maybeTo mas
         |> Transport.computeImpacts config.transports.modeProcesses mass
 
 
+computeToDistributionTransport : Requirements db -> Maybe Country -> LifeCycle -> List ExpandedItem -> Transport
+computeToDistributionTransport requirements maybeAssemblyCountry { production } expandedItems =
+    case maybeAssemblyCountry of
+        Just assemblyCountry ->
+            expandedItems
+                |> computeDistributionTransports requirements (Just assemblyCountry) (extractMass production)
+
+        Nothing ->
+            expandedItems
+                |> List.indexedMap
+                    (\index ->
+                        mapIndexedItemResult production index (computeItemTransportToDistribution requirements)
+                    )
+                |> List.filterMap identity
+                |> Transport.sum
+
+
 computeTransports : Requirements db -> Query -> LifeCycle -> Result String LifeCycle
-computeTransports ({ config, db } as requirements) query lifeCycle =
-    let
-        mapItemAt index fn item =
-            extractItems lifeCycle.production
-                |> LE.getAt index
-                |> Maybe.map (fn item)
-    in
+computeTransports ({ db } as requirements) query lifeCycle =
     Result.map2
         (\expandedItems assemblyCountry ->
             { lifeCycle
                 | transports =
                     { toAssembly =
-                        -- Only convey multiple items to assembly stage
+                        -- Only multiple items are transported to the assembly stage
                         -- TODO: refactor query to handle this through types https://github.com/MTES-MCT/ecobalyse/issues/1609
                         if List.length query.items > 1 then
                             expandedItems
                                 |> List.indexedMap
                                     (\index ->
-                                        mapItemAt index (computeItemTransportToAssembly requirements assemblyCountry)
+                                        mapIndexedItemResult lifeCycle.production index (computeItemTransportToAssembly requirements assemblyCountry)
                                             >> Maybe.map Tuple.second
                                     )
                                 |> List.filterMap identity
@@ -983,19 +1006,7 @@ computeTransports ({ config, db } as requirements) query lifeCycle =
                         else
                             Transport.default Impact.empty
                     , toDistribution =
-                        case assemblyCountry of
-                            Just _ ->
-                                expandedItems
-                                    |> computeDistributionTransports requirements assemblyCountry
-                                    -- Note: air transport is not handled for now
-                                    |> Transport.applyTransportRatios Split.zero
-                                    |> Transport.computeImpacts config.transports.modeProcesses (extractMass lifeCycle.production)
-
-                            Nothing ->
-                                expandedItems
-                                    |> List.indexedMap (\index -> mapItemAt index (computeItemTransportToDistribution requirements))
-                                    |> List.filterMap identity
-                                    |> Transport.sum
+                        computeToDistributionTransport requirements assemblyCountry lifeCycle expandedItems
                     }
             }
         )
@@ -1876,6 +1887,13 @@ loadEnergyMixes config =
                 , heat = config.production.defaultHeatProcess
                 }
             )
+
+
+mapIndexedItemResult : Results -> Int -> (ExpandedItem -> Results -> a) -> ExpandedItem -> Maybe a
+mapIndexedItemResult results index fn item =
+    extractItems results
+        |> LE.getAt index
+        |> Maybe.map (fn item)
 
 
 mapItems : (List Item -> List Item) -> Query -> Query

--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -8,7 +8,7 @@ module Data.Component exposing
     , EndOfLifeMaterialImpacts
     , ExpandedElement
     , ExpandedItem
-    , ExpandedTransform
+    , ExpandedLocalizedProcess
     , Id
     , Index
     , Item
@@ -42,7 +42,7 @@ module Data.Component exposing
     , decodeQuery
     , defaultConfig
     , defaultDurability
-    , defaultExpandedTransform
+    , defaultExpandedLocalizedProcess
     , defaultTransform
     , elementTransforms
     , elementsToString
@@ -110,7 +110,7 @@ module Data.Component exposing
 import Base64
 import Data.Common.DecodeUtils as DU
 import Data.Common.EncodeUtils as EU
-import Data.Complement as Complement exposing (ComplementsResultsImpacts)
+import Data.Complement as Complement exposing (ComplementsImpacts, ComplementsResultsImpacts)
 import Data.Component.Amount as Amount exposing (Amount)
 import Data.Component.Config as Config exposing (EndOfLifeStrategies, EndOfLifeStrategy)
 import Data.Country as Country exposing (Country)
@@ -253,19 +253,15 @@ Note: the `country` field is propagated from the parent component item, for conv
 -}
 type alias ExpandedElement =
     { amount : Amount
-    , material : ExpandedMaterial
-    , transforms : List ExpandedTransform
+    , material : ExpandedLocalizedProcess
+    , transforms : List ExpandedLocalizedProcess
     }
 
 
-type alias ExpandedTransform =
+type alias ExpandedLocalizedProcess =
     { country : Maybe Country
     , process : Process
     }
-
-
-type alias ExpandedMaterial =
-    ExpandedTransform
 
 
 type alias Index =
@@ -428,6 +424,18 @@ addResults (Results results) (Results acc) =
         }
 
 
+applyComplementsResultsImpacts : Amount -> Impacts -> ComplementsImpacts -> ComplementsResultsImpacts
+applyComplementsResultsImpacts amount impacts =
+    Complement.mapComplements
+        (Maybe.map
+            (\complement ->
+                impacts
+                    |> Complement.applyComplementsToImpacts complement
+                    |> Impact.multiplyBy (Amount.toFloat amount)
+            )
+        )
+
+
 applyDurability : Maybe Unit.Ratio -> LifeCycle -> Impacts
 applyDurability maybeDurability =
     sumLifeCycleImpacts
@@ -532,7 +540,7 @@ Energy mix impacts are computed at the transform step level: each step can optio
 specify a country to use its electricity/heat mixes, or fallback to config defaults when absent.
 
 -}
-applyTransforms : Requirements db -> Maybe Country -> Process.Unit -> List ExpandedTransform -> Results -> Result String Results
+applyTransforms : Requirements db -> Maybe Country -> Process.Unit -> List ExpandedLocalizedProcess -> Results -> Result String Results
 applyTransforms requirements initialCountry unit transforms materialResults =
     checkTransformsUnit unit transforms
         |> Result.andThen
@@ -566,7 +574,7 @@ applyWaste waste =
     Amount.map (\amount -> amount - (amount * Split.toFloat waste))
 
 
-checkTransformsUnit : Process.Unit -> List ExpandedTransform -> Result String (List ExpandedTransform)
+checkTransformsUnit : Process.Unit -> List ExpandedLocalizedProcess -> Result String (List ExpandedLocalizedProcess)
 checkTransformsUnit unit transforms =
     if not <| List.all (.process >> .unit >> (==) unit) transforms then
         "Les procédés de transformation ne partagent pas la même unité que la matière source ("
@@ -771,9 +779,10 @@ computeLocalizedTransport { config, db } maybeFrom maybeTo =
             config.transports.defaultDistance
 
 
-computeLocalizedTransportImpacts : Requirements db -> Mass -> Maybe Country -> Maybe Country -> Transport
-computeLocalizedTransportImpacts ({ config } as requirements) mass maybeFrom maybeTo =
+computeLocalizedTransportImpacts : Requirements db -> Maybe Country -> Maybe Country -> Mass -> Transport
+computeLocalizedTransportImpacts ({ config } as requirements) maybeFrom maybeTo mass =
     computeLocalizedTransport requirements maybeFrom maybeTo
+        -- TODO: consider handling air transport ratio in the future
         |> Transport.applyTransportRatios Split.zero
         |> Transport.computeImpacts config.transports.modeProcesses mass
 
@@ -786,76 +795,51 @@ computeItemTransportToAssembly requirements assemblyCountry item itemResults =
                 |> List.map getElementFinalCountry
 
         defaultOrigin =
-            origins
-                |> List.head
+            List.head origins
                 |> Maybe.withDefault Nothing
-
-        label =
-            case assemblyCountry of
-                Just { name } ->
-                    if List.all (\origin -> origin == defaultOrigin) origins then
-                        (origins
-                            |> List.head
-                            |> Maybe.andThen identity
-                            |> Maybe.map .name
-                            |> Maybe.withDefault "Trajet inconnu majoré"
-                        )
-                            ++ " → "
-                            ++ name
-
-                    else
-                        "Origines multiples → " ++ name
-
-                Nothing ->
-                    "Trajet inconnu majoré"
-
-        itemTransport =
-            List.map2
-                (\element elementResults ->
-                    computeLocalizedTransportImpacts
-                        requirements
-                        (extractMass elementResults)
-                        (getElementFinalCountry element)
-                        assemblyCountry
-                )
-                item.elements
-                (extractItems itemResults)
-                |> Transport.sum
     in
-    ( label
-    , itemTransport
+    ( case assemblyCountry of
+        Just { name } ->
+            if origins |> List.all ((==) defaultOrigin) then
+                (origins
+                    |> List.head
+                    |> Maybe.andThen identity
+                    |> Maybe.map .name
+                    |> Maybe.withDefault "Trajet inconnu majoré"
+                )
+                    ++ " → "
+                    ++ name
+
+            else
+                "Origines multiples → " ++ name
+
+        Nothing ->
+            "Trajet inconnu majoré"
+    , List.map2
+        (\element elementResults ->
+            extractMass elementResults
+                |> computeLocalizedTransportImpacts requirements (getElementFinalCountry element) assemblyCountry
+        )
+        item.elements
+        (extractItems itemResults)
+        |> Transport.sum
     )
 
 
 computeItemTransportToDistribution : Requirements db -> ExpandedItem -> Results -> Transport
 computeItemTransportToDistribution ({ config } as requirements) item itemResults =
+    let
+        destination =
+            config.distribution.country
+    in
     List.map2
         (\element elementResults ->
-            computeLocalizedTransportImpacts
-                requirements
-                (extractMass elementResults)
-                (getElementFinalCountry element)
-                (Just config.distribution.country)
+            extractMass elementResults
+                |> computeLocalizedTransportImpacts requirements (getElementFinalCountry element) (Just destination)
         )
         item.elements
         (extractItems itemResults)
         |> Transport.sum
-
-
-applyComplementsResultsImpacts : Amount -> Impacts -> Complement.ComplementsImpacts -> ComplementsResultsImpacts
-applyComplementsResultsImpacts amount impacts complementsImpacts =
-    let
-        applyComplementAmount : Maybe Unit.Impact -> Maybe Impacts
-        applyComplementAmount complement =
-            complement
-                |> Maybe.map
-                    (\c ->
-                        impacts
-                            |> Complement.applyComplementsToImpacts c
-                            |> Impact.multiplyBy (Amount.toFloat amount)
-                    )
-    in
-    complementsImpacts |> Complement.mapComplements applyComplementAmount
 
 
 computeMaterialResults : Amount -> Process -> Results
@@ -950,7 +934,6 @@ computeTransports ({ config, db } as req) query lifeCycle =
         (\expandedItems maybeAssemblyCountry ->
             { lifeCycle
                 | transports =
-                    -- Note: for now it's assumed there's never air transport
                     { toAssembly =
                         -- Only convey multiple items to assembly stage
                         -- TODO: refactor query to handle this through types https://github.com/MTES-MCT/ecobalyse/issues/1609
@@ -973,6 +956,7 @@ computeTransports ({ config, db } as req) query lifeCycle =
                             Just _ ->
                                 expandedItems
                                     |> computeDistributionTransports req maybeAssemblyCountry
+                                    -- TODO: consider handling air transport ratio in the future
                                     |> Transport.applyTransportRatios Split.zero
                                     |> Transport.computeImpacts config.transports.modeProcesses (extractMass lifeCycle.production)
 
@@ -995,7 +979,7 @@ computeTransports ({ config, db } as req) query lifeCycle =
 
 
 {-| Computes transports of components from the number of shipped items, and either their respective country
-of production or country of assembly to France (the only possible distribution destination).
+of production or country of assembly to configured distribution destination country.
 -}
 computeDistributionTransports : Requirements db -> Maybe Country -> List ExpandedItem -> Transport
 computeDistributionTransports { config, db } maybeAssemblyCountry items =
@@ -1232,8 +1216,8 @@ defaultDurability =
     Unit.ratio 1
 
 
-defaultExpandedTransform : Process -> ExpandedTransform
-defaultExpandedTransform process =
+defaultExpandedLocalizedProcess : Process -> ExpandedLocalizedProcess
+defaultExpandedLocalizedProcess process =
     { country = Nothing, process = process }
 
 
@@ -1601,13 +1585,13 @@ expandItems db =
     List.map (expandItem db) >> RE.combine
 
 
-{-| Turn a list of Transform into a list of ExpandedTransform
+{-| Turn a list of localized processes into expanded localized processes
 -}
-expandTransforms : DataContainer db -> List LocalizedProcess -> Result String (List ExpandedTransform)
+expandTransforms : DataContainer db -> List LocalizedProcess -> Result String (List ExpandedLocalizedProcess)
 expandTransforms { countries, processes } =
     List.map
         (\{ country, id } ->
-            Ok ExpandedTransform
+            Ok ExpandedLocalizedProcess
                 |> RE.andMap (Country.resolveMaybe country countries)
                 |> RE.andMap (Process.findById id processes)
         )
@@ -2109,7 +2093,7 @@ toSearchableString db component =
         ]
 
 
-transformListToString : List ExpandedTransform -> String
+transformListToString : List ExpandedLocalizedProcess -> String
 transformListToString =
     List.map
         (\{ country, process } ->

--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -922,36 +922,77 @@ computeTransportedMassImpacts ({ config } as requirements) maybeFrom maybeTo mas
 computeTransports : Requirements db -> Query -> LifeCycle -> Result String LifeCycle
 computeTransports ({ config, db } as requirements) query lifeCycle =
     Result.map2
-        (\expandedItems assemblyCountry ->
-            { lifeCycle
-                | transports =
-                    { toAssembly =
-                        -- Only multiple items are transported to the assembly stage
-                        -- TODO: refactor query to handle this through types https://github.com/MTES-MCT/ecobalyse/issues/1609
-                        if List.length query.items > 1 then
-                            expandedItems
-                                |> List.indexedMap
-                                    (\index expandedItem ->
-                                        extractItems lifeCycle.production
-                                            |> LE.getAt index
-                                            |> Maybe.map
-                                                (Tuple.second
-                                                    << computeItemTransportToAssembly requirements assemblyCountry expandedItem
-                                                )
-                                    )
-                                |> List.filterMap identity
-                                |> Transport.sum
+        (\expandedItems maybeAssemblyCountry ->
+            -- Only multiple items are transported to the assembly stage
+            -- TODO: refactor query to handle this through types https://github.com/MTES-MCT/ecobalyse/issues/1609
+            case ( expandedItems, maybeAssemblyCountry ) of
+                ( [], Just _ ) ->
+                    Err "Une liste de composants vide ne peut être assemblée"
 
-                        else
-                            Transport.default Impact.empty
-                    , toDistribution =
-                        extractMass lifeCycle.production
-                            |> computeTransportedMassImpacts requirements assemblyCountry (Just config.distribution.country)
-                    }
-            }
+                ( [ _ ], Just _ ) ->
+                    Err "Un composant unique ne peut pas être assemblé"
+
+                -- TODO: many component assembled; for all components, each elements are individually shipped to assembly,
+                -- then the assembled product mass is transported to distribution
+                ( multipleItems, Just assemblyCountry ) ->
+                    Ok
+                        { lifeCycle
+                            | transports = emptyLifeCycleTransports
+                        }
+
+                -- default state, empty transports
+                ( [], Nothing ) ->
+                    Ok { lifeCycle | transports = emptyLifeCycleTransports }
+
+                -- TODO: Single unique component; its elements are directly shipped to distribution individually,
+                -- with no transport to assembly stage
+                ( [ singleItem ], Nothing ) ->
+                    Ok
+                        { lifeCycle
+                            | transports =
+                                { emptyLifeCycleTransports
+                                  -- TODO
+                                    | toDistribution = Transport.default Impact.empty
+                                }
+                        }
+
+                -- TODO: Many items with no assembly country specified; all item elements are individually shipped to
+                -- the assembly stage unique default unknown transport distances,
+                -- then the total mass of the assembled end product is transported to distribution country
+                ( multipleItems, Nothing ) ->
+                    Ok
+                        { lifeCycle
+                            | transports =
+                                -- all item elements are individually shipped to the assembly stage unique default unknown transport distances
+                                { toAssembly = Transport.default Impact.empty
+
+                                -- total mass of the assembled end product is transported to distribution country
+                                , toDistribution = Transport.default Impact.empty
+                                }
+                        }
+         -- { toAssembly =
+         --     if List.length query.items > 1 then
+         --         expandedItems
+         --             |> List.indexedMap
+         --                 (\index expandedItem ->
+         --                     extractItems lifeCycle.production
+         --                         |> LE.getAt index
+         --                         |> Maybe.map
+         --                             (Tuple.second
+         --                                 << computeItemTransportToAssembly requirements maybeAssemblyCountry expandedItem
+         --                             )
+         --                 )
+         --             |> List.filterMap identity
+         --             |> Transport.sum
+         --     else
+         --         Transport.default Impact.empty
+         -- , toDistribution =
+         --     Transport.default Impact.empty
+         -- }
         )
         (expandItems db query.items)
         (Country.resolveMaybe query.assemblyCountry db.countries)
+        |> RE.join
 
 
 computeUseImpacts : Requirements db -> Query -> LifeCycle -> Result String LifeCycle
@@ -1548,15 +1589,6 @@ getDistributionProcess { config, db, scope } maybeDistribution =
                 |> Result.fromMaybe DistributionNothingAvailable
 
 
-{-| Get an element's country last transform if any, or the country of its material otherwise.
--}
-getFinalElementCountry : ExpandedElement -> Maybe Country
-getFinalElementCountry { material, transforms } =
-    LE.last transforms
-        |> Maybe.map .country
-        |> Maybe.withDefault material.country
-
-
 getEndOfLifeDetailedImpacts : Requirements db -> Results -> DetailedEndOfLifeImpacts
 getEndOfLifeDetailedImpacts { config, scope } =
     let
@@ -1628,6 +1660,15 @@ getEndOfLifeScopeCollectionRate { endOfLife } scope =
         |> AnyDict.get scope
         -- Assume every material is fully collected by default
         |> Maybe.withDefault Split.full
+
+
+{-| Get an element's country last transform if any, or the country of its material otherwise.
+-}
+getFinalElementCountry : ExpandedElement -> Maybe Country
+getFinalElementCountry { material, transforms } =
+    LE.last transforms
+        |> Maybe.map .country
+        |> Maybe.withDefault material.country
 
 
 {-| Compute mass distribution by material types

--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -16,6 +16,7 @@ module Data.Component exposing
     , Quantity
     , Query
     , Requirements
+    , ResultedElement
     , Results(..)
     , Stage(..)
     , TargetElement
@@ -69,6 +70,7 @@ module Data.Component exposing
     , getEndOfLifeImpacts
     , getEndOfLifeScopeCollectionRate
     , getFinalElementCountry
+    , getResultedElement
     , getTotalImpacts
     , idFromString
     , idToString
@@ -271,6 +273,12 @@ type alias ExpandedLocalizedProcess =
     { country : Maybe Country
     , process : Process
     }
+
+
+{-| An expanded element and its results
+-}
+type alias ResultedElement =
+    ( ExpandedElement, Results )
 
 
 {-| Index of an item element and associated source component
@@ -874,12 +882,27 @@ computeTransportedMassImpacts ({ config } as requirements) maybeFrom maybeTo mas
         |> Transport.computeImpacts config.transports.modeProcesses mass
 
 
+{-| Computes transports impacts:
+
+  - for a single component product, the summed impacts of transporting its individual elements directly to distribution
+  - for a multiple components product:
+      - if we know the country of assembly, the summed impacts of transporting each component's elements to assembly,
+        then the summed impacts of transporting the assembled product mass to distribution
+      - if we don't know the country of assembly, the summed impacts of each component's elements transported using
+        default unknown transport distances, then the assembled product mass to distribution
+
+-}
 computeTransports : Requirements db -> Query -> LifeCycle -> Result String LifeCycle
 computeTransports ({ config, db } as requirements) query lifeCycle =
     Result.map2
         (\expandedItems maybeAssemblyCountry ->
-            -- Only multiple items are transported to the assembly stage
-            -- TODO: refactor query to handle this through types https://github.com/MTES-MCT/ecobalyse/issues/1609
+            let
+                resultedElements =
+                    getResultedElementList lifeCycle.production expandedItems
+
+                totalProductMass =
+                    extractMass lifeCycle.production
+            in
             case ( expandedItems, maybeAssemblyCountry ) of
                 ( [], Just _ ) ->
                     Err "Une liste de composants vide ne peut être assemblée"
@@ -887,63 +910,87 @@ computeTransports ({ config, db } as requirements) query lifeCycle =
                 ( [ _ ], Just _ ) ->
                     Err "Un composant unique ne peut pas être assemblé"
 
-                -- TODO: many component assembled; for all components, each elements are individually shipped to assembly,
+                -- Many components assembled; for all components, each elements are individually shipped to assembly,
                 -- then the assembled product mass is transported to distribution
-                ( multipleItems, Just assemblyCountry ) ->
-                    Ok
-                        { lifeCycle
-                            | transports = emptyLifeCycleTransports
-                        }
+                ( _ :: _ :: _, Just assemblyCountry ) ->
+                    resultedElements
+                        |> Result.map
+                            (List.map
+                                (\( expandedElement, elementResults ) ->
+                                    extractMass elementResults
+                                        |> computeTransportedMassImpacts requirements
+                                            (getFinalElementCountry expandedElement)
+                                            (Just assemblyCountry)
+                                )
+                                >> Transport.sum
+                            )
+                        |> Result.map
+                            (\toAssembly ->
+                                { lifeCycle
+                                    | transports =
+                                        { toAssembly = toAssembly
+                                        , toDistribution =
+                                            totalProductMass
+                                                |> computeTransportedMassImpacts requirements
+                                                    maybeAssemblyCountry
+                                                    (Just config.distribution.country)
+                                        }
+                                }
+                            )
 
-                -- default state, empty transports
+                -- Default state, empty transports
                 ( [], Nothing ) ->
                     Ok { lifeCycle | transports = emptyLifeCycleTransports }
 
-                -- TODO: Single unique component; its elements are directly shipped to distribution individually,
+                -- Single unique component; its elements are directly shipped to distribution individually,
                 -- with no transport to assembly stage
-                ( [ singleItem ], Nothing ) ->
-                    Ok
-                        { lifeCycle
-                            | transports =
-                                { emptyLifeCycleTransports
-                                  -- TODO
-                                    | toDistribution = Transport.default Impact.empty
+                ( [ _ ], Nothing ) ->
+                    resultedElements
+                        |> Result.map
+                            (List.map
+                                (\( expandedElement, elementResults ) ->
+                                    extractMass elementResults
+                                        |> computeTransportedMassImpacts requirements
+                                            (getFinalElementCountry expandedElement)
+                                            (Just config.distribution.country)
+                                )
+                                >> Transport.sum
+                            )
+                        |> Result.map
+                            (\toDistribution ->
+                                { lifeCycle
+                                    | transports = { emptyLifeCycleTransports | toDistribution = toDistribution }
                                 }
-                        }
+                            )
 
-                -- TODO: Many items with no assembly country specified; all item elements are individually shipped to
+                -- Many items with no assembly country specified; all item elements are individually shipped to
                 -- the assembly stage unique default unknown transport distances,
                 -- then the total mass of the assembled end product is transported to distribution country
-                ( multipleItems, Nothing ) ->
-                    Ok
-                        { lifeCycle
-                            | transports =
-                                -- all item elements are individually shipped to the assembly stage unique default unknown transport distances
-                                { toAssembly = Transport.default Impact.empty
-
-                                -- total mass of the assembled end product is transported to distribution country
-                                , toDistribution = Transport.default Impact.empty
+                ( _ :: _ :: _, Nothing ) ->
+                    resultedElements
+                        |> Result.map
+                            (List.map
+                                (\( _, elementResults ) ->
+                                    -- all item elements are individually shipped to the assembly stage using default unknown transport distances
+                                    extractMass elementResults
+                                        |> computeTransportedMassImpacts requirements Nothing Nothing
+                                )
+                                >> Transport.sum
+                            )
+                        |> Result.map
+                            (\toAssemblyTransport ->
+                                { lifeCycle
+                                    | transports =
+                                        { toAssembly = toAssemblyTransport
+                                        , toDistribution =
+                                            -- total mass of the assembled end product is transported to the distribution country
+                                            totalProductMass
+                                                |> computeTransportedMassImpacts requirements
+                                                    Nothing
+                                                    (Just config.distribution.country)
+                                        }
                                 }
-                        }
-         -- { toAssembly =
-         --     if List.length query.items > 1 then
-         --         expandedItems
-         --             |> List.indexedMap
-         --                 (\index expandedItem ->
-         --                     extractItems lifeCycle.production
-         --                         |> LE.getAt index
-         --                         |> Maybe.map
-         --                             (Tuple.second
-         --                                 << computeItemTransportToAssembly requirements maybeAssemblyCountry expandedItem
-         --                             )
-         --                 )
-         --             |> List.filterMap identity
-         --             |> Transport.sum
-         --     else
-         --         Transport.default Impact.empty
-         -- , toDistribution =
-         --     Transport.default Impact.empty
-         -- }
+                            )
         )
         (expandItems db query.items)
         (Country.resolveMaybe query.assemblyCountry db.countries)
@@ -1384,6 +1431,18 @@ encodeResults maybeTrigram (Results results) =
         ]
 
 
+{-| Common reusable error strings
+-}
+errors :
+    { elementNotFound : String
+    , itemNotFound : String
+    }
+errors =
+    { elementNotFound = "Élément introuvable"
+    , itemNotFound = "Item introuvable"
+    }
+
+
 {-| Resolve full use consumption processes linked to their respective ids
 -}
 expandConsumptions : List Process -> List Consumption -> Result String (List ( Amount, Process ))
@@ -1544,6 +1603,16 @@ getDistributionProcess { config, db, scope } maybeDistribution =
                 |> Result.fromMaybe DistributionNothingAvailable
 
 
+{-| Get an element's results at a given location in the results tree.
+-}
+getElementResult : ( Index, Index ) -> Results -> Result String Results
+getElementResult ( itemIndex, elementIndex ) productionResults =
+    extractItems productionResults
+        |> LE.getAt itemIndex
+        |> Result.fromMaybe errors.itemNotFound
+        |> Result.andThen (extractItems >> LE.getAt elementIndex >> Result.fromMaybe errors.elementNotFound)
+
+
 getEndOfLifeDetailedImpacts : Requirements db -> Results -> DetailedEndOfLifeImpacts
 getEndOfLifeDetailedImpacts { config, scope } =
     let
@@ -1660,6 +1729,39 @@ getMaterialDistribution (Results results) =
                         )
             )
             (AnyDict.empty Category.materialTypeToString)
+
+
+{-| Get the an expanded element and its results at a given location in the elements tree.
+-}
+getResultedElement : ( Index, Index ) -> Results -> List ExpandedItem -> Result String ResultedElement
+getResultedElement ( itemIndex, elementIndex ) productionResults expandedItems =
+    Result.map2 Tuple.pair
+        -- Expanded element
+        (expandedItems
+            |> LE.getAt itemIndex
+            |> Result.fromMaybe errors.itemNotFound
+            |> Result.andThen (.elements >> LE.getAt elementIndex >> Result.fromMaybe errors.elementNotFound)
+        )
+        -- Element results
+        (getElementResult ( itemIndex, elementIndex ) productionResults)
+
+
+{-| Create a list of expanded elements with their associated results from a list of items and production results.
+-}
+getResultedElementList : Results -> List ExpandedItem -> Result String (List ResultedElement)
+getResultedElementList productionResults =
+    List.indexedMap
+        (\itemIndex expandedItem ->
+            expandedItem.elements
+                |> List.indexedMap
+                    (\elementIndex expandedElement ->
+                        productionResults
+                            |> getElementResult ( itemIndex, elementIndex )
+                            |> Result.map (\results -> ( expandedElement, results ))
+                    )
+        )
+        >> List.concat
+        >> RE.combine
 
 
 getTotalImpacts : Results -> Impacts

--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -66,10 +66,10 @@ module Data.Component exposing
     , extractStage
     , findById
     , getAvailableDistributionProcesses
-    , getElementFinalCountry
     , getEndOfLifeDetailedImpacts
     , getEndOfLifeImpacts
     , getEndOfLifeScopeCollectionRate
+    , getFinalElementCountry
     , getTotalImpacts
     , idFromString
     , idToString
@@ -767,7 +767,7 @@ computeItemTransportToAssembly requirements assemblyCountry item itemResults =
     let
         origins =
             item.elements
-                |> List.map getElementFinalCountry
+                |> List.map getFinalElementCountry
 
         defaultOrigin =
             origins
@@ -797,7 +797,7 @@ computeItemTransportToAssembly requirements assemblyCountry item itemResults =
         |> List.map2
             (\element elementResults ->
                 extractMass elementResults
-                    |> computeTransportedMassImpacts requirements (getElementFinalCountry element) assemblyCountry
+                    |> computeTransportedMassImpacts requirements (getFinalElementCountry element) assemblyCountry
             )
             item.elements
         |> Transport.sum
@@ -1498,25 +1498,6 @@ extractImpacts (Results { impacts }) =
     impacts
 
 
-getTotalImpacts : Results -> Impacts
-getTotalImpacts (Results { impacts, complementsImpacts }) =
-    Impact.sumImpacts
-        [ impacts
-        , complementsImpacts |> Complement.mergeComplementsResultsImpacts
-        ]
-
-
-{-| Get the final country of an element, which is the country of the last transform if any,
-or the country of the material otherwise.
--}
-getElementFinalCountry : ExpandedElement -> Maybe Country
-getElementFinalCountry { material, transforms } =
-    transforms
-        |> LE.last
-        |> Maybe.map .country
-        |> Maybe.withDefault material.country
-
-
 extractItems : Results -> List Results
 extractItems (Results { items }) =
     items
@@ -1565,6 +1546,15 @@ getDistributionProcess { config, db, scope } maybeDistribution =
             config.distribution.defaultProcess
                 |> Scope.dictGetMaybe scope
                 |> Result.fromMaybe DistributionNothingAvailable
+
+
+{-| Get an element's country last transform if any, or the country of its material otherwise.
+-}
+getFinalElementCountry : ExpandedElement -> Maybe Country
+getFinalElementCountry { material, transforms } =
+    LE.last transforms
+        |> Maybe.map .country
+        |> Maybe.withDefault material.country
 
 
 getEndOfLifeDetailedImpacts : Requirements db -> Results -> DetailedEndOfLifeImpacts
@@ -1674,6 +1664,14 @@ getMaterialDistribution (Results results) =
                         )
             )
             (AnyDict.empty Category.materialTypeToString)
+
+
+getTotalImpacts : Results -> Impacts
+getTotalImpacts (Results { impacts, complementsImpacts }) =
+    Impact.sumImpacts
+        [ impacts
+        , complementsImpacts |> Complement.mergeComplementsResultsImpacts
+        ]
 
 
 getTotalTransportImpacts : LifeCycleTransport -> Impacts

--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -235,7 +235,7 @@ type alias DataContainer db =
 -}
 type alias Element =
     { amount : Amount
-    , material : Material
+    , material : LocalizedProcess
     , transforms : List LocalizedProcess
     }
 
@@ -244,10 +244,6 @@ type alias LocalizedProcess =
     { country : Maybe Country.Code
     , id : Process.Id
     }
-
-
-type alias Material =
-    LocalizedProcess
 
 
 {-| A full representation of an amount of material and optional transformations of it
@@ -1120,7 +1116,7 @@ decodeLocalizedProcess =
         |> Decode.required "id" Process.decodeId
 
 
-decodeMaterial : Decoder Material
+decodeMaterial : Decoder LocalizedProcess
 decodeMaterial =
     Decode.oneOf
         [ decodeLocalizedProcess
@@ -1246,7 +1242,7 @@ defaultLocalizedProcess id =
     { country = Nothing, id = id }
 
 
-defaultMaterial : Process.Id -> Material
+defaultMaterial : Process.Id -> LocalizedProcess
 defaultMaterial =
     defaultLocalizedProcess
 

--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -131,7 +131,6 @@ import Data.Uuid as Uuid exposing (Uuid)
 import Dict.Any as AnyDict
 import Energy
 import Json.Decode as Decode exposing (Decoder)
-import Json.Decode.Extra as DE
 import Json.Decode.Pipeline as Decode
 import Json.Encode as Encode
 import List.Extra as LE
@@ -1128,12 +1127,6 @@ decodeTransforms =
 
 decodeItem : Decoder Item
 decodeItem =
-    decodeItemWithLegacyCountry
-        |> Decode.map mapLegacyCountryToItem
-
-
-decodeItemBase : Decoder Item
-decodeItemBase =
     Decode.succeed Item
         |> DU.strictOptional "custom" decodeCustom
         |> DU.strictOptional "id" (Decode.map Id Uuid.decoder)
@@ -1172,39 +1165,7 @@ decodeQuery =
         |> Decode.optional "consumptions" (Decode.list decodeConsumption) []
         |> DU.strictOptional "distribution" Process.decodeId
         |> DU.strictOptional "durability" Unit.decodeRatio
-        |> Decode.required "components" decodeItemsWithLegacyCountry
-
-
-decodeItemsWithLegacyCountry : Decoder (List Item)
-decodeItemsWithLegacyCountry =
-    Decode.list decodeItem
-
-
-decodeItemWithLegacyCountry : Decoder ( Maybe Country.Code, Item )
-decodeItemWithLegacyCountry =
-    Decode.map2 Tuple.pair
-        (DE.optionalNullableField "country" Country.decodeCode)
-        decodeItemBase
-
-
-mapLegacyCountryToItem : ( Maybe Country.Code, Item ) -> Item
-mapLegacyCountryToItem ( maybeCountryCode, item ) =
-    let
-        mapElement element =
-            { element
-                | material =
-                    if element.material.country == Nothing then
-                        { country = maybeCountryCode, id = element.material.id }
-
-                    else
-                        element.material
-            }
-    in
-    { item
-        | custom =
-            item.custom
-                |> Maybe.map (\custom -> { custom | elements = List.map mapElement custom.elements })
-    }
+        |> Decode.required "components" (Decode.list decodeItem)
 
 
 {-| Proxified for convenience
@@ -1960,17 +1921,6 @@ removeElementTransform targetElement transformIndex =
         \el -> { el | transforms = el.transforms |> LE.removeAt transformIndex }
 
 
-updateElementTransformCountry : TargetElement -> Index -> Maybe Country.Code -> List Item -> List Item
-updateElementTransformCountry targetElement transformIndex maybeCountryCode =
-    updateElement targetElement <|
-        \el ->
-            { el
-                | transforms =
-                    el.transforms
-                        |> LE.updateAt transformIndex (\step -> { step | country = maybeCountryCode })
-            }
-
-
 setCustomScope : Component -> Scope -> Item -> Item
 setCustomScope component scope item =
     { item
@@ -2202,6 +2152,17 @@ updateElementMaterialCountry : TargetElement -> Maybe Country.Code -> List Item 
 updateElementMaterialCountry targetElement maybeCountryCode =
     updateElement targetElement <|
         \({ material } as el) -> { el | material = { material | country = maybeCountryCode } }
+
+
+updateElementTransformCountry : TargetElement -> Index -> Maybe Country.Code -> List Item -> List Item
+updateElementTransformCountry targetElement transformIndex maybeCountryCode =
+    updateElement targetElement <|
+        \el ->
+            { el
+                | transforms =
+                    el.transforms
+                        |> LE.updateAt transformIndex (\step -> { step | country = maybeCountryCode })
+            }
 
 
 updateItemCustom : TargetItem -> (Custom -> Custom) -> List Item -> List Item

--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -66,6 +66,7 @@ module Data.Component exposing
     , extractStage
     , findById
     , getAvailableDistributionProcesses
+    , getElementFinalCountry
     , getEndOfLifeDetailedImpacts
     , getEndOfLifeImpacts
     , getEndOfLifeScopeCollectionRate

--- a/src/Page/Admin/Component.elm
+++ b/src/Page/Admin/Component.elm
@@ -684,8 +684,10 @@ modalView { componentConfig, db } modals index modal =
                                             item |> updateSingleItem (Component.updateElementAmount targetElement amount)
                                         )
                                         >> Maybe.withDefault NoOp
+                            , updateElementMaterialCountry =
+                                \targetElement maybeCountryCode ->
+                                    item |> updateSingleItem (Component.updateElementMaterialCountry targetElement maybeCountryCode)
                             , updateElementTransformCountry = \_ _ _ -> NoOp
-                            , updateItemCountry = \_ _ -> NoOp
                             , updateItemName =
                                 \targetItem name ->
                                     item |> updateSingleItem (Component.updateItemCustomName targetItem name)

--- a/src/Page/Explore/Components.elm
+++ b/src/Page/Explore/Components.elm
@@ -51,7 +51,7 @@ table ({ db } as session) { detailed, scope } =
           , toValue =
                 Table.StringValue <|
                     \{ elements } ->
-                        case Component.expandElements db Nothing elements of
+                        case Component.expandElements db elements of
                             Err _ ->
                                 ""
 
@@ -60,14 +60,14 @@ table ({ db } as session) { detailed, scope } =
                                     |> List.map
                                         (\{ amount, material } ->
                                             Amount.toString amount
-                                                ++ Process.unitToString material.unit
+                                                ++ Process.unitToString material.process.unit
                                                 ++ " de "
-                                                ++ Process.getDisplayName material
+                                                ++ Process.getDisplayName material.process
                                         )
                                     |> String.join ", "
           , toCell =
                 \{ elements } ->
-                    case Component.expandElements db Nothing elements of
+                    case Component.expandElements db elements of
                         Err err ->
                             Alert.simple
                                 { attributes = []
@@ -85,8 +85,8 @@ table ({ db } as session) { detailed, scope } =
                                 |> List.map
                                     (\{ amount, material, transforms } ->
                                         li []
-                                            [ Format.amount material amount
-                                            , text <| " de " ++ Process.getDisplayName material
+                                            [ Format.amount material.process amount
+                                            , text <| " de " ++ Process.getDisplayName material.process
                                             , transforms
                                                 |> List.map (.process >> Process.getDisplayName >> text >> List.singleton >> li [])
                                                 |> ul []

--- a/src/Page/Object.elm
+++ b/src/Page/Object.elm
@@ -1081,7 +1081,7 @@ modalView session ({ modals } as model) modal =
 
         EditElementModal { name } targetElement ->
             ModalView.view
-                { size = ModalView.ExtraLarge
+                { size = ModalView.Fluid
                 , close = SetModals (List.drop 1 modals)
                 , noOp = NoOp
                 , title = "Modifier l'élément #" ++ String.fromInt (Tuple.second targetElement + 1)

--- a/src/Page/Object.elm
+++ b/src/Page/Object.elm
@@ -660,6 +660,7 @@ update ({ navKey } as session) msg model =
                         |> Component.mapItems
                             (Component.updateElementMaterialCountry targetElement maybeCountryCode)
                     )
+                |> App.withCmds [ Plausible.send session <| Plausible.ComponentUpdated model.scope ]
 
         ( UpdateElementTransformCountry targetElement transformIndex maybeCountryCode, _ ) ->
             createPageUpdate session model
@@ -668,6 +669,7 @@ update ({ navKey } as session) msg model =
                         |> Component.mapItems
                             (Component.updateElementTransformCountry targetElement transformIndex maybeCountryCode)
                     )
+                |> App.withCmds [ Plausible.send session <| Plausible.ComponentUpdated model.scope ]
 
         ( UpdateRenamedBookmarkName bookmark name, _ ) ->
             { model | bookmarkBeingRenamed = Just { bookmark | name = name } }

--- a/src/Page/Object.elm
+++ b/src/Page/Object.elm
@@ -128,7 +128,6 @@ type Msg
     | ToggleComparedSimulation Bookmark Bool
     | UpdateAssemblyCountry (Maybe Country.Code)
     | UpdateBookmarkName String
-    | UpdateComponentItemCountry Index (Maybe Country.Code)
     | UpdateComponentItemName TargetItem String
     | UpdateComponentItemQuantity Index Component.Quantity
     | UpdateConsumptionAmount Index (Maybe Amount)
@@ -137,6 +136,7 @@ type Msg
     | UpdateDistribution (Result String Process.Id)
     | UpdateDurability (Result String Unit.Ratio)
     | UpdateElementAmount TargetElement (Maybe Amount)
+    | UpdateElementMaterialCountry TargetElement (Maybe Country.Code)
     | UpdateElementTransformCountry TargetElement Index (Maybe Country.Code)
     | UpdateRenamedBookmarkName Bookmark String
 
@@ -596,14 +596,6 @@ update ({ navKey } as session) msg model =
             { model | bookmarkName = newName }
                 |> createPageUpdate session
 
-        ( UpdateComponentItemCountry itemIndex country, _ ) ->
-            createPageUpdate session model
-                |> updateQuery
-                    (query
-                        |> Component.mapItems (Component.updateItem itemIndex (\item -> { item | country = country }))
-                    )
-                |> App.withCmds [ Plausible.send session <| Plausible.ComponentUpdated model.scope ]
-
         ( UpdateComponentItemName targetItem name, _ ) ->
             createPageUpdate session model
                 |> updateQuery
@@ -659,6 +651,14 @@ update ({ navKey } as session) msg model =
                     (query
                         |> Component.mapItems
                             (Component.updateElement targetElement (\el -> { el | amount = amount }))
+                    )
+
+        ( UpdateElementMaterialCountry targetElement maybeCountryCode, _ ) ->
+            createPageUpdate session model
+                |> updateQuery
+                    (query
+                        |> Component.mapItems
+                            (Component.updateElementMaterialCountry targetElement maybeCountryCode)
                     )
 
         ( UpdateElementTransformCountry targetElement transformIndex maybeCountryCode, _ ) ->
@@ -888,8 +888,8 @@ simulatorView ({ componentConfig } as session) ({ scope } as model) =
                 , updateConsumptionAmount = UpdateConsumptionAmount
                 , updateDistribution = UpdateDistribution
                 , updateElementAmount = UpdateElementAmount
+                , updateElementMaterialCountry = UpdateElementMaterialCountry
                 , updateElementTransformCountry = UpdateElementTransformCountry
-                , updateItemCountry = UpdateComponentItemCountry
                 , updateItemName = UpdateComponentItemName
                 , updateItemQuantity = UpdateComponentItemQuantity
                 }
@@ -1119,8 +1119,8 @@ modalView session ({ modals } as model) modal =
                         , updateConsumptionAmount = UpdateConsumptionAmount
                         , updateDistribution = UpdateDistribution
                         , updateElementAmount = UpdateElementAmount
+                        , updateElementMaterialCountry = UpdateElementMaterialCountry
                         , updateElementTransformCountry = UpdateElementTransformCountry
-                        , updateItemCountry = UpdateComponentItemCountry
                         , updateItemName = UpdateComponentItemName
                         , updateItemQuantity = UpdateComponentItemQuantity
                         }

--- a/src/Page/Textile.elm
+++ b/src/Page/Textile.elm
@@ -1022,8 +1022,8 @@ simulatorFormView session model ({ inputs } as simulator) =
         , updateConsumptionAmount = \_ _ -> NoOp
         , updateDistribution = \_ -> NoOp
         , updateElementAmount = \_ _ -> NoOp
+        , updateElementMaterialCountry = \_ _ -> NoOp
         , updateElementTransformCountry = \_ _ _ -> NoOp
-        , updateItemCountry = \_ _ -> NoOp
         , updateItemName = \_ _ -> NoOp
         , updateItemQuantity = UpdateTrimQuantity
         }

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -33,7 +33,7 @@ import Data.Process as Process exposing (Process)
 import Data.Process.Category as Category exposing (Category)
 import Data.Scope as Scope exposing (Scope)
 import Data.Split as Split
-import Data.Transport as Transport exposing (Transport)
+import Data.Transport exposing (Transport)
 import Data.Unit as Unit
 import Dict.Any as AnyDict
 import Html exposing (..)
@@ -330,55 +330,6 @@ componentDetailedView config elements itemIndex expandedItem itemResults =
                     ]
                 ]
           ]
-        , if List.length config.query.items > 1 then
-            [ tr [ class "bg-light border-top border-bottom" ]
-                [ th [] []
-                , th [ class "pb-1", colspan 6 ] [ text "Acheminement vers assemblage" ]
-                ]
-            , componentTransportToAssembly config expandedItem itemResults
-            ]
-
-          else
-            []
-        ]
-
-
-componentTransportToAssembly : Config db msg -> ExpandedItem -> Results -> Html msg
-componentTransportToAssembly { componentConfig, db, impact, query, scope } expandedItem itemResults =
-    let
-        ( label, transports ) =
-            case Country.resolveMaybe query.assemblyCountry db.countries of
-                Err error ->
-                    ( span [ class "text-danger" ] [ text <| "Erreur\u{00A0}: " ++ error ]
-                    , Transport.default Impact.empty
-                    )
-
-                Ok maybeAssemblyCountry ->
-                    Tuple.mapFirst text <|
-                        Component.computeItemTransportToAssembly
-                            { config = componentConfig, db = db, scope = scope }
-                            maybeAssemblyCountry
-                            expandedItem
-                            itemResults
-    in
-    tr [ class "fs-7" ]
-        [ td [] []
-        , td [ class "py-1", colspan 3 ]
-            [ div [ class "d-flex justify-content-between align-items-center gap-2 ps-0" ]
-                [ span [ class "fw-bold" ] [ label ]
-                , div [ class "d-flex justify-content-between align-items-center gap-2" ]
-                    [ Icon.boat
-                    , Format.km transports.sea
-                    , Icon.bus
-                    , Format.km transports.road
-                    ]
-                ]
-            ]
-        , td [ class "text-end" ]
-            [ itemResults |> Component.extractMass |> Format.kg ]
-        , td [ class "text-end" ]
-            [ transports.impacts |> Format.formatImpact impact ]
-        , td [] []
         ]
 
 

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -834,28 +834,25 @@ elementMaterialView config targetElement materialResults material amount =
     let
         complementsImpacts =
             Component.extractComplementsImpacts materialResults
-
-        materialProcess =
-            material.process
     in
     [ tr [ class "fs-7" ]
         [ td [] []
         , td [ class "text-end align-middle text-nowrap ps-0", style "min-width" "130px" ]
             [ if config.scope == Scope.Textile then
-                Format.amount materialProcess amount
+                Format.amount material.process amount
 
               else
-                amountInput (config.updateElementAmount targetElement) materialProcess.unit amount
+                amountInput (config.updateElementAmount targetElement) material.process.unit amount
             ]
         , td
             [ class "align-middle text-truncate w-100"
-            , title <| Process.getDisplayName materialProcess
+            , title <| Process.getDisplayName material.process
             , colspan 2
             ]
-            [ div [ class "d-flex align-items-center gap-2" ]
-                [ selectMaterialButton config targetElement materialProcess
+            [ div [ class "d-flex justify-content-between align-items-center gap-2" ]
+                [ selectMaterialButton config targetElement material.process
                 , transformCountrySelector
-                    { attributes = [ style "min-width" "180px" ]
+                    { attributes = [ style "width" "260px" ]
                     , countries = config.db.countries
                     , domId = "material-country-" ++ Component.targetElementToString targetElement
                     , scope = config.scope
@@ -868,7 +865,7 @@ elementMaterialView config targetElement materialResults material amount =
             []
         , td [ class "text-end align-middle text-nowrap" ]
             [ Component.extractAmount materialResults
-                |> Format.amount materialProcess
+                |> Format.amount material.process
             ]
         , td [ class "text-end align-middle text-nowrap" ]
             [ Component.getTotalImpacts materialResults
@@ -949,7 +946,7 @@ elementTransformsView config targetElement transformsResults transforms =
                     ]
                 , td [ class "text-end align-middle text-nowrap" ]
                     [ transformCountrySelector
-                        { attributes = [ style "min-width" "230px" ]
+                        { attributes = [ style "width" "260px" ]
                         , countries = config.db.countries
                         , domId =
                             "transform-country-"

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -908,7 +908,7 @@ elementMaterialView config targetElement materialResults material amount =
     ]
 
 
-elementTransformsView : Config db msg -> TargetElement -> List Results -> List Component.ExpandedTransform -> List (Html msg)
+elementTransformsView : Config db msg -> TargetElement -> List Results -> List Component.ExpandedLocalizedProcess -> List (Html msg)
 elementTransformsView config targetElement transformsResults transforms =
     List.map3
         (\transformIndex transformResult transformStep ->

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -668,15 +668,11 @@ countrySelector config =
 
 elementView : Config db msg -> TargetItem -> Index -> ExpandedElement -> Results -> Html msg
 elementView config (( component, _ ) as targetItem) elementIndex { amount, material, transforms } elementResults =
-    let
-        materialProcess =
-            material.process
-    in
     tbody []
         [ tr [ class "fs-7 border-top" ]
             [ td [] []
             , td [ class "ps-0 align-start text-end text-nowrap" ]
-                [ Format.amount materialProcess amount ]
+                [ Format.amount material.process amount ]
             , td
                 [ colspan 2
                 , class "align-middle text-truncate"
@@ -689,9 +685,9 @@ elementView config (( component, _ ) as targetItem) elementIndex { amount, mater
                         , onClick (config.openEditElementModal component ( targetItem, elementIndex ))
                         ]
                         [ span [ class "ComponentElementIcon" ] [ Icon.material ]
-                        , text <| Process.getDisplayName materialProcess
+                        , text <| Process.getDisplayName material.process
                         , material.country
-                            |> Maybe.map (\{ name } -> " (" ++ name ++ ")")
+                            |> Maybe.map (\{ code } -> " (" ++ Country.codeToString code ++ ")")
                             |> Maybe.withDefault ""
                             |> text
                         ]
@@ -838,7 +834,13 @@ selectMaterialButton config ( targetItem, elementIndex ) material =
         ]
 
 
-elementMaterialView : Config db msg -> TargetElement -> Results -> { a | country : Maybe Country, process : Process } -> Amount -> List (Html msg)
+elementMaterialView :
+    Config db msg
+    -> TargetElement
+    -> Results
+    -> ExpandedLocalizedProcess
+    -> Amount
+    -> List (Html msg)
 elementMaterialView config targetElement materialResults material amount =
     let
         complementsImpacts =
@@ -923,15 +925,13 @@ elementTransportView config transportedMass maybeFrom maybeTo =
     in
     tr [ class "fs-7 text-muted" ]
         [ td [ colspan 3 ] []
-        , td [ class "text-end align-middle text-nowrap" ]
-            [ div [ class "d-flex justify-content-end align-items-center gap-2", style "width" "260px" ]
-                [ Icon.boat
-                , Format.km transport.sea
-                , Icon.bus
-                , Format.km transport.road
-                , Icon.package
-                , Format.kg transportedMass
-                ]
+        , td [ class "text-end align-middle d-flex justify-content-end align-items-center gap-2 text-nowrap" ]
+            [ Icon.boat
+            , Format.km transport.sea
+            , Icon.bus
+            , Format.km transport.road
+            , Icon.package
+            , Format.kg transportedMass
             ]
         , td [ colspan 2 ] []
         , td [ class "text-end align-middle text-nowrap" ]
@@ -942,7 +942,14 @@ elementTransportView config transportedMass maybeFrom maybeTo =
         ]
 
 
-elementTransformsView : Config db msg -> TargetElement -> Results -> Maybe Country -> List Results -> List ExpandedLocalizedProcess -> List (Html msg)
+elementTransformsView :
+    Config db msg
+    -> TargetElement
+    -> Results
+    -> Maybe Country
+    -> List Results
+    -> List ExpandedLocalizedProcess
+    -> List (Html msg)
 elementTransformsView config targetElement materialResults materialCountry transformsResults transforms =
     transforms
         |> List.indexedMap
@@ -953,24 +960,22 @@ elementTransformsView config targetElement materialResults materialCountry trans
                             |> LE.getAt transformIndex
                             |> Maybe.withDefault Component.emptyResults
 
-                    previousMass =
-                        if transformIndex == 0 then
-                            Component.extractMass materialResults
+                    ( previousMass, previousCountry ) =
+                        case transformIndex of
+                            0 ->
+                                ( Component.extractMass materialResults
+                                , materialCountry
+                                )
 
-                        else
-                            transformsResults
-                                |> LE.getAt (transformIndex - 1)
-                                |> Maybe.withDefault Component.emptyResults
-                                |> Component.extractMass
-
-                    previousCountry =
-                        if transformIndex == 0 then
-                            materialCountry
-
-                        else
-                            transforms
-                                |> LE.getAt (transformIndex - 1)
-                                |> Maybe.andThen .country
+                            index ->
+                                ( transformsResults
+                                    |> LE.getAt (index - 1)
+                                    |> Maybe.withDefault Component.emptyResults
+                                    |> Component.extractMass
+                                , transforms
+                                    |> LE.getAt (index - 1)
+                                    |> Maybe.andThen .country
+                                )
 
                     tooltipText =
                         "Procédé\u{00A0}: "

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -20,6 +20,7 @@ import Data.Component as Component
         , Quantity
         , Query
         , Requirements
+        , ResultedElement
         , Results
         , TargetElement
         , TargetItem
@@ -42,6 +43,7 @@ import Html.Events exposing (..)
 import Json.Encode as Encode
 import List.Extra as LE
 import Mass exposing (Mass)
+import Result.Extra as RE
 import Route exposing (Route)
 import Views.Alert as Alert
 import Views.Button as Button
@@ -685,30 +687,17 @@ elementView config (( component, _ ) as targetItem) elementIndex { amount, mater
         ]
 
 
-getEditedElementData : Config db msg -> TargetElement -> Query -> Result String ( ExpandedElement, Results )
-getEditedElementData { db, lifeCycle } ( ( _, itemIndex ), elementIndex ) query =
-    let
-        ( itemNotFoundError, elementNotFoundError ) =
-            ( "Item introuvable", "Élément introuvable" )
-    in
-    Result.map2 Tuple.pair
-        -- Expanded edited element
-        (query.items
-            |> Component.expandItems db
-            |> Result.andThen (LE.getAt itemIndex >> Result.fromMaybe itemNotFoundError)
-            |> Result.andThen (.elements >> LE.getAt elementIndex >> Result.fromMaybe elementNotFoundError)
-        )
-        -- Edited element results
-        (lifeCycle
-            |> Result.map (.production >> Component.extractItems)
-            |> Result.andThen (LE.getAt itemIndex >> Result.fromMaybe itemNotFoundError)
-            |> Result.andThen (Component.extractItems >> LE.getAt elementIndex >> Result.fromMaybe elementNotFoundError)
-        )
+getEditedResultedElement : Config db msg -> TargetElement -> Query -> Result String ResultedElement
+getEditedResultedElement { db, lifeCycle } ( ( _, itemIndex ), elementIndex ) query =
+    Result.map2 (Component.getResultedElement ( itemIndex, elementIndex ))
+        (Result.map .production lifeCycle)
+        (Component.expandItems db query.items)
+        |> RE.join
 
 
 elementEditModalView : Config db msg -> TargetElement -> Html msg
 elementEditModalView ({ query } as config) (( _, elementIndex ) as targetElement) =
-    case query |> getEditedElementData config targetElement of
+    case query |> getEditedResultedElement config targetElement of
         Err error ->
             div [ class "alert alert-danger" ] [ text error ]
 

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -751,13 +751,13 @@ elementEditModalView ({ query } as config) (( _, elementIndex ) as targetElement
 
                 materialResults =
                     stageItems
-                        |> List.filter (\(Component.Results { stage }) -> stage == Just Component.MaterialStage)
+                        |> List.filter (Component.extractStage >> (==) (Just Component.MaterialStage))
                         |> List.head
                         |> Maybe.withDefault Component.emptyResults
 
                 transformsResults =
                     stageItems
-                        |> List.filter (\(Component.Results { stage }) -> stage == Just Component.TransformStage)
+                        |> List.filter (Component.extractStage >> (==) (Just Component.TransformStage))
             in
             div [ class "table-responsive p-2" ]
                 [ table [ class "table table-sm table-borderless mb-0" ]

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -678,6 +678,10 @@ elementView config (( component, _ ) as targetItem) elementIndex { amount, mater
                         ]
                         [ span [ class "ComponentElementIcon" ] [ Icon.material ]
                         , text <| Process.getDisplayName materialProcess
+                        , material.country
+                            |> Maybe.map (\{ name } -> " (" ++ name ++ ")")
+                            |> Maybe.withDefault ""
+                            |> text
                         ]
                     , div [ class "d-flex align-items-center gap-1 text-muted" ]
                         [ span [ class "ComponentElementIcon me-0" ] [ Icon.transform ]

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -79,8 +79,8 @@ type alias Config db msg =
     , updateConsumptionAmount : Index -> Maybe Amount -> msg
     , updateDistribution : Result String Process.Id -> msg
     , updateElementAmount : TargetElement -> Maybe Amount -> msg
+    , updateElementMaterialCountry : TargetElement -> Maybe Country.Code -> msg
     , updateElementTransformCountry : TargetElement -> Index -> Maybe Country.Code -> msg
-    , updateItemCountry : Index -> Maybe Country.Code -> msg
     , updateItemName : TargetItem -> String -> msg
     , updateItemQuantity : Index -> Quantity -> msg
     }
@@ -185,7 +185,7 @@ addElementTransformButton { db, openSelectProcessModal, query, scope } material 
 
 
 componentView : Config db msg -> Index -> ExpandedItem -> Results -> List (Html msg)
-componentView config itemIndex ({ component, country, elements, quantity } as expandedItem) itemResults =
+componentView config itemIndex ({ component, elements, quantity } as expandedItem) itemResults =
     let
         collapsed =
             config.detailed
@@ -206,11 +206,7 @@ componentView config itemIndex ({ component, country, elements, quantity } as ex
                         [ th [] []
                         , th [ class "pb-0 fs-8 fw-normal text-muted" ] [ text "Quantité" ]
                         , th [ class "pb-0 fs-8 fw-normal text-muted", colspan 2 ]
-                            [ div [ class "d-flex justify-content-between" ]
-                                [ span [] [ text "Nom du composant" ]
-                                , span [] [ text "Région" ]
-                                ]
-                            ]
+                            [ span [] [ text "Nom du composant" ] ]
                         , th [ colspan 3 ] []
                         ]
 
@@ -255,13 +251,6 @@ componentView config itemIndex ({ component, country, elements, quantity } as ex
                                         , value component.name
                                         ]
                                         []
-                                    , countrySelector
-                                        { countries = config.db.countries
-                                        , domId = "item-country-" ++ String.fromInt itemIndex
-                                        , scope = config.scope
-                                        , select = config.updateItemCountry itemIndex
-                                        , selected = Maybe.map .code country
-                                        }
                                     ]
                                 ]
 
@@ -667,11 +656,15 @@ countrySelector config =
 
 elementView : Config db msg -> TargetItem -> Index -> ExpandedElement -> Results -> Html msg
 elementView config (( component, _ ) as targetItem) elementIndex { amount, material, transforms } elementResults =
+    let
+        materialProcess =
+            material.process
+    in
     tbody []
         [ tr [ class "fs-7 border-top" ]
             [ td [] []
             , td [ class "ps-0 align-start text-end text-nowrap" ]
-                [ Format.amount material amount ]
+                [ Format.amount materialProcess amount ]
             , td
                 [ colspan 2
                 , class "align-middle text-truncate"
@@ -684,7 +677,7 @@ elementView config (( component, _ ) as targetItem) elementIndex { amount, mater
                         , onClick (config.openEditElementModal component ( targetItem, elementIndex ))
                         ]
                         [ span [ class "ComponentElementIcon" ] [ Icon.material ]
-                        , text <| Process.getDisplayName material
+                        , text <| Process.getDisplayName materialProcess
                         ]
                     , div [ class "d-flex align-items-center gap-1 text-muted" ]
                         [ span [ class "ComponentElementIcon me-0" ] [ Icon.transform ]
@@ -751,13 +744,21 @@ elementEditModalView ({ query } as config) (( _, elementIndex ) as targetElement
 
         Ok ( { amount, material, transforms }, elementResults ) ->
             let
-                ( materialResults, transformsResults ) =
-                    case Component.extractItems elementResults of
-                        [] ->
-                            ( Component.emptyResults, [] )
+                materialProcess =
+                    material.process
 
-                        materialResults_ :: transformsResults_ ->
-                            ( materialResults_, transformsResults_ )
+                stageItems =
+                    Component.extractItems elementResults
+
+                materialResults =
+                    stageItems
+                        |> List.filter (\(Component.Results { stage }) -> stage == Just Component.MaterialStage)
+                        |> List.head
+                        |> Maybe.withDefault Component.emptyResults
+
+                transformsResults =
+                    stageItems
+                        |> List.filter (\(Component.Results { stage }) -> stage == Just Component.TransformStage)
             in
             div [ class "table-responsive p-2" ]
                 [ table [ class "table table-sm table-borderless mb-0" ]
@@ -765,7 +766,7 @@ elementEditModalView ({ query } as config) (( _, elementIndex ) as targetElement
                         (tr [ class "fs-7 text-muted" ]
                             [ th [] []
                             , th [ class "align-middle ps-0", scope "col" ]
-                                [ if material.unit == Process.Kilogram then
+                                [ if materialProcess.unit == Process.Kilogram then
                                     text "Masse finale"
 
                                   else
@@ -778,7 +779,7 @@ elementEditModalView ({ query } as config) (( _, elementIndex ) as targetElement
                             , th [ class "align-middle", scope "col" ]
                                 [ text "Pertes" ]
                             , th [ class "align-middle text-truncate", scope "col" ]
-                                [ material.unit |> Process.unitLabel |> text ]
+                                [ materialProcess.unit |> Process.unitLabel |> text ]
                             , th [ class "align-middle text-end", scope "col" ]
                                 [ Component.getTotalImpacts elementResults
                                     |> Format.formatImpact config.impact
@@ -790,7 +791,7 @@ elementEditModalView ({ query } as config) (( _, elementIndex ) as targetElement
                             ++ [ tr []
                                     [ td [ colspan 2 ] []
                                     , td [ colspan 6 ]
-                                        [ addElementTransformButton config material targetElement ]
+                                        [ addElementTransformButton config materialProcess targetElement ]
                                     ]
                                ]
                         )
@@ -824,32 +825,46 @@ selectMaterialButton config ( targetItem, elementIndex ) material =
         ]
 
 
-elementMaterialView : Config db msg -> TargetElement -> Results -> Process -> Amount -> List (Html msg)
+elementMaterialView : Config db msg -> TargetElement -> Results -> { a | country : Maybe Country, process : Process } -> Amount -> List (Html msg)
 elementMaterialView config targetElement materialResults material amount =
     let
         complementsImpacts =
             Component.extractComplementsImpacts materialResults
+
+        materialProcess =
+            material.process
     in
     [ tr [ class "fs-7" ]
         [ td [] []
         , td [ class "text-end align-middle text-nowrap ps-0", style "min-width" "130px" ]
             [ if config.scope == Scope.Textile then
-                Format.amount material amount
+                Format.amount materialProcess amount
 
               else
-                amountInput (config.updateElementAmount targetElement) material.unit amount
+                amountInput (config.updateElementAmount targetElement) materialProcess.unit amount
             ]
         , td
             [ class "align-middle text-truncate w-100"
-            , title <| Process.getDisplayName material
+            , title <| Process.getDisplayName materialProcess
             , colspan 2
             ]
-            [ selectMaterialButton config targetElement material ]
+            [ div [ class "d-flex align-items-center gap-2" ]
+                [ selectMaterialButton config targetElement materialProcess
+                , transformCountrySelector
+                    { attributes = [ style "min-width" "180px" ]
+                    , countries = config.db.countries
+                    , domId = "material-country-" ++ Component.targetElementToString targetElement
+                    , scope = config.scope
+                    , select = config.updateElementMaterialCountry targetElement
+                    , selected = material.country |> Maybe.map .code
+                    }
+                ]
+            ]
         , td [ class "text-end align-middle text-nowrap" ]
             []
         , td [ class "text-end align-middle text-nowrap" ]
             [ Component.extractAmount materialResults
-                |> Format.amount material
+                |> Format.amount materialProcess
             ]
         , td [ class "text-end align-middle text-nowrap" ]
             [ Component.getTotalImpacts materialResults

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -668,6 +668,13 @@ countrySelector config =
 
 elementView : Config db msg -> TargetItem -> Index -> ExpandedElement -> Results -> Html msg
 elementView config (( component, _ ) as targetItem) elementIndex { amount, material, transforms } elementResults =
+    let
+        materialLabel { country, process } =
+            String.join " "
+                [ Process.getDisplayName process
+                , "(" ++ (country |> Maybe.map .name |> Maybe.withDefault "Inconnu") ++ ")"
+                ]
+    in
     tbody []
         [ tr [ class "fs-7 border-top" ]
             [ td [] []
@@ -683,15 +690,15 @@ elementView config (( component, _ ) as targetItem) elementIndex { amount, mater
                         [ type_ "button"
                         , class "btn btn-sm btn-link text-decoration-none p-0 text-start"
                         , onClick (config.openEditElementModal component ( targetItem, elementIndex ))
+                        , title <| materialLabel material
                         ]
                         [ span [ class "ComponentElementIcon" ] [ Icon.material ]
-                        , text <| Process.getDisplayName material.process
-                        , material.country
-                            |> Maybe.map (\{ name } -> " (" ++ name ++ ")")
-                            |> Maybe.withDefault ""
-                            |> text
+                        , text <| materialLabel material
                         ]
-                    , div [ class "d-flex align-items-center gap-1 text-muted" ]
+                    , div
+                        [ class "d-flex align-items-center gap-1 text-muted"
+                        , title <| Component.transformListToString transforms
+                        ]
                         [ span [ class "ComponentElementIcon me-0" ] [ Icon.transform ]
                         , if List.isEmpty transforms then
                             text "Aucune transformation"

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -14,6 +14,7 @@ import Data.Component as Component
         , EndOfLifeMaterialImpacts
         , ExpandedElement
         , ExpandedItem
+        , ExpandedLocalizedProcess
         , Index
         , LifeCycle
         , Quantity
@@ -779,7 +780,7 @@ elementEditModalView ({ query } as config) (( _, elementIndex ) as targetElement
                             , th [ class "align-middle", scope "col" ]
                                 [ text <| "Élément #" ++ String.fromInt (elementIndex + 1) ]
                             , th [ class "align-middle text-center", scope "col" ]
-                                [ text "Mix" ]
+                                [ text "Pays/Région" ]
                             , th [ class "align-middle", scope "col" ]
                                 [ text "Pertes" ]
                             , th [ class "align-middle text-truncate", scope "col" ]
@@ -791,8 +792,8 @@ elementEditModalView ({ query } as config) (( _, elementIndex ) as targetElement
                             , th [] []
                             ]
                             :: elementMaterialView config targetElement materialResults material amount
-                            ++ elementTransformsView config targetElement transformsResults transforms
-                            ++ [ tr []
+                            ++ elementTransformsView config targetElement materialResults material.country transformsResults transforms
+                            ++ [ tr [ class "border-top" ]
                                     [ td [ colspan 2 ] []
                                     , td [ colspan 6 ]
                                         [ addElementTransformButton config materialProcess targetElement ]
@@ -885,13 +886,11 @@ elementMaterialView config targetElement materialResults material amount =
             , td [ class "text-end align-middle text-nowrap ps-0", style "min-width" "130px" ]
                 []
             , td
-                [ class "align-middle text-truncate w-100 text-muted cursor-help"
+                [ class "align-middle text-truncate w-100 text-muted cursor-help ps-4 fs-8"
                 , title (Format.formatComplementsResultsImpactsToString config.impact complementsImpacts)
                 ]
                 [ span [ class "ComponentElementIcon" ] [ Icon.calculator ], text "Dont compléments" ]
-            , td [ class "text-end align-middle text-nowrap" ]
-                []
-            , td [ class "text-end align-middle text-nowrap" ]
+            , td [ class "text-end align-middle text-nowrap", colspan 3 ]
                 []
             , td [ class "text-end align-middle text-nowrap" ]
                 [ complementsImpacts
@@ -907,81 +906,145 @@ elementMaterialView config targetElement materialResults material amount =
     ]
 
 
-elementTransformsView : Config db msg -> TargetElement -> List Results -> List Component.ExpandedLocalizedProcess -> List (Html msg)
-elementTransformsView config targetElement transformsResults transforms =
-    List.map3
-        (\transformIndex transformResult transformStep ->
-            let
-                maybeCountry =
-                    transformStep.country
+elementTransportView : Config db msg -> TargetElement -> Index -> Mass -> Maybe Country -> Maybe Country -> Html msg
+elementTransportView config targetElement transformIndex previousMass maybeFrom maybeTo =
+    let
+        transport =
+            (case ( maybeFrom, maybeTo ) of
+                ( Just from, Just to ) ->
+                    config.db.distances
+                        |> Transport.getTransportBetween Impact.empty from.code to.code
 
-                tooltipText =
-                    "Procédé\u{00A0}: "
-                        ++ Process.getDisplayName transformStep.process
-                        ++ (maybeCountry
-                                |> Component.loadEnergyMixes config.componentConfig
-                                |> Result.map
-                                    (\{ elec, heat } ->
-                                        "\nÉlectricité\u{00A0}: "
-                                            ++ Process.getDisplayName elec
-                                            ++ "\nChaleur\u{00A0}: "
-                                            ++ Process.getDisplayName heat
-                                    )
-                                |> Result.withDefault ""
-                           )
-            in
-            tr [ class "fs-7" ]
-                [ td [] []
-                , td [ class "text-end align-middle text-nowrap" ] []
-                , td
-                    [ class "text-truncate align-middle w-66 cursor-help "
+                _ ->
+                    config.componentConfig.transports.defaultDistance
+            )
+                |> Transport.applyTransportRatios Split.zero
+                |> Transport.computeImpacts config.componentConfig.transports.modeProcesses previousMass
+    in
+    tr [ class "fs-7 text-muted" ]
+        [ td [ colspan 3 ] []
+        , td [ class "text-end align-middle text-nowrap" ]
+            [ div [ class "d-flex justify-content-end align-items-center gap-2", style "width" "260px" ]
+                [ Icon.boat
+                , Format.km transport.sea
+                , Icon.bus
+                , Format.km transport.road
+                ]
+            ]
+        , td [ colspan 2 ] []
+        , td [ class "text-end align-middle text-nowrap" ]
+            [ transport.impacts
+                |> Format.formatImpact config.impact
+            ]
+        , td []
+            [ button
+                [ type_ "button"
+                , class "btn btn-sm btn-outline-secondary invisible"
+                , transformIndex
+                    |> config.removeElementTransform targetElement
+                    |> onClick
+                ]
+                [ Icon.trash ]
+            ]
+        ]
 
-                    -- Note: allows truncated ellipsis in table cells https://stackoverflow.com/a/11877033/330911
-                    , style "max-width" "0"
-                    , title tooltipText
-                    ]
-                    [ span [ class "ComponentElementIcon" ] [ Icon.transform ]
-                    , text <| Process.getDisplayName transformStep.process
-                    ]
-                , td [ class "text-end align-middle text-nowrap" ]
-                    [ transformCountrySelector
-                        { attributes = [ style "width" "260px" ]
-                        , countries = config.db.countries
-                        , domId =
-                            "transform-country-"
-                                ++ Component.targetElementToString targetElement
-                                ++ "-"
-                                ++ String.fromInt transformIndex
-                        , scope = config.scope
-                        , select = config.updateElementTransformCountry targetElement transformIndex
-                        , selected = maybeCountry |> Maybe.map .code
-                        }
-                    ]
-                , td [ class "align-middle text-end text-nowrap" ]
-                    [ Format.splitAsPercentage 2 transformStep.process.waste ]
-                , td [ class "text-end align-middle text-nowrap" ]
-                    [ Component.extractAmount transformResult
-                        |> Format.amount transformStep.process
-                    ]
-                , td [ class "text-end align-middle text-nowrap" ]
-                    [ Component.extractImpacts transformResult
-                        |> Format.formatImpact config.impact
-                    ]
-                , td []
-                    [ button
-                        [ type_ "button"
-                        , class "btn btn-sm btn-outline-secondary"
-                        , transformIndex
-                            |> config.removeElementTransform targetElement
-                            |> onClick
+
+elementTransformsView : Config db msg -> TargetElement -> Results -> Maybe Country -> List Results -> List ExpandedLocalizedProcess -> List (Html msg)
+elementTransformsView config targetElement materialResults materialCountry transformsResults transforms =
+    transforms
+        |> List.indexedMap
+            (\transformIndex transform ->
+                let
+                    transformResult =
+                        transformsResults
+                            |> LE.getAt transformIndex
+                            |> Maybe.withDefault Component.emptyResults
+
+                    previousMass =
+                        if transformIndex == 0 then
+                            Component.extractMass materialResults
+
+                        else
+                            transformsResults
+                                |> LE.getAt (transformIndex - 1)
+                                |> Maybe.withDefault Component.emptyResults
+                                |> Component.extractMass
+
+                    previousCountry =
+                        if transformIndex == 0 then
+                            materialCountry
+
+                        else
+                            transforms
+                                |> LE.getAt (transformIndex - 1)
+                                |> Maybe.andThen .country
+
+                    tooltipText =
+                        "Procédé\u{00A0}: "
+                            ++ Process.getDisplayName transform.process
+                            ++ (transform.country
+                                    |> Component.loadEnergyMixes config.componentConfig
+                                    |> Result.map
+                                        (\{ elec, heat } ->
+                                            "\nÉlectricité\u{00A0}: "
+                                                ++ Process.getDisplayName elec
+                                                ++ "\nChaleur\u{00A0}: "
+                                                ++ Process.getDisplayName heat
+                                        )
+                                    |> Result.withDefault ""
+                               )
+                in
+                [ transform.country
+                    |> elementTransportView config targetElement transformIndex previousMass previousCountry
+                , tr [ class "fs-7 border-top" ]
+                    [ td [] []
+                    , td [ class "text-end align-middle text-nowrap" ] []
+                    , td
+                        [ class "text-truncate align-middle w-66 cursor-help "
+                        , style "max-width" "0"
+                        , title tooltipText
                         ]
-                        [ Icon.trash ]
+                        [ span [ class "ComponentElementIcon" ] [ Icon.transform ]
+                        , text <| Process.getDisplayName transform.process
+                        ]
+                    , td [ class "text-end align-middle text-nowrap" ]
+                        [ transformCountrySelector
+                            { attributes = [ style "width" "260px" ]
+                            , countries = config.db.countries
+                            , domId =
+                                "transform-country-"
+                                    ++ Component.targetElementToString targetElement
+                                    ++ "-"
+                                    ++ String.fromInt transformIndex
+                            , scope = config.scope
+                            , select = config.updateElementTransformCountry targetElement transformIndex
+                            , selected = transform.country |> Maybe.map .code
+                            }
+                        ]
+                    , td [ class "align-middle text-end text-nowrap" ]
+                        [ Format.splitAsPercentage 2 transform.process.waste ]
+                    , td [ class "text-end align-middle text-nowrap" ]
+                        [ Component.extractAmount transformResult
+                            |> Format.amount transform.process
+                        ]
+                    , td [ class "text-end align-middle text-nowrap" ]
+                        [ Component.extractImpacts transformResult
+                            |> Format.formatImpact config.impact
+                        ]
+                    , td []
+                        [ button
+                            [ type_ "button"
+                            , class "btn btn-sm btn-outline-secondary"
+                            , transformIndex
+                                |> config.removeElementTransform targetElement
+                                |> onClick
+                            ]
+                            [ Icon.trash ]
+                        ]
                     ]
                 ]
-        )
-        (List.range 0 (List.length transforms - 1))
-        transformsResults
-        transforms
+            )
+        |> List.concat
 
 
 type alias TransformCountrySelector msg =

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -19,6 +19,7 @@ import Data.Component as Component
         , LifeCycle
         , Quantity
         , Query
+        , Requirements
         , Results
         , TargetElement
         , TargetItem
@@ -91,6 +92,19 @@ type Context
     = AdminContext
     | GenericContext
     | TextileTrimsContext
+
+
+{-| Extract the requirements from the config
+
+FIXME: maybe the config should use Requirements directly instead
+
+-}
+requirementsFromConfig : Config db msg -> Requirements db
+requirementsFromConfig config =
+    { config = config.componentConfig
+    , db = config.db
+    , scope = config.scope
+    }
 
 
 addComponentButton : Config db msg -> Html msg
@@ -900,20 +914,12 @@ elementMaterialView config targetElement materialResults material amount =
     ]
 
 
-elementTransportView : Config db msg -> TargetElement -> Index -> Mass -> Maybe Country -> Maybe Country -> Html msg
-elementTransportView config targetElement transformIndex previousMass maybeFrom maybeTo =
+elementTransportView : Config db msg -> Mass -> Maybe Country -> Maybe Country -> Html msg
+elementTransportView config transportedMass maybeFrom maybeTo =
     let
         transport =
-            (case ( maybeFrom, maybeTo ) of
-                ( Just from, Just to ) ->
-                    config.db.distances
-                        |> Transport.getTransportBetween Impact.empty from.code to.code
-
-                _ ->
-                    config.componentConfig.transports.defaultDistance
-            )
-                |> Transport.applyTransportRatios Split.zero
-                |> Transport.computeImpacts config.componentConfig.transports.modeProcesses previousMass
+            transportedMass
+                |> Component.computeTransportedMassImpacts (requirementsFromConfig config) maybeFrom maybeTo
     in
     tr [ class "fs-7 text-muted" ]
         [ td [ colspan 3 ] []
@@ -923,6 +929,8 @@ elementTransportView config targetElement transformIndex previousMass maybeFrom 
                 , Format.km transport.sea
                 , Icon.bus
                 , Format.km transport.road
+                , Icon.package
+                , Format.kg transportedMass
                 ]
             ]
         , td [ colspan 2 ] []
@@ -930,16 +938,7 @@ elementTransportView config targetElement transformIndex previousMass maybeFrom 
             [ transport.impacts
                 |> Format.formatImpact config.impact
             ]
-        , td []
-            [ button
-                [ type_ "button"
-                , class "btn btn-sm btn-outline-secondary invisible"
-                , transformIndex
-                    |> config.removeElementTransform targetElement
-                    |> onClick
-                ]
-                [ Icon.trash ]
-            ]
+        , td [] []
         ]
 
 
@@ -989,7 +988,7 @@ elementTransformsView config targetElement materialResults materialCountry trans
                                )
                 in
                 [ transform.country
-                    |> elementTransportView config targetElement transformIndex previousMass previousCountry
+                    |> elementTransportView config previousMass previousCountry
                 , tr [ class "fs-7 border-top" ]
                     [ td [] []
                     , td [ class "text-end align-middle text-nowrap" ] []

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -339,16 +339,13 @@ componentTransportToAssembly { componentConfig, db, impact, query, scope } expan
                     , Transport.default Impact.empty
                     )
 
-                Ok assemblyCountry ->
+                Ok maybeAssemblyCountry ->
                     Tuple.mapFirst text <|
                         Component.computeItemTransportToAssembly
                             { config = componentConfig, db = db, scope = scope }
-                            assemblyCountry
+                            maybeAssemblyCountry
                             expandedItem
                             itemResults
-
-        mass =
-            Component.extractMass itemResults
     in
     tr [ class "fs-7" ]
         [ td [] []
@@ -364,7 +361,7 @@ componentTransportToAssembly { componentConfig, db, impact, query, scope } expan
                 ]
             ]
         , td [ class "text-end" ]
-            [ Format.kg mass ]
+            [ Component.extractMass itemResults |> Format.kg ]
         , td [ class "text-end" ]
             [ transports |> .impacts |> Format.formatImpact impact ]
         , td [] []
@@ -749,9 +746,6 @@ elementEditModalView ({ query } as config) (( _, elementIndex ) as targetElement
 
         Ok ( { amount, material, transforms }, elementResults ) ->
             let
-                materialProcess =
-                    material.process
-
                 stageItems =
                     Component.extractItems elementResults
 
@@ -771,7 +765,7 @@ elementEditModalView ({ query } as config) (( _, elementIndex ) as targetElement
                         (tr [ class "fs-7 text-muted" ]
                             [ th [] []
                             , th [ class "align-middle ps-0", scope "col" ]
-                                [ if materialProcess.unit == Process.Kilogram then
+                                [ if material.process.unit == Process.Kilogram then
                                     text "Masse finale"
 
                                   else
@@ -784,7 +778,7 @@ elementEditModalView ({ query } as config) (( _, elementIndex ) as targetElement
                             , th [ class "align-middle", scope "col" ]
                                 [ text "Pertes" ]
                             , th [ class "align-middle text-truncate", scope "col" ]
-                                [ materialProcess.unit |> Process.unitLabel |> text ]
+                                [ material.process.unit |> Process.unitLabel |> text ]
                             , th [ class "align-middle text-end", scope "col" ]
                                 [ Component.getTotalImpacts elementResults
                                     |> Format.formatImpact config.impact
@@ -796,7 +790,7 @@ elementEditModalView ({ query } as config) (( _, elementIndex ) as targetElement
                             ++ [ tr [ class "border-top" ]
                                     [ td [ colspan 2 ] []
                                     , td [ colspan 6 ]
-                                        [ addElementTransformButton config materialProcess targetElement ]
+                                        [ addElementTransformButton config material.process targetElement ]
                                     ]
                                ]
                         )

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -756,7 +756,7 @@ getEditedElementData { db, lifeCycle } ( ( _, itemIndex ), elementIndex ) query 
 
 
 elementEditModalView : Config db msg -> TargetElement -> Html msg
-elementEditModalView ({ componentConfig, query } as config) (( _, elementIndex ) as targetElement) =
+elementEditModalView ({ query } as config) (( _, elementIndex ) as targetElement) =
     case query |> getEditedElementData config targetElement of
         Err error ->
             div [ class "alert alert-danger" ] [ text error ]
@@ -775,15 +775,6 @@ elementEditModalView ({ componentConfig, query } as config) (( _, elementIndex )
                 transformsResults =
                     stageItems
                         |> List.filter (Component.extractStage >> (==) (Just Component.TransformStage))
-
-                lastTransportedMass =
-                    transformsResults
-                        |> LE.last
-                        |> Maybe.map Component.extractMass
-                        |> Maybe.withDefault (Component.extractMass materialResults)
-
-                lastTransportedCountry =
-                    Component.getElementFinalCountry expandedElement
             in
             div [ class "table-responsive p-2" ]
                 [ table [ class "table table-sm table-borderless mb-0" ]
@@ -813,11 +804,10 @@ elementEditModalView ({ componentConfig, query } as config) (( _, elementIndex )
                             ]
                             :: elementMaterialView config targetElement materialResults material amount
                             ++ elementTransformsView config targetElement materialResults material.country transformsResults transforms
-                            ++ [ config.db.countries
-                                    |> Country.resolveMaybe config.query.assemblyCountry
-                                    |> Result.map (Maybe.withDefault componentConfig.distribution.country >> Just)
-                                    |> Result.map (elementTransportView config [ class "subdued" ] lastTransportedMass lastTransportedCountry)
-                                    |> Result.withDefault (text "")
+                            ++ [ LE.last transformsResults
+                                    |> Maybe.map Component.extractMass
+                                    |> Maybe.withDefault (Component.extractMass materialResults)
+                                    |> finalElementTransportView config (Component.getFinalElementCountry expandedElement)
                                , tr [ class "border-top" ]
                                     [ td [ colspan 2 ] []
                                     , td [ colspan 6 ]
@@ -827,6 +817,31 @@ elementEditModalView ({ componentConfig, query } as config) (( _, elementIndex )
                         )
                     ]
                 ]
+
+
+{-| Render transports from last transform step to assembly or distribution stage
+-}
+finalElementTransportView : Config db msg -> Maybe Country -> Mass -> Html msg
+finalElementTransportView ({ componentConfig, db, query } as config) elementCountry mass =
+    let
+        maybeDestinationCountryCode =
+            case ( List.length query.items > 1, query.assemblyCountry ) of
+                -- multiple items and an assembly country: transport to assembly country
+                ( True, Just assemblyCountryCode ) ->
+                    Just assemblyCountryCode
+
+                -- single item and no assembly country: transport to default distribution country
+                ( False, Nothing ) ->
+                    Just componentConfig.distribution.country.code
+
+                -- fallback to unknown destination
+                _ ->
+                    Nothing
+    in
+    db.countries
+        |> Country.resolveMaybe maybeDestinationCountryCode
+        |> Result.map (elementTransportView config [ class "subdued" ] mass elementCountry)
+        |> Result.withDefault (text "")
 
 
 listAvailableProcesses :
@@ -942,10 +957,14 @@ elementTransportView config attributes transportedMass maybeFrom maybeTo =
         transport =
             transportedMass
                 |> Component.computeTransportedMassImpacts (requirementsFromConfig config) maybeFrom maybeTo
+
+        renderCountry =
+            Maybe.map .name >> Maybe.withDefault "Région inconnue"
     in
     tr (class "fs-7 text-muted" :: attributes)
         [ td [ colspan 2 ] []
-        , td [] [ text <| "Transport vers " ++ (maybeTo |> Maybe.map .name |> Maybe.withDefault "Région inconnue") ]
+        , td []
+            [ text <| "Transport " ++ renderCountry maybeFrom ++ " → " ++ renderCountry maybeTo ]
         , td [ class "text-end align-middle d-flex justify-content-end align-items-center gap-2 text-nowrap" ]
             [ Icon.boat
             , Format.km transport.sea

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -749,12 +749,12 @@ getEditedElementData { db, lifeCycle } ( ( _, itemIndex ), elementIndex ) query 
 
 
 elementEditModalView : Config db msg -> TargetElement -> Html msg
-elementEditModalView ({ query } as config) (( _, elementIndex ) as targetElement) =
+elementEditModalView ({ componentConfig, query } as config) (( _, elementIndex ) as targetElement) =
     case query |> getEditedElementData config targetElement of
         Err error ->
             div [ class "alert alert-danger" ] [ text error ]
 
-        Ok ( { amount, material, transforms }, elementResults ) ->
+        Ok ( { amount, material, transforms } as expandedElement, elementResults ) ->
             let
                 stageItems =
                     Component.extractItems elementResults
@@ -768,6 +768,15 @@ elementEditModalView ({ query } as config) (( _, elementIndex ) as targetElement
                 transformsResults =
                     stageItems
                         |> List.filter (Component.extractStage >> (==) (Just Component.TransformStage))
+
+                lastTransportedMass =
+                    transformsResults
+                        |> LE.last
+                        |> Maybe.map Component.extractMass
+                        |> Maybe.withDefault (Component.extractMass materialResults)
+
+                lastTransportedCountry =
+                    Component.getElementFinalCountry expandedElement
             in
             div [ class "table-responsive p-2" ]
                 [ table [ class "table table-sm table-borderless mb-0" ]
@@ -797,7 +806,12 @@ elementEditModalView ({ query } as config) (( _, elementIndex ) as targetElement
                             ]
                             :: elementMaterialView config targetElement materialResults material amount
                             ++ elementTransformsView config targetElement materialResults material.country transformsResults transforms
-                            ++ [ tr [ class "border-top" ]
+                            ++ [ config.db.countries
+                                    |> Country.resolveMaybe config.query.assemblyCountry
+                                    |> Result.map (Maybe.withDefault componentConfig.distribution.country >> Just)
+                                    |> Result.map (elementTransportView config [ class "subdued" ] lastTransportedMass lastTransportedCountry)
+                                    |> Result.withDefault (text "")
+                               , tr [ class "border-top" ]
                                     [ td [ colspan 2 ] []
                                     , td [ colspan 6 ]
                                         [ addElementTransformButton config material.process targetElement ]
@@ -808,10 +822,7 @@ elementEditModalView ({ query } as config) (( _, elementIndex ) as targetElement
                 ]
 
 
-listAvailableProcesses :
-    { config | db : Component.DataContainer db, scope : Scope }
-    -> Category
-    -> List Process
+listAvailableProcesses : { config | db : Component.DataContainer db, scope : Scope } -> Category -> List Process
 listAvailableProcesses { db, scope } category =
     db.processes
         |> Scope.anyOf [ scope ]
@@ -916,15 +927,16 @@ elementMaterialView config targetElement materialResults material amount =
     ]
 
 
-elementTransportView : Config db msg -> Mass -> Maybe Country -> Maybe Country -> Html msg
-elementTransportView config transportedMass maybeFrom maybeTo =
+elementTransportView : Config db msg -> List (Attribute msg) -> Mass -> Maybe Country -> Maybe Country -> Html msg
+elementTransportView config attributes transportedMass maybeFrom maybeTo =
     let
         transport =
             transportedMass
                 |> Component.computeTransportedMassImpacts (requirementsFromConfig config) maybeFrom maybeTo
     in
-    tr [ class "fs-7 text-muted" ]
-        [ td [ colspan 3 ] []
+    tr (class "fs-7 text-muted" :: attributes)
+        [ td [ colspan 2 ] []
+        , td [] [ text <| "Transport vers " ++ (maybeTo |> Maybe.map .name |> Maybe.withDefault "Région inconnue") ]
         , td [ class "text-end align-middle d-flex justify-content-end align-items-center gap-2 text-nowrap" ]
             [ Icon.boat
             , Format.km transport.sea
@@ -993,7 +1005,7 @@ elementTransformsView config targetElement materialResults materialCountry trans
                                )
                 in
                 [ transform.country
-                    |> elementTransportView config previousMass previousCountry
+                    |> elementTransportView config [] previousMass previousCountry
                 , tr [ class "fs-7 border-top" ]
                     [ td [] []
                     , td [ class "text-end align-middle text-nowrap" ] []

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -173,7 +173,7 @@ addElementTransformButton { db, openSelectProcessModal, query, scope } material 
         [ type_ "button"
         , class "btn btn-link btn-sm w-100 text-decoration-none"
         , class "d-flex justify-content-start align-items-center"
-        , class "gap-1 w-100 p-0 pb-1"
+        , class "gap-1 w-100 ps-0"
         , disabled <| List.isEmpty availableTransformProcesses
         , autocompleteState
             |> openSelectProcessModal Category.Transform targetItem (Just elementIndex)
@@ -847,19 +847,18 @@ elementMaterialView config targetElement materialResults material amount =
         , td
             [ class "align-middle text-truncate w-100"
             , title <| Process.getDisplayName material.process
-            , colspan 2
             ]
-            [ div [ class "d-flex justify-content-between align-items-center gap-2" ]
-                [ selectMaterialButton config targetElement material.process
-                , transformCountrySelector
-                    { attributes = [ style "width" "260px" ]
-                    , countries = config.db.countries
-                    , domId = "material-country-" ++ Component.targetElementToString targetElement
-                    , scope = config.scope
-                    , select = config.updateElementMaterialCountry targetElement
-                    , selected = material.country |> Maybe.map .code
-                    }
-                ]
+            [ selectMaterialButton config targetElement material.process
+            ]
+        , td [ class "text-end align-middle text-nowrap" ]
+            [ transformCountrySelector
+                { attributes = [ style "width" "260px" ]
+                , countries = config.db.countries
+                , domId = "material-country-" ++ Component.targetElementToString targetElement
+                , scope = config.scope
+                , select = config.updateElementMaterialCountry targetElement
+                , selected = material.country |> Maybe.map .code
+                }
             ]
         , td [ class "text-end align-middle text-nowrap" ]
             []

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -687,7 +687,7 @@ elementView config (( component, _ ) as targetItem) elementIndex { amount, mater
                         [ span [ class "ComponentElementIcon" ] [ Icon.material ]
                         , text <| Process.getDisplayName material.process
                         , material.country
-                            |> Maybe.map (\{ code } -> " (" ++ Country.codeToString code ++ ")")
+                            |> Maybe.map (\{ name } -> " (" ++ name ++ ")")
                             |> Maybe.withDefault ""
                             |> text
                         ]

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -375,9 +375,9 @@ componentTransportToAssembly { componentConfig, db, impact, query, scope } expan
                 ]
             ]
         , td [ class "text-end" ]
-            [ Component.extractMass itemResults |> Format.kg ]
+            [ itemResults |> Component.extractMass |> Format.kg ]
         , td [ class "text-end" ]
-            [ transports |> .impacts |> Format.formatImpact impact ]
+            [ transports.impacts |> Format.formatImpact impact ]
         , td [] []
         ]
 
@@ -822,7 +822,10 @@ elementEditModalView ({ componentConfig, query } as config) (( _, elementIndex )
                 ]
 
 
-listAvailableProcesses : { config | db : Component.DataContainer db, scope : Scope } -> Category -> List Process
+listAvailableProcesses :
+    { config | db : Component.DataContainer db, scope : Scope }
+    -> Category
+    -> List Process
 listAvailableProcesses { db, scope } category =
     db.processes
         |> Scope.anyOf [ scope ]
@@ -873,9 +876,8 @@ elementMaterialView config targetElement materialResults material amount =
             [ selectMaterialButton config targetElement material.process
             ]
         , td [ class "text-end align-middle text-nowrap" ]
-            [ transformCountrySelector
-                { attributes = [ style "width" "260px" ]
-                , countries = config.db.countries
+            [ regionSelector
+                { countries = config.db.countries
                 , domId = "material-country-" ++ Component.targetElementToString targetElement
                 , scope = config.scope
                 , select = config.updateElementMaterialCountry targetElement
@@ -1018,9 +1020,8 @@ elementTransformsView config targetElement materialResults materialCountry trans
                         , text <| Process.getDisplayName transform.process
                         ]
                     , td [ class "text-end align-middle text-nowrap" ]
-                        [ transformCountrySelector
-                            { attributes = [ style "width" "260px" ]
-                            , countries = config.db.countries
+                        [ regionSelector
+                            { countries = config.db.countries
                             , domId =
                                 "transform-country-"
                                     ++ Component.targetElementToString targetElement
@@ -1057,9 +1058,8 @@ elementTransformsView config targetElement materialResults materialCountry trans
         |> List.concat
 
 
-type alias TransformCountrySelector msg =
-    { attributes : List (Attribute msg)
-    , countries : List Country
+type alias RegionSelector msg =
+    { countries : List Country
     , domId : String
     , scope : Scope
     , select : Maybe Country.Code -> msg
@@ -1067,8 +1067,8 @@ type alias TransformCountrySelector msg =
     }
 
 
-transformCountrySelector : TransformCountrySelector msg -> Html msg
-transformCountrySelector config =
+regionSelector : RegionSelector msg -> Html msg
+regionSelector config =
     let
         countries =
             config.countries
@@ -1097,30 +1097,28 @@ transformCountrySelector config =
                     ]
             )
         |> select
-            (config.attributes
-                ++ [ class "form-select form-select-sm"
-                   , id config.domId
-                   , autocomplete False
-                   , config.selected
-                        |> Maybe.andThen
-                            (\code ->
-                                Country.findByCode code countries
-                                    |> Result.map .name
-                                    |> Result.toMaybe
-                            )
-                        |> Maybe.withDefault "Par défaut"
-                        |> (++) "Mix: "
-                        |> title
-                   , onInput <|
-                        \str ->
-                            config.select <|
-                                if String.isEmpty str then
-                                    Nothing
+            [ class "RegionSelector form-select form-select-sm"
+            , id config.domId
+            , autocomplete False
+            , config.selected
+                |> Maybe.andThen
+                    (\code ->
+                        Country.findByCode code countries
+                            |> Result.map .name
+                            |> Result.toMaybe
+                    )
+                |> Maybe.withDefault "Par défaut"
+                |> (++) "Mix: "
+                |> title
+            , onInput <|
+                \str ->
+                    config.select <|
+                        if String.isEmpty str then
+                            Nothing
 
-                                else
-                                    Just <| Country.codeFromString str
-                   ]
-            )
+                        else
+                            Just <| Country.codeFromString str
+            ]
 
 
 quantityInput : Config db msg -> Index -> Quantity -> Html msg

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -1084,7 +1084,7 @@ regionSelector config =
     in
     countries
         |> List.map (\{ code, name } -> ( name, Just code ))
-        |> (::) ( "Mix par défaut", Nothing )
+        |> (::) ( "Par défaut", Nothing )
         |> List.map
             (\( name, maybeCode ) ->
                 option
@@ -1115,7 +1115,7 @@ regionSelector config =
                             |> Result.toMaybe
                     )
                 |> Maybe.withDefault "Par défaut"
-                |> (++) "Mix: "
+                |> (++) "Région\u{00A0}: "
                 |> title
             , onInput <|
                 \str ->

--- a/src/Views/Modal.elm
+++ b/src/Views/Modal.elm
@@ -20,6 +20,7 @@ type alias Config msg =
 
 type Size
     = ExtraLarge
+    | Fluid
     | Large
     | Small
     | Standard
@@ -57,6 +58,7 @@ view config =
                     [ ( "modal-xl", config.size == ExtraLarge )
                     , ( "modal-lg", config.size == Large )
                     , ( "modal-sm", config.size == Small )
+                    , ( "modal-fluid", config.size == Fluid )
                     ]
                 , attribute "aria-modal" "true"
                 ]

--- a/styles.scss
+++ b/styles.scss
@@ -575,6 +575,10 @@ q {
   box-shadow: inset 0 3px 5px #00000011;
 }
 
+.subdued {
+  opacity: 0.5;
+}
+
 .w {
   &-33 {
     width: 33.333333%;

--- a/styles.scss
+++ b/styles.scss
@@ -474,9 +474,14 @@ q {
   }
 }
 
-.modal-xl {
-  @media (width >= 1200px) {
-    --bs-modal-width: 1300px;
+.modal-fluid {
+  &.modal-dialog {
+    // maximize horizontal space
+    --bs-modal-width: calc(100vw - .25rem);
+    @media screen and (width >= $viewport-xl) {
+      // … but limit it to the largest available viewport width
+      max-width: calc($viewport-xl);
+    }
   }
 }
 

--- a/styles.scss
+++ b/styles.scss
@@ -1284,6 +1284,10 @@ q {
   }
 }
 
+.RegionSelector {
+  width: 260px;
+}
+
 .Simulator {
   @media screen and (width < $viewport-sm) {
     margin-top: 5px;

--- a/tests/Data/ComponentTest.elm
+++ b/tests/Data/ComponentTest.elm
@@ -134,7 +134,7 @@ suite =
                                     |> Component.applyTransforms requirements
                                         Nothing
                                         Process.Kilogram
-                                        (List.map Component.defaultExpandedTransform transforms)
+                                        (List.map Component.defaultExpandedLocalizedProcess transforms)
                                     |> Result.withDefault Component.emptyResults
                                     |> Component.extractMass
                                     |> Mass.inKilograms
@@ -169,7 +169,7 @@ suite =
                                     |> Component.applyTransforms requirements
                                         Nothing
                                         Process.Kilogram
-                                        (List.map Component.defaultExpandedTransform transforms)
+                                        (List.map Component.defaultExpandedLocalizedProcess transforms)
                                     |> Result.withDefault Component.emptyResults
                                     |> extractEcsImpact
                           in
@@ -232,7 +232,7 @@ suite =
                                     Ok country ->
                                         let
                                             ( defaultImpact, localizedImpact ) =
-                                                ( getImpact [ Component.defaultExpandedTransform fading ]
+                                                ( getImpact [ Component.defaultExpandedLocalizedProcess fading ]
                                                 , getImpact [ { country = Just country, process = fading } ]
                                                 )
                                         in
@@ -272,7 +272,7 @@ suite =
                                         |> Component.applyTransforms requirements
                                             Nothing
                                             Process.CubicMeter
-                                            [ Component.defaultExpandedTransform transformInKg ]
+                                            [ Component.defaultExpandedLocalizedProcess transformInKg ]
                                         |> Expect.equal (Err "Les procédés de transformation ne partagent pas la même unité que la matière source (m3)\u{00A0}: Moulage par injection (kg)")
                                     )
                                 ]
@@ -293,7 +293,7 @@ suite =
                                     |> Component.applyTransforms requirements
                                         Nothing
                                         Process.Kilogram
-                                        (List.map Component.defaultExpandedTransform transforms)
+                                        (List.map Component.defaultExpandedLocalizedProcess transforms)
                                     |> Result.withDefault Component.emptyResults
                           in
                           describe "impacts & waste"

--- a/tests/Data/ComponentTest.elm
+++ b/tests/Data/ComponentTest.elm
@@ -683,6 +683,71 @@ suite =
                                     )
                                 ]
                             )
+                        , it "should include transport stage impacts when applying transforms"
+                            (case
+                                requirements.db.countries
+                                    |> Scope.anyOf [ requirements.scope ]
+                                    |> List.head
+                                    |> Result.fromMaybe "No country available in test scope"
+                             of
+                                Err error ->
+                                    Expect.fail error
+
+                                Ok country ->
+                                    Process.idFromString "f0dbe27b-1e74-55d0-88a2-bda812441744"
+                                        |> Result.andThen
+                                            (\materialId ->
+                                                { amount = Amount.fromFloat 1
+                                                , material = { country = Just country.code, id = materialId }
+                                                , transforms =
+                                                    [ { id = fading.id
+                                                      , country = Just country.code
+                                                      }
+                                                    ]
+                                                }
+                                                    |> Component.computeElementResults requirements
+                                                    |> Result.map Component.extractItems
+                                                    |> Result.map (List.any (Component.extractStage >> (==) (Just Component.TransportStage)))
+                                            )
+                                        |> Expect.equal (Ok True)
+                            )
+                        ]
+                    , describe "computeVolumeFromMass"
+                        [ it "should compute a volume from a mass"
+                            -- Remember, this is a temporary situation until we obtain volume per unit data in processes db
+                            (Component.computeVolumeFromMass (Mass.kilograms 1000)
+                                |> Expect.equal (Volume.cubicMeters 1)
+                            )
+                        ]
+                    , describe "decodeItem"
+                        [ it "should decode an item"
+                            ("""{ "id": "64fa65b3-c2df-4fd0-958b-83965bd6aa08", "quantity": 1 }"""
+                                |> decodeJson Component.decodeItem
+                                |> Expect.ok
+                            )
+                        , it "should decode an item with a custom material country override"
+                            ("""{
+                                  "quantity": 1,
+                                  "custom": {
+                                    "elements": [
+                                      {
+                                        "amount": 1,
+                                        "material": {
+                                          "id": "17431e06-2973-516e-b043-be9ad405e4fb",
+                                          "country": "CN"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }"""
+                                |> decodeJsonThen Component.decodeItem
+                                    (.custom
+                                        >> Maybe.andThen (.elements >> LE.getAt 0)
+                                        >> Maybe.map (.material >> .country)
+                                        >> Result.fromMaybe "Missing custom element material country"
+                                    )
+                                |> Expect.equal (Ok (Just (Country.codeFromString "CN")))
+                            )
                         , it "should decode legacy item country into custom element material country"
                             ("""{
                                   "country": "CN",
@@ -698,52 +763,39 @@ suite =
                                   }
                                 }"""
                                 |> decodeJsonThen Component.decodeItem
-                                    (\item ->
-                                        item.custom
-                                            |> Maybe.andThen (.elements >> LE.getAt 0)
-                                            |> Maybe.map (.material >> .country)
-                                            |> Result.fromMaybe "Missing custom element material country"
+                                    (.custom
+                                        >> Maybe.andThen (.elements >> LE.getAt 0)
+                                        >> Maybe.map (.material >> .country)
+                                        >> Result.fromMaybe "Missing custom element material country"
                                     )
                                 |> Expect.equal (Ok (Just (Country.codeFromString "CN")))
                             )
-                        , it "should include transport stage impacts when applying transforms"
-                            (case
-                                requirements.db.countries
-                                    |> Scope.anyOf [ requirements.scope ]
-                                    |> List.head
-                             of
-                                Nothing ->
-                                    Expect.fail "No country available in test scope"
-
-                                Just country ->
-                                    Process.idFromString "f0dbe27b-1e74-55d0-88a2-bda812441744"
-                                        |> Result.andThen
-                                            (\materialId ->
-                                                { amount = Amount.fromFloat 1
-                                                , material = { country = Just country.code, id = materialId }
-                                                , transforms =
-                                                    [ { id = fading.id
-                                                      , country = Just country.code
-                                                      }
-                                                    ]
-                                                }
-                                                    |> Component.computeElementResults requirements
-                                                    |> Result.map Component.extractItems
-                                                    |> Result.map
-                                                        (List.any
-                                                            (\(Component.Results { stage }) ->
-                                                                stage == Just Component.TransportStage
-                                                            )
-                                                        )
-                                            )
-                                        |> Expect.equal (Ok True)
-                            )
-                        ]
-                    , describe "computeVolumeFromMass"
-                        [ it "should compute a volume from a mass"
-                            -- Remember, this is a temporary situation until we obtain volume per unit data in processes db
-                            (Component.computeVolumeFromMass (Mass.kilograms 1000)
-                                |> Expect.equal (Volume.cubicMeters 1)
+                        , it "should decode an item with a custom transform country override"
+                            ("""{
+                                  "quantity": 1,
+                                  "custom": {
+                                    "elements": [
+                                      {
+                                        "amount": 1,
+                                        "material": "17431e06-2973-516e-b043-be9ad405e4fb",
+                                        "transforms": [
+                                          {
+                                            "id": "931c9bb0-619a-5f75-b41b-ab8061e2ad92",
+                                            "country": "CN"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                }"""
+                                |> decodeJsonThen Component.decodeItem
+                                    (.custom
+                                        >> Maybe.andThen (.elements >> LE.getAt 0)
+                                        >> Maybe.andThen (.transforms >> LE.getAt 0)
+                                        >> Maybe.map .country
+                                        >> Result.fromMaybe "Missing custom element transform country"
+                                    )
+                                |> Expect.equal (Ok (Just (Country.codeFromString "CN")))
                             )
                         ]
                     , TestUtils.suiteFromResult "itemToComponent"
@@ -1042,12 +1094,12 @@ suite =
                                     |> List.filterMap identity
                                     |> Impact.sumImpacts
                                     |> getEcsImpact
-                                    |> Expect.within (Expect.Absolute 1)
-                                        (Impact.sumImpacts
-                                            [ Component.extractImpacts lifeCycle.production
-                                            , lifeCycle.transports.toAssembly.impacts
-                                            , lifeCycle.transports.toDistribution.impacts
-                                            ]
+                                    |> Expect.within (Expect.Absolute 0.00001)
+                                        ([ Component.extractImpacts lifeCycle.production
+                                         , lifeCycle.transports.toAssembly.impacts
+                                         , lifeCycle.transports.toDistribution.impacts
+                                         ]
+                                            |> Impact.sumImpacts
                                             |> getEcsImpact
                                         )
                                 )

--- a/tests/Data/ComponentTest.elm
+++ b/tests/Data/ComponentTest.elm
@@ -747,13 +747,150 @@ suite =
                                     )
                                 ]
                             )
+                        , it "should reject single item assembly"
+                            ("""{
+                                  "assemblyCountry": "FR",
+                                  "components": [
+                                    { "id": "ad9d7f23-076b-49c5-93a4-ee1cd7b53973", "quantity": 1 }
+                                  ]
+                                }"""
+                                |> decodeJsonThen Component.decodeQuery (Component.compute requirements)
+                                |> expectResultErrorContains "Un composant unique ne peut pas être assemblé"
+                            )
+                        , suiteFromResult "assembly country handling"
+                            -- setup
+                            ("""{
+                                  "assemblyCountry": "FR",
+                                  "components": [
+                                    { "id": "ad9d7f23-076b-49c5-93a4-ee1cd7b53973", "quantity": 1 },
+                                    { "id": "eda5dd7e-52e4-450f-8658-1876efc62bd6", "quantity": 1 }
+                                  ]
+                                }"""
+                                |> decodeJsonThen Component.decodeQuery (Component.compute requirements)
+                            )
+                            -- tests
+                            (\productAssembledInFrance ->
+                                [ it "should add both assembly and distribution transport impacts when assembly country is specified"
+                                    (let
+                                        ( assemblyImpact, distributionImpact ) =
+                                            ( productAssembledInFrance
+                                                |> .transports
+                                                |> .toAssembly
+                                                |> .impacts
+                                                |> getEcsImpact
+                                            , productAssembledInFrance
+                                                |> .transports
+                                                |> .toDistribution
+                                                |> .impacts
+                                                |> getEcsImpact
+                                            )
+                                     in
+                                     ( assemblyImpact, distributionImpact )
+                                        |> Expect.all
+                                            [ Tuple.first >> Expect.greaterThan 0
+                                            , Tuple.second >> Expect.greaterThan 0
+                                            ]
+                                    )
+                                ]
+                            )
+                        , suiteFromResult "single item distribution transport"
+                            -- setup
+                            ("""{"components": [{ "id": "64fa65b3-c2df-4fd0-958b-83965bd6aa08", "quantity": 1 }]}"""
+                                |> decodeJsonThen Component.decodeQuery (Component.compute requirements)
+                            )
+                            -- tests
+                            (\singleItemProduct ->
+                                [ it "should not add transport to assembly when shipping a single item"
+                                    (singleItemProduct
+                                        |> .transports
+                                        |> .toAssembly
+                                        |> .impacts
+                                        |> getEcsImpact
+                                        |> Expect.equal 0
+                                    )
+                                , it "should add transport impacts to distribution when shipping a single item"
+                                    (singleItemProduct
+                                        |> .transports
+                                        |> .toDistribution
+                                        |> .impacts
+                                        |> getEcsImpact
+                                        |> Expect.greaterThan 0
+                                    )
+                                ]
+                            )
+                        , suiteFromResult2 "multiple items without assembly country"
+                            -- setup
+                            ("""{
+                                  "components": [
+                                    { "id": "ad9d7f23-076b-49c5-93a4-ee1cd7b53973", "quantity": 1 },
+                                    { "id": "eda5dd7e-52e4-450f-8658-1876efc62bd6", "quantity": 1 }
+                                  ]
+                                }"""
+                                |> decodeJsonThen Component.decodeQuery (Component.compute requirements)
+                            )
+                            ("""{
+                                  "components": [
+                                    { "id": "ad9d7f23-076b-49c5-93a4-ee1cd7b53973", "quantity": 1 },
+                                    { "id": "eda5dd7e-52e4-450f-8658-1876efc62bd6", "quantity": 2 }
+                                  ]
+                                }"""
+                                |> decodeJsonThen Component.decodeQuery (Component.compute requirements)
+                            )
+                            -- tests
+                            (\productAssembledInUnknownCountry heavierProductAssembledInUnknownCountry ->
+                                [ it "should add both assembly and distribution transports when multiple items have no assembly country"
+                                    (let
+                                        ( assemblyImpact, distributionImpact ) =
+                                            ( productAssembledInUnknownCountry
+                                                |> .transports
+                                                |> .toAssembly
+                                                |> .impacts
+                                                |> getEcsImpact
+                                            , productAssembledInUnknownCountry
+                                                |> .transports
+                                                |> .toDistribution
+                                                |> .impacts
+                                                |> getEcsImpact
+                                            )
+                                     in
+                                     ( assemblyImpact, distributionImpact )
+                                        |> Expect.all
+                                            [ Tuple.first >> Expect.greaterThan 0
+                                            , Tuple.second >> Expect.greaterThan 0
+                                            ]
+                                    )
+                                , it "should increase distribution transport impacts when total transported mass increases"
+                                    (let
+                                        productAssembledInUnknownCountryImpacts =
+                                            productAssembledInUnknownCountry
+                                                |> .transports
+                                                |> .toDistribution
+                                                |> .impacts
+                                                |> getEcsImpact
+
+                                        heavierProductAssembledInUnknownCountryImpacts =
+                                            heavierProductAssembledInUnknownCountry
+                                                |> .transports
+                                                |> .toDistribution
+                                                |> .impacts
+                                                |> getEcsImpact
+                                     in
+                                     heavierProductAssembledInUnknownCountryImpacts
+                                        |> Expect.greaterThan productAssembledInUnknownCountryImpacts
+                                    )
+                                ]
+                            )
                         , itFromResult2 "should include transport stage impacts when applying transforms"
+                            -- setup
+                            -- test country
                             (requirements.db.countries
                                 |> Scope.anyOf [ requirements.scope ]
                                 |> List.head
-                                |> Result.fromMaybe "No country available in test scope"
+                                |> Result.fromMaybe ("No test country available scoped " ++ Scope.toString requirements.scope)
                             )
+                            -- cotton
                             (Process.idFromString "f0dbe27b-1e74-55d0-88a2-bda812441744")
+                            -- tests
                             (\country materialId ->
                                 { amount = Amount.fromFloat 1
                                 , material = { country = Just country.code, id = materialId }

--- a/tests/Data/ComponentTest.elm
+++ b/tests/Data/ComponentTest.elm
@@ -3,6 +3,7 @@ module Data.ComponentTest exposing (..)
 import Data.Complement as Complement
 import Data.Component as Component exposing (Component, Item, LifeCycle, Requirements)
 import Data.Component.Amount as Amount
+import Data.Country as Country
 import Data.Impact as Impact exposing (Impacts)
 import Data.Impact.Definition as Definition
 import Data.Process as Process exposing (Process)
@@ -61,7 +62,7 @@ suite =
                                                 -- access the second element
                                                 |> Maybe.andThen (.elements >> LE.getAt 1)
                                                 -- and its material process id
-                                                |> Maybe.map .material
+                                                |> Maybe.map (.material >> .id)
                                         )
                                     -- it should be equal to the one we swapped in
                                     |> Expect.equal (Ok (Just validMaterial.id))
@@ -130,7 +131,8 @@ suite =
                                     , quantity = 1
                                     , stage = Nothing
                                     }
-                                    |> Component.applyTransforms requirements.config
+                                    |> Component.applyTransforms requirements
+                                        Nothing
                                         Process.Kilogram
                                         (List.map Component.defaultExpandedTransform transforms)
                                     |> Result.withDefault Component.emptyResults
@@ -164,7 +166,8 @@ suite =
                                     , quantity = 1
                                     , stage = Nothing
                                     }
-                                    |> Component.applyTransforms requirements.config
+                                    |> Component.applyTransforms requirements
+                                        Nothing
                                         Process.Kilogram
                                         (List.map Component.defaultExpandedTransform transforms)
                                     |> Result.withDefault Component.emptyResults
@@ -181,7 +184,7 @@ suite =
                                         |> resetProcessElecAndHeat
                                         |> setProcessEcsImpact (Unit.impact 10)
                                     ]
-                                    |> Expect.within (Expect.Absolute 1) 10
+                                    |> Expect.within (Expect.Absolute 1) 33.4234
                                 )
                             , it "should add impacts when one transform is passed (including elec and heat)"
                                 (getTestEcsImpact
@@ -191,7 +194,7 @@ suite =
                                                 |> Impact.insertWithoutAggregateComputation Definition.Ecs (Unit.impact 10)
                                       }
                                     ]
-                                    |> Expect.within (Expect.Absolute 1) 420
+                                    |> Expect.within (Expect.Absolute 1) 443.14817633333337
                                 )
                             , it "should compute apply custom mix impacts when a transform step country is set"
                                 (let
@@ -207,7 +210,7 @@ suite =
                                             , quantity = 1
                                             , stage = Nothing
                                             }
-                                            |> Component.applyTransforms requirements.config Process.Kilogram steps
+                                            |> Component.applyTransforms requirements Nothing Process.Kilogram steps
                                             |> Result.withDefault Component.emptyResults
                                             |> extractEcsImpact
                                  in
@@ -241,14 +244,14 @@ suite =
                                     [ fading |> resetProcessElecAndHeat |> setProcessEcsImpact (Unit.impact 10)
                                     , fading |> resetProcessElecAndHeat |> setProcessEcsImpact (Unit.impact 20)
                                     ]
-                                    |> Expect.within (Expect.Absolute 1) 30
+                                    |> Expect.within (Expect.Absolute 1) 76.8468
                                 )
                             , it "should add impacts when multiple transforms are passed (including elec and heat)"
                                 (getTestEcsImpact
                                     [ fading |> setProcessEcsImpact (Unit.impact 10)
                                     , fading |> setProcessEcsImpact (Unit.impact 20)
                                     ]
-                                    |> Expect.within (Expect.Absolute 1) 849
+                                    |> Expect.within (Expect.Absolute 1) 896.2963526666667
                                 )
                             ]
                         , TestUtils.suiteFromResult "unit mismatch"
@@ -266,7 +269,8 @@ suite =
                                         , quantity = 1
                                         , stage = Nothing
                                         }
-                                        |> Component.applyTransforms requirements.config
+                                        |> Component.applyTransforms requirements
+                                            Nothing
                                             Process.CubicMeter
                                             [ Component.defaultExpandedTransform transformInKg ]
                                         |> Expect.equal (Err "Les procédés de transformation ne partagent pas la même unité que la matière source (m3)\u{00A0}: Moulage par injection (kg)")
@@ -286,7 +290,8 @@ suite =
                                     , quantity = 1
                                     , stage = Nothing
                                     }
-                                    |> Component.applyTransforms requirements.config
+                                    |> Component.applyTransforms requirements
+                                        Nothing
                                         Process.Kilogram
                                         (List.map Component.defaultExpandedTransform transforms)
                                     |> Result.withDefault Component.emptyResults
@@ -311,7 +316,7 @@ suite =
                                   it "should handle impacts+waste when applying transforms: impacts"
                                     (noElecAndNoHeat
                                         |> extractEcsImpact
-                                        |> Expect.within (Expect.Absolute 1) 120
+                                        |> Expect.within (Expect.Absolute 1) 155.13510000000002
                                     )
 
                                 -- (1kg * 0.5) * 0.5 == 0.25
@@ -337,7 +342,7 @@ suite =
                                 [ it "should handle impacts+waste when applying transforms: impacts"
                                     (withElecAndHeat
                                         |> extractEcsImpact
-                                        |> Expect.within (Expect.Absolute 1) 734
+                                        |> Expect.within (Expect.Absolute 1) 769.7222644999999
                                     )
                                 , it "should handle impacts+waste when applying transforms: mass"
                                     (withElecAndHeat
@@ -495,9 +500,8 @@ suite =
                                 |> Result.andThen
                                     (\cottonId ->
                                         Component.computeElementResults requirements
-                                            Nothing
                                             { amount = Amount.fromFloat 1
-                                            , material = cottonId
+                                            , material = { country = Nothing, id = cottonId }
 
                                             -- Note: weaving waste: 0.06253, fading: 0
                                             , transforms =
@@ -512,7 +516,7 @@ suite =
                                 [ it "should compute element impacts"
                                     (elementResults
                                         |> extractEcsImpact
-                                        |> Expect.within (Expect.Absolute 1) 2213
+                                        |> Expect.within (Expect.Absolute 1) 2261.3236957846225
                                     )
                                 , it "should compute element mass"
                                     (elementResults
@@ -529,16 +533,16 @@ suite =
                                 let
                                     results =
                                         { amount = Amount.fromFloat 1
-                                        , material = materialInCubicMeters.id
+                                        , material = { country = Nothing, id = materialInCubicMeters.id }
                                         , transforms = [ Component.defaultTransform transformInCubicMeters.id ]
                                         }
-                                            |> Component.computeElementResults requirements Nothing
+                                            |> Component.computeElementResults requirements
                                 in
                                 [ it "should compute impacts according on material unit"
                                     (results
                                         |> Result.map extractEcsImpact
                                         |> Result.withDefault 0
-                                        |> Expect.within (Expect.Absolute 1) 38342
+                                        |> Expect.within (Expect.Absolute 1) 69261.288
                                     )
                                 , it "should compute mass according on material unit"
                                     (results
@@ -555,10 +559,10 @@ suite =
                                 let
                                     results =
                                         { amount = Amount.fromFloat 1
-                                        , material = materialInCubicMeters.id
+                                        , material = { country = Nothing, id = materialInCubicMeters.id }
                                         , transforms = [ Component.defaultTransform transformInCubicMeters.id ]
                                         }
-                                            |> Component.computeElementResults requirements Nothing
+                                            |> Component.computeElementResults requirements
                                 in
                                 [ it "should compute complements impacts according on material unit"
                                     (results
@@ -678,6 +682,61 @@ suite =
                                         |> Expect.greaterThan 0
                                     )
                                 ]
+                            )
+                        , it "should decode legacy item country into custom element material country"
+                            ("""{
+                                    "country": "CN",
+                                    "quantity": 1,
+                                    "custom": {
+                                      "elements": [
+                                        {
+                                          "amount": 1,
+                                          "material": "17431e06-2973-516e-b043-be9ad405e4fb",
+                                          "transforms": []
+                                        }
+                                      ]
+                                    }
+                                  }"""
+                                |> decodeJsonThen Component.decodeItem
+                                    (\item ->
+                                        item.custom
+                                            |> Maybe.andThen (.elements >> LE.getAt 0)
+                                            |> Maybe.map (.material >> .country)
+                                            |> Result.fromMaybe "Missing custom element material country"
+                                    )
+                                |> Expect.equal (Ok (Just (Country.codeFromString "CN")))
+                            )
+                        , it "should include transport stage impacts when applying transforms"
+                            (case
+                                requirements.db.countries
+                                    |> Scope.anyOf [ requirements.scope ]
+                                    |> List.head
+                             of
+                                Nothing ->
+                                    Expect.fail "No country available in test scope"
+
+                                Just country ->
+                                    Process.idFromString "f0dbe27b-1e74-55d0-88a2-bda812441744"
+                                        |> Result.andThen
+                                            (\materialId ->
+                                                { amount = Amount.fromFloat 1
+                                                , material = { country = Just country.code, id = materialId }
+                                                , transforms =
+                                                    [ { id = fading.id
+                                                      , country = Just country.code
+                                                      }
+                                                    ]
+                                                }
+                                                    |> Component.computeElementResults requirements
+                                                    |> Result.map Component.extractItems
+                                                    |> Result.map
+                                                        (List.any
+                                                            (\(Component.Results { stage }) ->
+                                                                stage == Just Component.TransportStage
+                                                            )
+                                                        )
+                                            )
+                                        |> Expect.equal (Ok True)
                             )
                         ]
                     , describe "computeVolumeFromMass"
@@ -901,8 +960,7 @@ suite =
                                     |> Expect.equal
                                         (Ok <|
                                             Just
-                                                { country = Nothing
-                                                , custom = Nothing
+                                                { custom = Nothing
                                                 , id = testComponent.id
                                                 , quantity = Component.quantityFromInt 1
                                                 }
@@ -930,7 +988,7 @@ suite =
                                                 -- access the first element
                                                 |> Maybe.andThen (.elements >> LE.getAt 0)
                                                 -- and its material process id
-                                                |> Maybe.map .material
+                                                |> Maybe.map (.material >> .id)
                                         )
                                     -- it should be equal to the one we swapped in
                                     |> Expect.equal (Ok (Just validTestProcess.id))
@@ -980,11 +1038,18 @@ suite =
                                     |> Expect.greaterThan 0
                                 )
                             , it "should have total stages impacts equal total impacts"
-                                ([ stagesImpacts.materials, stagesImpacts.transform ]
+                                ([ stagesImpacts.materials, stagesImpacts.transform, stagesImpacts.transports ]
                                     |> List.filterMap identity
                                     |> Impact.sumImpacts
                                     |> getEcsImpact
-                                    |> Expect.within (Expect.Absolute 1) (extractEcsImpact lifeCycle.production)
+                                    |> Expect.within (Expect.Absolute 1)
+                                        (Impact.sumImpacts
+                                            [ Component.extractImpacts lifeCycle.production
+                                            , lifeCycle.transports.toAssembly.impacts
+                                            , lifeCycle.transports.toDistribution.impacts
+                                            ]
+                                            |> getEcsImpact
+                                        )
                                 )
                             ]
                         )

--- a/tests/Data/ComponentTest.elm
+++ b/tests/Data/ComponentTest.elm
@@ -752,28 +752,6 @@ suite =
                                     )
                             )
                             (Expect.equal (Just (Country.codeFromString "CN")))
-                        , it "should decode legacy item country into custom element material country"
-                            ("""{
-                                  "country": "CN",
-                                  "quantity": 1,
-                                  "custom": {
-                                    "elements": [
-                                      {
-                                        "amount": 1,
-                                        "material": "17431e06-2973-516e-b043-be9ad405e4fb",
-                                        "transforms": []
-                                      }
-                                    ]
-                                  }
-                                }"""
-                                |> decodeJsonThen Component.decodeItem
-                                    (.custom
-                                        >> Maybe.andThen (.elements >> LE.getAt 0)
-                                        >> Maybe.map (.material >> .country)
-                                        >> Result.fromMaybe "Missing custom element material country"
-                                    )
-                                |> Expect.equal (Ok (Just (Country.codeFromString "CN")))
-                            )
                         , itFromResult "should decode an item with a custom transform country override"
                             ("""{
                                   "quantity": 1,

--- a/tests/Data/ComponentTest.elm
+++ b/tests/Data/ComponentTest.elm
@@ -134,7 +134,7 @@ suite =
                                     |> Component.applyTransforms requirements
                                         Nothing
                                         Process.Kilogram
-                                        (List.map Component.nonExpandedLocalizedProcess transforms)
+                                        (List.map Component.nonLocalizedExpandedProcess transforms)
                                     |> Result.withDefault Component.emptyResults
                                     |> Component.extractMass
                                     |> Mass.inKilograms
@@ -169,7 +169,7 @@ suite =
                                     |> Component.applyTransforms requirements
                                         Nothing
                                         Process.Kilogram
-                                        (List.map Component.nonExpandedLocalizedProcess transforms)
+                                        (List.map Component.nonLocalizedExpandedProcess transforms)
                                     |> Result.withDefault Component.emptyResults
                                     |> extractEcsImpact
                           in
@@ -232,7 +232,7 @@ suite =
                                     Ok country ->
                                         let
                                             ( defaultImpact, localizedImpact ) =
-                                                ( getImpact [ Component.nonExpandedLocalizedProcess fading ]
+                                                ( getImpact [ Component.nonLocalizedExpandedProcess fading ]
                                                 , getImpact [ { country = Just country, process = fading } ]
                                                 )
                                         in
@@ -272,7 +272,7 @@ suite =
                                         |> Component.applyTransforms requirements
                                             Nothing
                                             Process.CubicMeter
-                                            [ Component.nonExpandedLocalizedProcess transformInKg ]
+                                            [ Component.nonLocalizedExpandedProcess transformInKg ]
                                         |> Expect.equal (Err "Les procédés de transformation ne partagent pas la même unité que la matière source (m3)\u{00A0}: Moulage par injection (kg)")
                                     )
                                 ]
@@ -293,7 +293,7 @@ suite =
                                     |> Component.applyTransforms requirements
                                         Nothing
                                         Process.Kilogram
-                                        (List.map Component.nonExpandedLocalizedProcess transforms)
+                                        (List.map Component.nonLocalizedExpandedProcess transforms)
                                     |> Result.withDefault Component.emptyResults
                           in
                           describe "impacts & waste"
@@ -685,18 +685,18 @@ suite =
                             )
                         , it "should decode legacy item country into custom element material country"
                             ("""{
-                                    "country": "CN",
-                                    "quantity": 1,
-                                    "custom": {
-                                      "elements": [
-                                        {
-                                          "amount": 1,
-                                          "material": "17431e06-2973-516e-b043-be9ad405e4fb",
-                                          "transforms": []
-                                        }
-                                      ]
-                                    }
-                                  }"""
+                                  "country": "CN",
+                                  "quantity": 1,
+                                  "custom": {
+                                    "elements": [
+                                      {
+                                        "amount": 1,
+                                        "material": "17431e06-2973-516e-b043-be9ad405e4fb",
+                                        "transforms": []
+                                      }
+                                    ]
+                                  }
+                                }"""
                                 |> decodeJsonThen Component.decodeItem
                                     (\item ->
                                         item.custom

--- a/tests/Data/ComponentTest.elm
+++ b/tests/Data/ComponentTest.elm
@@ -96,7 +96,7 @@ suite =
                                                 -- and its material process id
                                                 |> Maybe.map .transforms
                                         )
-                                    |> Expect.equal (Ok (Just [ Component.defaultTransform validTransformProcess.id ]))
+                                    |> Expect.equal (Ok (Just [ Component.nonLocalizedProcess validTransformProcess.id ]))
                                 )
                             , it "should reject an invalid transformation process"
                                 (chair
@@ -134,7 +134,7 @@ suite =
                                     |> Component.applyTransforms requirements
                                         Nothing
                                         Process.Kilogram
-                                        (List.map Component.defaultExpandedLocalizedProcess transforms)
+                                        (List.map Component.nonExpandedLocalizedProcess transforms)
                                     |> Result.withDefault Component.emptyResults
                                     |> Component.extractMass
                                     |> Mass.inKilograms
@@ -169,7 +169,7 @@ suite =
                                     |> Component.applyTransforms requirements
                                         Nothing
                                         Process.Kilogram
-                                        (List.map Component.defaultExpandedLocalizedProcess transforms)
+                                        (List.map Component.nonExpandedLocalizedProcess transforms)
                                     |> Result.withDefault Component.emptyResults
                                     |> extractEcsImpact
                           in
@@ -232,7 +232,7 @@ suite =
                                     Ok country ->
                                         let
                                             ( defaultImpact, localizedImpact ) =
-                                                ( getImpact [ Component.defaultExpandedLocalizedProcess fading ]
+                                                ( getImpact [ Component.nonExpandedLocalizedProcess fading ]
                                                 , getImpact [ { country = Just country, process = fading } ]
                                                 )
                                         in
@@ -272,7 +272,7 @@ suite =
                                         |> Component.applyTransforms requirements
                                             Nothing
                                             Process.CubicMeter
-                                            [ Component.defaultExpandedLocalizedProcess transformInKg ]
+                                            [ Component.nonExpandedLocalizedProcess transformInKg ]
                                         |> Expect.equal (Err "Les procédés de transformation ne partagent pas la même unité que la matière source (m3)\u{00A0}: Moulage par injection (kg)")
                                     )
                                 ]
@@ -293,7 +293,7 @@ suite =
                                     |> Component.applyTransforms requirements
                                         Nothing
                                         Process.Kilogram
-                                        (List.map Component.defaultExpandedLocalizedProcess transforms)
+                                        (List.map Component.nonExpandedLocalizedProcess transforms)
                                     |> Result.withDefault Component.emptyResults
                           in
                           describe "impacts & waste"
@@ -505,8 +505,8 @@ suite =
 
                                             -- Note: weaving waste: 0.06253, fading: 0
                                             , transforms =
-                                                [ Component.defaultTransform weaving.id
-                                                , Component.defaultTransform fading.id
+                                                [ Component.nonLocalizedProcess weaving.id
+                                                , Component.nonLocalizedProcess fading.id
                                                 ]
                                             }
                                     )
@@ -534,7 +534,7 @@ suite =
                                     results =
                                         { amount = Amount.fromFloat 1
                                         , material = { country = Nothing, id = materialInCubicMeters.id }
-                                        , transforms = [ Component.defaultTransform transformInCubicMeters.id ]
+                                        , transforms = [ Component.nonLocalizedProcess transformInCubicMeters.id ]
                                         }
                                             |> Component.computeElementResults requirements
                                 in
@@ -560,7 +560,7 @@ suite =
                                     results =
                                         { amount = Amount.fromFloat 1
                                         , material = { country = Nothing, id = materialInCubicMeters.id }
-                                        , transforms = [ Component.defaultTransform transformInCubicMeters.id ]
+                                        , transforms = [ Component.nonLocalizedProcess transformInCubicMeters.id ]
                                         }
                                             |> Component.computeElementResults requirements
                                 in

--- a/tests/Data/ComponentTest.elm
+++ b/tests/Data/ComponentTest.elm
@@ -195,7 +195,7 @@ suite =
                                         |> resetProcessElecAndHeat
                                         |> setProcessEcsImpact (Unit.impact 10)
                                     ]
-                                    |> Expect.within (Expect.Absolute 1) 33.4234
+                                    |> Expect.within (Expect.Absolute 1) 33
                                 )
                             , it "should add impacts when one transform is passed (including elec and heat)"
                                 (getTestEcsImpact
@@ -205,7 +205,7 @@ suite =
                                                 |> Impact.insertWithoutAggregateComputation Definition.Ecs (Unit.impact 10)
                                       }
                                     ]
-                                    |> Expect.within (Expect.Absolute 1) 443.14817633333337
+                                    |> Expect.within (Expect.Absolute 1) 443
                                 )
                             , it "should compute apply custom mix impacts when a transform step country is set"
                                 (let
@@ -255,14 +255,14 @@ suite =
                                     [ fading |> resetProcessElecAndHeat |> setProcessEcsImpact (Unit.impact 10)
                                     , fading |> resetProcessElecAndHeat |> setProcessEcsImpact (Unit.impact 20)
                                     ]
-                                    |> Expect.within (Expect.Absolute 1) 76.8468
+                                    |> Expect.within (Expect.Absolute 1) 76
                                 )
                             , it "should add impacts when multiple transforms are passed (including elec and heat)"
                                 (getTestEcsImpact
                                     [ fading |> setProcessEcsImpact (Unit.impact 10)
                                     , fading |> setProcessEcsImpact (Unit.impact 20)
                                     ]
-                                    |> Expect.within (Expect.Absolute 1) 896.2963526666667
+                                    |> Expect.within (Expect.Absolute 1) 896
                                 )
                             ]
                         , suiteFromResult "unit mismatch"
@@ -527,7 +527,7 @@ suite =
                                 [ it "should compute element impacts"
                                     (elementResults
                                         |> extractEcsImpact
-                                        |> Expect.within (Expect.Absolute 1) 2261.3236957846225
+                                        |> Expect.within (Expect.Absolute 1) 2261
                                     )
                                 , it "should compute element mass"
                                     (elementResults
@@ -553,7 +553,7 @@ suite =
                                     (results
                                         |> Result.map extractEcsImpact
                                         |> Result.withDefault 0
-                                        |> Expect.within (Expect.Absolute 1) 69261.288
+                                        |> Expect.within (Expect.Absolute 1) 69261
                                     )
                                 , it "should compute mass according on material unit"
                                     (results

--- a/tests/Data/ComponentTest.elm
+++ b/tests/Data/ComponentTest.elm
@@ -21,7 +21,18 @@ import Quantity
 import Result.Extra as RE
 import Static.Db exposing (Db)
 import Test exposing (..)
-import TestUtils exposing (expectResultErrorContains, it, suiteWithDb)
+import TestUtils
+    exposing
+        ( expectResultErrorContains
+        , it
+        , itFromResult
+        , itFromResult2
+        , suiteFromResult
+        , suiteFromResult2
+        , suiteFromResult3
+        , suiteFromResult4
+        , suiteWithDb
+        )
 import Volume
 
 
@@ -39,17 +50,17 @@ suite =
                 db =
                     setupTestDb originalDb
             in
-            [ TestUtils.suiteFromResult "setupRequirements"
+            [ suiteFromResult "setupRequirements"
                 (createTestRequirements db)
                 (\requirements ->
-                    [ TestUtils.suiteFromResult3 "addElement"
+                    [ suiteFromResult3 "addElement"
                         -- setup
                         chairBack
                         steel
                         injectionMoulding
                         -- tests
                         (\testComponent validMaterial invalidMaterial ->
-                            [ it "should add a new element using a valid material"
+                            [ itFromResult "should add a new element using a valid material"
                                 (chair
                                     |> Result.andThen (Component.addElement ( testComponent, 1 ) validMaterial)
                                     |> Result.map
@@ -64,9 +75,9 @@ suite =
                                                 -- and its material process id
                                                 |> Maybe.map (.material >> .id)
                                         )
-                                    -- it should be equal to the one we swapped in
-                                    |> Expect.equal (Ok (Just validMaterial.id))
                                 )
+                                -- it should be equal to the one we swapped in
+                                (Expect.equal (Just validMaterial.id))
                             , it "should reject an invalid element material"
                                 (chair
                                     |> Result.andThen (Component.addElement ( testComponent, 1 ) invalidMaterial)
@@ -74,14 +85,14 @@ suite =
                                 )
                             ]
                         )
-                    , TestUtils.suiteFromResult3 "addElementTransform"
+                    , suiteFromResult3 "addElementTransform"
                         -- setup
                         chairBack
                         injectionMoulding
                         wood
                         -- tests
                         (\testComponent validTransformProcess invalidTransformProcess ->
-                            [ it "should add a valid transformation process to a component element"
+                            [ itFromResult "should add a valid transformation process to a component element"
                                 (chair
                                     |> Result.andThen (Component.addElementTransform ( ( testComponent, 1 ), 0 ) validTransformProcess)
                                     |> Result.map
@@ -96,8 +107,8 @@ suite =
                                                 -- and its material process id
                                                 |> Maybe.map .transforms
                                         )
-                                    |> Expect.equal (Ok (Just [ Component.nonLocalizedProcess validTransformProcess.id ]))
                                 )
+                                (Expect.equal (Just [ Component.nonLocalizedProcess validTransformProcess.id ]))
                             , it "should reject an invalid transformation process"
                                 (chair
                                     |> Result.andThen (Component.addElementTransform ( ( testComponent, 1 ), 0 ) invalidTransformProcess)
@@ -105,7 +116,7 @@ suite =
                                 )
                             ]
                         )
-                    , TestUtils.suiteFromResult "addItem"
+                    , suiteFromResult "addItem"
                         chairBack
                         (\testComponent ->
                             [ it "should allow adding the same component twice"
@@ -254,7 +265,7 @@ suite =
                                     |> Expect.within (Expect.Absolute 1) 896.2963526666667
                                 )
                             ]
-                        , TestUtils.suiteFromResult "unit mismatch"
+                        , suiteFromResult "unit mismatch"
                             injectionMoulding
                             (\transformInKg ->
                                 [ it "should reject when the unit of the material and the transforms do not match"
@@ -382,7 +393,7 @@ suite =
                                 |> Result.map (.production >> extractEcsImpact)
                                 |> TestUtils.expectResultWithin (Expect.Absolute 1) 282
                             )
-                        , TestUtils.suiteFromResult "distribution impacts"
+                        , suiteFromResult "distribution impacts"
                             -- setup
                             chair
                             -- tests
@@ -391,7 +402,7 @@ suite =
                                     requirementsDb =
                                         requirements.db
                                 in
-                                [ TestUtils.suiteFromResult "when no default distribution process is available"
+                                [ suiteFromResult "when no default distribution process is available"
                                     -- setup
                                     (chairItems
                                         |> computeItemsWithRequirements
@@ -422,7 +433,7 @@ suite =
                                             )
                                         ]
                                     )
-                                , TestUtils.suiteFromResult "when an explicit distribution process is specified"
+                                , suiteFromResult "when an explicit distribution process is specified"
                                     -- setup
                                     (requirementsDb.processes
                                         |> List.head
@@ -450,7 +461,7 @@ suite =
                                     )
                                     -- tests
                                     (\( testDistributionProcess, testRequirements ) ->
-                                        [ TestUtils.suiteFromResult "distribution result tests"
+                                        [ suiteFromResult "distribution result tests"
                                             (Component.emptyQuery
                                                 |> Component.setQueryItems chairItems
                                                 |> Component.updateDistribution (Just testDistributionProcess.id)
@@ -494,7 +505,7 @@ suite =
                             )
                         ]
                     , describe "computeElementResults"
-                        [ TestUtils.suiteFromResult "basic tests"
+                        [ suiteFromResult "basic tests"
                             -- setup
                             (Process.idFromString "f0dbe27b-1e74-55d0-88a2-bda812441744"
                                 |> Result.andThen
@@ -526,7 +537,7 @@ suite =
                                     )
                                 ]
                             )
-                        , TestUtils.suiteFromResult2 "unit preservation"
+                        , suiteFromResult2 "unit preservation"
                             wood
                             sawing
                             (\materialInCubicMeters transformInCubicMeters ->
@@ -552,7 +563,7 @@ suite =
                                     )
                                 ]
                             )
-                        , TestUtils.suiteFromResult2 "compute metadata complements"
+                        , suiteFromResult2 "compute metadata complements"
                             wood
                             sawing
                             (\materialInCubicMeters transformInCubicMeters ->
@@ -651,7 +662,7 @@ suite =
                          ]
                         )
                     , describe "computeTransports"
-                        [ TestUtils.suiteFromResult2 "unknown locations"
+                        [ suiteFromResult2 "unknown locations"
                             -- setup
                             ("""[{ "id": "ad9d7f23-076b-49c5-93a4-ee1cd7b53973", "quantity": 1 }]"""
                                 |> decodeJsonThen (Decode.list Component.decodeItem) (computeItemsWithRequirements requirements)
@@ -683,33 +694,26 @@ suite =
                                     )
                                 ]
                             )
-                        , it "should include transport stage impacts when applying transforms"
-                            (case
-                                requirements.db.countries
-                                    |> Scope.anyOf [ requirements.scope ]
-                                    |> List.head
-                                    |> Result.fromMaybe "No country available in test scope"
-                             of
-                                Err error ->
-                                    Expect.fail error
-
-                                Ok country ->
-                                    Process.idFromString "f0dbe27b-1e74-55d0-88a2-bda812441744"
-                                        |> Result.andThen
-                                            (\materialId ->
-                                                { amount = Amount.fromFloat 1
-                                                , material = { country = Just country.code, id = materialId }
-                                                , transforms =
-                                                    [ { id = fading.id
-                                                      , country = Just country.code
-                                                      }
-                                                    ]
-                                                }
-                                                    |> Component.computeElementResults requirements
-                                                    |> Result.map Component.extractItems
-                                                    |> Result.map (List.any (Component.extractStage >> (==) (Just Component.TransportStage)))
-                                            )
-                                        |> Expect.equal (Ok True)
+                        , itFromResult2 "should include transport stage impacts when applying transforms"
+                            (requirements.db.countries
+                                |> Scope.anyOf [ requirements.scope ]
+                                |> List.head
+                                |> Result.fromMaybe "No country available in test scope"
+                            )
+                            (Process.idFromString "f0dbe27b-1e74-55d0-88a2-bda812441744")
+                            (\country materialId ->
+                                { amount = Amount.fromFloat 1
+                                , material = { country = Just country.code, id = materialId }
+                                , transforms =
+                                    [ { id = fading.id
+                                      , country = Just country.code
+                                      }
+                                    ]
+                                }
+                                    |> Component.computeElementResults requirements
+                                    |> Result.map Component.extractItems
+                                    |> Result.map (List.any (Component.extractStage >> (==) (Just Component.TransportStage)))
+                                    |> Expect.equal (Ok True)
                             )
                         ]
                     , describe "computeVolumeFromMass"
@@ -725,7 +729,7 @@ suite =
                                 |> decodeJson Component.decodeItem
                                 |> Expect.ok
                             )
-                        , it "should decode an item with a custom material country override"
+                        , itFromResult "should decode an item with a custom material country override"
                             ("""{
                                   "quantity": 1,
                                   "custom": {
@@ -746,8 +750,8 @@ suite =
                                         >> Maybe.map (.material >> .country)
                                         >> Result.fromMaybe "Missing custom element material country"
                                     )
-                                |> Expect.equal (Ok (Just (Country.codeFromString "CN")))
                             )
+                            (Expect.equal (Just (Country.codeFromString "CN")))
                         , it "should decode legacy item country into custom element material country"
                             ("""{
                                   "country": "CN",
@@ -770,7 +774,7 @@ suite =
                                     )
                                 |> Expect.equal (Ok (Just (Country.codeFromString "CN")))
                             )
-                        , it "should decode an item with a custom transform country override"
+                        , itFromResult "should decode an item with a custom transform country override"
                             ("""{
                                   "quantity": 1,
                                   "custom": {
@@ -795,11 +799,10 @@ suite =
                                         >> Maybe.map .country
                                         >> Result.fromMaybe "Missing custom element transform country"
                                     )
-                                |> Expect.equal (Ok (Just (Country.codeFromString "CN")))
                             )
+                            (Expect.equal (Just (Country.codeFromString "CN")))
                         ]
-                    , TestUtils.suiteFromResult "itemToComponent"
-                        -- setup
+                    , suiteFromResult "itemToComponent"
                         ("""{ "id": "64fa65b3-c2df-4fd0-958b-83965bd6aa08",
                               "quantity": 1,
                               "custom": {
@@ -820,7 +823,6 @@ suite =
                                         |> Result.map (\component -> ( item.custom, component ))
                                 )
                         )
-                        -- tests
                         (\( maybeCustom, component ) ->
                             [ it "should merge custom item elements into a final component"
                                 (Expect.equal component.elements
@@ -833,8 +835,7 @@ suite =
                                 (Expect.equal component.name "custom name")
                             ]
                         )
-                    , TestUtils.suiteFromResult "itemToString with an existing component"
-                        -- setup
+                    , itFromResult "itemToString with an existing component"
                         (""" { "id": "64fa65b3-c2df-4fd0-958b-83965bd6aa08",
                                "quantity": 1,
                                "custom": {
@@ -852,15 +853,8 @@ suite =
                             }"""
                             |> decodeJsonThen Component.decodeItem (Component.itemToString db)
                         )
-                        -- tests
-                        (\string ->
-                            [ it "should serialise an item as a human readable string representation"
-                                (Expect.equal string
-                                    "1 Pied 70 cm (plein bois) [ 4,40e-4m3 Bois d'oeuvre (Feuillus / Hêtre) | 8,80e-4kg Plastique granulé (PP) ]"
-                                )
-                            ]
-                        )
-                    , TestUtils.suiteFromResult "itemToString with an existing component and a custom name"
+                        (Expect.equal "1 Pied 70 cm (plein bois) [ 4,40e-4m3 Bois d'oeuvre (Feuillus / Hêtre) | 8,80e-4kg Plastique granulé (PP) ]")
+                    , itFromResult "itemToString with an existing component and a custom name"
                         -- setup
                         (""" { "id": "64fa65b3-c2df-4fd0-958b-83965bd6aa08",
                                "quantity": 1,
@@ -880,16 +874,8 @@ suite =
                             }"""
                             |> decodeJsonThen Component.decodeItem (Component.itemToString db)
                         )
-                        -- tests
-                        (\string ->
-                            [ it "should serialise an item as a human readable string representation"
-                                (Expect.equal string
-                                    "1 Customized existing component [ 4,40e-4m3 Bois d'oeuvre (Feuillus / Hêtre) | 8,80e-4kg Plastique granulé (PP) ]"
-                                )
-                            ]
-                        )
-                    , TestUtils.suiteFromResult "itemToString with a new component"
-                        -- setup
+                        (Expect.equal "1 Customized existing component [ 4,40e-4m3 Bois d'oeuvre (Feuillus / Hêtre) | 8,80e-4kg Plastique granulé (PP) ]")
+                    , itFromResult "itemToString with a new component"
                         (""" { "quantity": 1,
                                "custom": {
                                  "name": "Custom new component",
@@ -907,15 +893,8 @@ suite =
                             }"""
                             |> decodeJsonThen Component.decodeItem (Component.itemToString db)
                         )
-                        -- tests
-                        (\string ->
-                            [ it "should serialise a new item without id as a human readable string representation"
-                                (Expect.equal string
-                                    "1 Custom new component [ 4,40e-4m3 Bois d'oeuvre (Feuillus / Hêtre) | 8,80e-4kg Plastique granulé (PP) ]"
-                                )
-                            ]
-                        )
-                    , TestUtils.suiteFromResult "getEndOfLifeDetailedImpacts"
+                        (Expect.equal "1 Custom new component [ 4,40e-4m3 Bois d'oeuvre (Feuillus / Hêtre) | 8,80e-4kg Plastique granulé (PP) ]")
+                    , suiteFromResult "getEndOfLifeDetailedImpacts"
                         -- setup
                         (chair
                             |> Result.andThen (computeItemsWithRequirements requirements)
@@ -972,15 +951,14 @@ suite =
                                 )
                             ]
                         )
-                    , TestUtils.suiteFromResult2 "removeElement"
+                    , suiteFromResult2 "removeElement"
                         -- setup
                         sofaFabric
                         steel
                         -- tests
                         (\testComponent material ->
-                            [ it "should remove an item element"
-                                (""" [ { "id": "8ca2ca05-8aec-4121-acaa-7cdcc03150a9", "quantity": 1 }
-                             ]"""
+                            [ itFromResult "should remove an item element"
+                                ("""[ { "id": "8ca2ca05-8aec-4121-acaa-7cdcc03150a9", "quantity": 1 } ]"""
                                     |> decodeJsonThen (Decode.list Component.decodeItem)
                                         (Component.addElement ( testComponent, 0 ) material
                                             >> Result.map (Component.removeElement ( ( testComponent, 0 ), 1 ))
@@ -995,39 +973,39 @@ suite =
                                                 -- get custom elements length
                                                 |> Maybe.map (.elements >> List.length)
                                         )
-                                    |> Expect.equal (Ok (Just 2))
                                 )
+                                (Expect.equal (Just 2))
                             ]
                         )
-                    , TestUtils.suiteFromResult2 "removeElementTransform"
+                    , suiteFromResult2 "removeElementTransform"
                         chairBack
                         injectionMoulding
                         -- tests
                         (\testComponent testProcess ->
-                            [ it "should remove an element transform"
+                            [ itFromResult "should remove an element transform"
                                 (chair
                                     |> Result.andThen (Component.addElementTransform ( ( testComponent, 1 ), 0 ) testProcess)
                                     |> Result.map (Component.removeElementTransform ( ( testComponent, 1 ), 0 ) 0)
                                     |> Result.map (LE.getAt 1)
-                                    |> Expect.equal
-                                        (Ok <|
-                                            Just
-                                                { custom = Nothing
-                                                , id = testComponent.id
-                                                , quantity = Component.quantityFromInt 1
-                                                }
-                                        )
+                                )
+                                (Expect.equal
+                                    (Just
+                                        { custom = Nothing
+                                        , id = testComponent.id
+                                        , quantity = Component.quantityFromInt 1
+                                        }
+                                    )
                                 )
                             ]
                         )
-                    , TestUtils.suiteFromResult3 "setElementMaterial"
+                    , suiteFromResult3 "setElementMaterial"
                         -- setup
                         chairBack
                         steel
                         injectionMoulding
                         -- tests
                         (\testComponent validTestProcess invalidTestProcess ->
-                            [ it "should set a valid element material"
+                            [ itFromResult "should set a valid element material"
                                 (chair
                                     |> Result.andThen (Component.setElementMaterial ( ( testComponent, 1 ), 0 ) validTestProcess)
                                     |> Result.map
@@ -1042,9 +1020,9 @@ suite =
                                                 -- and its material process id
                                                 |> Maybe.map (.material >> .id)
                                         )
-                                    -- it should be equal to the one we swapped in
-                                    |> Expect.equal (Ok (Just validTestProcess.id))
                                 )
+                                -- it should be equal to the one we swapped in
+                                (Expect.equal (Just validTestProcess.id))
                             , it "should reject an invalid element material"
                                 (chair
                                     |> Result.andThen (Component.setElementMaterial ( ( testComponent, 1 ), 0 ) invalidTestProcess)
@@ -1052,7 +1030,7 @@ suite =
                                 )
                             ]
                         )
-                    , TestUtils.suiteFromResult "stagesImpacts"
+                    , suiteFromResult "stagesImpacts"
                         ("""{
                               "components": [
                                 { "id": "8ca2ca05-8aec-4121-acaa-7cdcc03150a9", "quantity": 1 }
@@ -1105,7 +1083,7 @@ suite =
                                 )
                             ]
                         )
-                    , TestUtils.suiteFromResult "setCustomScope"
+                    , suiteFromResult "setCustomScope"
                         -- setup
                         ("""{ "id": "8ca2ca05-8aec-4121-acaa-7cdcc03150a9", "quantity": 1 }"""
                             |> decodeJson Component.decodeItem
@@ -1148,14 +1126,13 @@ suite =
                                 )
                             ]
                         )
-                    , TestUtils.suiteFromResult "updateItemCustomName"
+                    , suiteFromResult "updateItemCustomName"
                         -- setup
                         sofaFabric
                         -- tests
                         (\testComponent ->
-                            [ it "should set a custom name to a component item"
-                                (""" [ { "id": "8ca2ca05-8aec-4121-acaa-7cdcc03150a9", "quantity": 1 }
-                             ]"""
+                            [ itFromResult "should set a custom name to a component item"
+                                (""" [ { "id": "8ca2ca05-8aec-4121-acaa-7cdcc03150a9", "quantity": 1 } ]"""
                                     |> decodeJsonThen (Decode.list Component.decodeItem)
                                         (Component.updateItemCustomName ( testComponent, 0 ) "My custom component" >> Ok)
                                     |> Result.map
@@ -1165,9 +1142,9 @@ suite =
                                                 |> Maybe.andThen .custom
                                                 |> Maybe.andThen .name
                                         )
-                                    |> Expect.equal (Ok (Just "My custom component"))
                                 )
-                            , it "should trim a custom item name when serializing it"
+                                (Expect.equal (Just "My custom component"))
+                            , itFromResult "should trim a custom item name when serializing it"
                                 (""" [ { "id": "8ca2ca05-8aec-4121-acaa-7cdcc03150a9", "quantity": 1 } ]"""
                                     |> decodeJsonThen (Decode.list Component.decodeItem)
                                         (Component.updateItemCustomName ( testComponent, 0 ) " My custom component " >> Ok)
@@ -1180,8 +1157,8 @@ suite =
                                                 |> Maybe.andThen .custom
                                                 |> Maybe.andThen .name
                                         )
-                                    |> Expect.equal (Ok (Just "My custom component"))
                                 )
+                                (Expect.equal (Just "My custom component"))
                             ]
                         )
                     , describe "validateItem"
@@ -1198,7 +1175,7 @@ suite =
                                 |> expectResultErrorContains "Aucun composant avec id="
                             )
                         ]
-                    , TestUtils.suiteFromResult4 "validateQuery"
+                    , suiteFromResult4 "validateQuery"
                         -- Non-existing process
                         (Process.idFromString "5fad4e70-5736-552d-a686-97e4fb627c37")
                         -- Steel process

--- a/tests/Data/ComponentTest.elm
+++ b/tests/Data/ComponentTest.elm
@@ -207,48 +207,43 @@ suite =
                                     ]
                                     |> Expect.within (Expect.Absolute 1) 443
                                 )
-                            , it "should compute apply custom mix impacts when a transform step country is set"
-                                (let
-                                    getImpact steps =
-                                        Component.Results
-                                            { amount = Amount.fromFloat 1
-                                            , complementsImpacts = Complement.emptyComplementsResultsImpacts
-                                            , impacts = Impact.empty
-                                            , items = []
-                                            , label = Nothing
-                                            , mass = Mass.kilogram
-                                            , materialType = Nothing
-                                            , quantity = 1
-                                            , stage = Nothing
-                                            }
-                                            |> Component.applyTransforms requirements Nothing Process.Kilogram steps
-                                            |> Result.withDefault Component.emptyResults
-                                            |> extractEcsImpact
-                                 in
-                                 case
-                                    -- fetch first country with mixes different from defaults
-                                    requirements.db.countries
-                                        |> Scope.anyOf [ requirements.scope ]
-                                        |> List.filter
-                                            (\{ electricityProcess, heatProcess } ->
-                                                (electricityProcess /= requirements.config.production.defaultElecProcess)
-                                                    || (heatProcess /= requirements.config.production.defaultHeatProcess)
-                                            )
-                                        |> List.head
-                                        |> Result.fromMaybe "No country found with mixes different from defaults"
-                                 of
-                                    Err error ->
-                                        Expect.fail error
+                            , itFromResult "should compute apply custom mix impacts when a transform step country is set"
+                                -- fetch first country with mixes different from defaults
+                                (requirements.db.countries
+                                    |> Scope.anyOf [ requirements.scope ]
+                                    |> List.filter
+                                        (\{ electricityProcess, heatProcess } ->
+                                            (electricityProcess /= requirements.config.production.defaultElecProcess)
+                                                || (heatProcess /= requirements.config.production.defaultHeatProcess)
+                                        )
+                                    |> List.head
+                                    |> Result.fromMaybe "No country found with mixes different from defaults"
+                                )
+                                (\country ->
+                                    let
+                                        getImpact steps =
+                                            Component.Results
+                                                { amount = Amount.fromFloat 1
+                                                , complementsImpacts = Complement.emptyComplementsResultsImpacts
+                                                , impacts = Impact.empty
+                                                , items = []
+                                                , label = Nothing
+                                                , mass = Mass.kilogram
+                                                , materialType = Nothing
+                                                , quantity = 1
+                                                , stage = Nothing
+                                                }
+                                                |> Component.applyTransforms requirements Nothing Process.Kilogram steps
+                                                |> Result.withDefault Component.emptyResults
+                                                |> extractEcsImpact
 
-                                    Ok country ->
-                                        let
-                                            ( defaultImpact, localizedImpact ) =
-                                                ( getImpact [ Component.nonLocalizedExpandedProcess fading ]
-                                                , getImpact [ { country = Just country, process = fading } ]
-                                                )
-                                        in
-                                        abs (defaultImpact - localizedImpact)
-                                            |> Expect.greaterThan 0.00001
+                                        ( defaultImpact, localizedImpact ) =
+                                            ( getImpact [ Component.nonLocalizedExpandedProcess fading ]
+                                            , getImpact [ { country = Just country, process = fading } ]
+                                            )
+                                    in
+                                    abs (defaultImpact - localizedImpact)
+                                        |> Expect.greaterThan 0.00001
                                 )
                             , it "should add impacts when multiple transforms are passed (no elec, no heat)"
                                 (getTestEcsImpact
@@ -362,6 +357,64 @@ suite =
                                         |> Expect.within (Expect.Absolute 0.01) 0.25
                                     )
                                 ]
+                            ]
+                        , describe "transports" <|
+                            let
+                                extractTransportStagesCount kind results =
+                                    results
+                                        |> Component.extractItems
+                                        |> List.filter (Component.extractStage >> (==) (Just kind))
+                                        |> List.length
+
+                                extractStages results =
+                                    results
+                                        |> Component.extractItems
+                                        |> List.filterMap Component.extractStage
+
+                                getResults localizedTransforms =
+                                    Component.Results
+                                        { amount = Amount.fromFloat 1
+                                        , complementsImpacts = Complement.emptyComplementsResultsImpacts
+                                        , impacts = Impact.empty
+                                        , items = []
+                                        , label = Nothing
+                                        , mass = Mass.kilogram
+                                        , materialType = Nothing
+                                        , quantity = 1
+                                        , stage = Nothing
+                                        }
+                                        |> Component.applyTransforms requirements
+                                            Nothing
+                                            Process.Kilogram
+                                            localizedTransforms
+                                        |> Result.withDefault Component.emptyResults
+                            in
+                            [ it "should add one transport stage per transform step"
+                                (getResults
+                                    [ Component.nonLocalizedExpandedProcess fading
+                                    , Component.nonLocalizedExpandedProcess fading
+                                    ]
+                                    |> extractTransportStagesCount Component.TransportStage
+                                    |> Expect.equal 2
+                                )
+                            , it "should add no transport stage when no transform is applied"
+                                (getResults []
+                                    |> extractTransportStagesCount Component.TransportStage
+                                    |> Expect.equal 0
+                                )
+                            , it "should insert transport before each transform stage"
+                                (getResults
+                                    [ Component.nonLocalizedExpandedProcess fading
+                                    , Component.nonLocalizedExpandedProcess fading
+                                    ]
+                                    |> extractStages
+                                    |> Expect.equal
+                                        [ Component.TransportStage
+                                        , Component.TransformStage
+                                        , Component.TransportStage
+                                        , Component.TransformStage
+                                        ]
+                                )
                             ]
                         ]
                     , describe "compute"

--- a/tests/Server/RouteTest.elm
+++ b/tests/Server/RouteTest.elm
@@ -272,8 +272,7 @@ textileEndpoints db =
                                 { query
                                     | trims =
                                         Just
-                                            [ { country = Nothing
-                                              , custom = Nothing
+                                            [ { custom = Nothing
                                               , id = Just nonExistentId
                                               , quantity = Component.quantityFromInt 1
                                               }
@@ -296,8 +295,7 @@ textileEndpoints db =
                                 { query
                                     | trims =
                                         Just
-                                            [ { country = Nothing
-                                              , custom = Nothing
+                                            [ { custom = Nothing
                                               , id = Just id
                                               , quantity = Component.quantityFromInt -1
                                               }

--- a/tests/TestUtils.elm
+++ b/tests/TestUtils.elm
@@ -5,6 +5,8 @@ module TestUtils exposing
     , expectResultErrorContains
     , expectResultWithin
     , it
+    , itFromResult
+    , itFromResult2
     , jupeCotonAsie
     , suiteFromResult
     , suiteFromResult2
@@ -41,6 +43,26 @@ asTest =
 it : String -> Expectation -> Test
 it label =
     always >> test label
+
+
+itFromResult : String -> Result String a -> (a -> Expectation) -> Test
+itFromResult label result fn =
+    case result of
+        Ok value ->
+            it label (fn value)
+
+        Err error ->
+            it (label ++ " setup result failure") (Expect.fail error)
+
+
+itFromResult2 : String -> Result String a -> Result String b -> (a -> b -> Expectation) -> Test
+itFromResult2 label result1 result2 fn =
+    case Result.map2 fn result1 result2 of
+        Ok expectation ->
+            it label expectation
+
+        Err error ->
+            it (label ++ " setup result failure") (Expect.fail error)
 
 
 suiteFromResult : String -> Result String a -> (a -> List Test) -> Test


### PR DESCRIPTION
## :wrench: Problem

Fixes #1958
Fixes #1960

## :cake: Solution

It's now possible to select a region per material and transform element steps:

<img width="2747" height="1894" alt="image" src="https://github.com/user-attachments/assets/ce05be66-8ac0-4663-a9ad-79c8d72f1510" />

## :rotating_light:  Points to watch/comments

Yes, the patch is huge, but also is the complexity of the feature. I couldn't see how to split the implementation in smaller, "easily" reviewable chunks, sorry for that.

Also, I've refactored the ComponentTest.elm suite to leverage new test helpers, which creates a bit of noise but helped me a lot covering the cases; again, sorry for that but I think it's for the best.

## :desert_island: How to test

Toy around with the new UI and probably sum things up as a control check to see if I didn't miss anything. Also, I've added a bunch of unit tests so most of the critical behaviors should be covered.