### PR TITLE
feat(generic): reassign compatible transforms on material update

### DIFF
--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -101,7 +101,6 @@ module Data.Component exposing
     , updateConsumptionAmount
     , updateDistribution
     , updateDurability
-    , updateElement
     , updateElementAmount
     , updateElementMaterialCountry
     , updateElementTransformCountry
@@ -408,11 +407,11 @@ addItem maybeId items =
     items ++ [ createItem maybeId ]
 
 
-addOrSetProcess : Category -> TargetItem -> Maybe Index -> Process -> List Item -> Result String (List Item)
-addOrSetProcess category targetItem maybeElementIndex process items =
+addOrSetProcess : DataContainer db -> Category -> TargetItem -> Maybe Index -> Process -> List Item -> Result String (List Item)
+addOrSetProcess db category targetItem maybeElementIndex process items =
     case ( category, maybeElementIndex ) of
         ( Category.Material, Just elementIndex ) ->
-            items |> setElementMaterial ( targetItem, elementIndex ) process
+            items |> setElementMaterial db ( targetItem, elementIndex ) process
 
         ( Category.Material, Nothing ) ->
             items |> addElement targetItem process
@@ -1969,8 +1968,8 @@ setCustomScope component scope item =
     }
 
 
-setElementMaterial : TargetElement -> Process -> List Item -> Result String (List Item)
-setElementMaterial targetElement material items =
+setElementMaterial : DataContainer db -> TargetElement -> Process -> List Item -> Result String (List Item)
+setElementMaterial db targetElement material items =
     if not <| List.member Category.Material material.categories then
         Err "Seuls les procédés de catégorie `material` sont mobilisables comme matière"
 
@@ -1978,11 +1977,32 @@ setElementMaterial targetElement material items =
         items
             |> updateElement targetElement
                 (\el ->
+                    let
+                        materialType =
+                            List.head (Process.getMaterialTypes material)
+                    in
                     { el
-                        | material = nonLocalizedProcess material.id
+                      -- preserve initial material country
+                        | material = { country = el.material.country, id = material.id }
 
-                        -- Note: always reset the transforms when replacing a material for consistency
-                        , transforms = []
+                        -- preserve compatible transforms
+                        , transforms =
+                            el.transforms
+                                |> List.map
+                                    (\localizedProcess ->
+                                        db.processes
+                                            |> Process.findById localizedProcess.id
+                                            |> Result.map (\fullProcess -> ( localizedProcess, fullProcess ))
+                                    )
+                                |> RE.combine
+                                |> Result.map
+                                    (List.filter
+                                        (\( _, transform ) ->
+                                            materialType /= Nothing && List.head (Process.getMaterialTypes transform) == materialType
+                                        )
+                                    )
+                                |> Result.map (List.map Tuple.first)
+                                |> Result.withDefault []
                     }
                 )
             |> Ok

--- a/src/Page/Admin/Component.elm
+++ b/src/Page/Admin/Component.elm
@@ -392,7 +392,7 @@ selectProcess category (( component, _ ) as targetItem) maybeElementIndex autoco
         Just process ->
             case
                 [ item ]
-                    |> Component.addOrSetProcess category targetItem maybeElementIndex process
+                    |> Component.addOrSetProcess session.db category targetItem maybeElementIndex process
                     |> Result.andThen (List.head >> Result.fromMaybe "Pas d'élément résultant")
             of
                 Err err ->

--- a/src/Page/Object.elm
+++ b/src/Page/Object.elm
@@ -647,11 +647,7 @@ update ({ navKey } as session) msg model =
 
         ( UpdateElementAmount targetElement (Just amount), _ ) ->
             createPageUpdate session model
-                |> updateQuery
-                    (query
-                        |> Component.mapItems
-                            (Component.updateElement targetElement (\el -> { el | amount = amount }))
-                    )
+                |> updateQuery (query |> Component.mapItems (Component.updateElementAmount targetElement amount))
 
         ( UpdateElementMaterialCountry targetElement maybeCountryCode, _ ) ->
             createPageUpdate session model
@@ -808,13 +804,13 @@ selectProcess :
     -> Component.Query
     -> PageUpdate Model Msg
     -> PageUpdate Model Msg
-selectProcess category targetItem maybeElementIndex autocompleteState query ({ model } as pageUpdate) =
+selectProcess category targetItem maybeElementIndex autocompleteState query ({ model, session } as pageUpdate) =
     case Autocomplete.selectedValue autocompleteState of
         Just process ->
             case
                 query
                     |> Component.tryMapItems
-                        (Component.addOrSetProcess category targetItem maybeElementIndex process)
+                        (Component.addOrSetProcess session.db category targetItem maybeElementIndex process)
             of
                 Err err ->
                     pageUpdate |> App.notifyError "Erreur" err

--- a/tests/Data/ComponentTest.elm
+++ b/tests/Data/ComponentTest.elm
@@ -1175,7 +1175,7 @@ suite =
                         (\testComponent validTestProcess invalidTestProcess ->
                             [ itFromResult "should set a valid element material"
                                 (chair
-                                    |> Result.andThen (Component.setElementMaterial ( ( testComponent, 1 ), 0 ) validTestProcess)
+                                    |> Result.andThen (Component.setElementMaterial requirements.db ( ( testComponent, 1 ), 0 ) validTestProcess)
                                     |> Result.map
                                         (\items ->
                                             items
@@ -1193,7 +1193,7 @@ suite =
                                 (Expect.equal (Just validTestProcess.id))
                             , it "should reject an invalid element material"
                                 (chair
-                                    |> Result.andThen (Component.setElementMaterial ( ( testComponent, 1 ), 0 ) invalidTestProcess)
+                                    |> Result.andThen (Component.setElementMaterial requirements.db ( ( testComponent, 1 ), 0 ) invalidTestProcess)
                                     |> expectResultErrorContains "Seuls les procédés de catégorie `material` sont mobilisables comme matière"
                                 )
                             ]


### PR DESCRIPTION
## :wrench: Problem

Fixes #2212

## :cake: Solution

Preserve compatible element transforms when switching materials

## :desert_island: How to test

Try updating the material of an element with transforms applied, and if the material is the same material type, transforms should be preserved in the list (same with the country).