### PR TITLE
fix: textile complements

### DIFF
--- a/src/Data/Complement.elm
+++ b/src/Data/Complement.elm
@@ -179,7 +179,7 @@ impactsWithComplements complementsImpacts impacts =
         ecsWithComplements =
             Impact.getImpact Definition.Ecs impacts
                 -- Reminder: substracting a malus — a.k.a negative complement — adds to the total impact
-                |> Quantity.minus complementsImpact
+                |> Quantity.plus complementsImpact
     in
     impacts
         |> Impact.insertWithoutAggregateComputation Definition.Ecs ecsWithComplements

--- a/src/Data/Textile/Inputs.elm
+++ b/src/Data/Textile/Inputs.elm
@@ -487,10 +487,10 @@ getOutOfEuropeEOLComplement { mass, materials } =
     let
         impact =
             Unit.impact
-                -(Split.toFloat (getOutOfEuropeEOLProbability materials)
+                (Split.toFloat (getOutOfEuropeEOLProbability materials)
                     * Mass.inKilograms mass
                     * 5000
-                 )
+                )
     in
     if impact == Unit.noImpacts then
         Nothing

--- a/src/Data/Textile/Inputs.elm
+++ b/src/Data/Textile/Inputs.elm
@@ -483,7 +483,6 @@ getOutOfEuropeEOLProbability materialInputs =
 
 getOutOfEuropeEOLComplement : Inputs -> Maybe Unit.Impact
 getOutOfEuropeEOLComplement { mass, materials } =
-    -- Note: this complement is a malus, hence the minus sign
     let
         impact =
             Unit.impact

--- a/src/Data/Textile/Material/Origin.elm
+++ b/src/Data/Textile/Material/Origin.elm
@@ -54,20 +54,19 @@ toMicrofibersComplement : Origin -> Unit.Impact
 toMicrofibersComplement origin =
     -- see https://fabrique-numerique.gitbook.io/ecobalyse/textile/complements-hors-acv/microfibres
     -- Notes:
-    -- - this is a malus expressed as a negative Pts/kg impact
     -- - the float value corresponds to Ref(f) * 1000 to ease applying the formula
     case origin of
         ArtificialFromOrganic ->
-            Unit.impact -330
+            Unit.impact 330
 
         NaturalFromAnimal ->
-            Unit.impact -390
+            Unit.impact 390
 
         NaturalFromVegetal ->
-            Unit.impact -250
+            Unit.impact 250
 
         Synthetic ->
-            Unit.impact -820
+            Unit.impact 820
 
 
 toLabel : Origin -> String

--- a/src/Data/Textile/Simulator.elm
+++ b/src/Data/Textile/Simulator.elm
@@ -851,7 +851,7 @@ toStagesImpacts trigram simulator =
         applyComplement complementImpact =
             if trigram == Definition.Ecs then
                 Maybe.map
-                    (Quantity.minus
+                    (Quantity.plus
                         (complementImpact
                             |> Maybe.withDefault Unit.noImpacts
                             |> Quantity.multiplyBy (Unit.floatDurabilityFromHolistic simulator.durability)

--- a/tests/Data/Textile/InputsTest.elm
+++ b/tests/Data/Textile/InputsTest.elm
@@ -53,7 +53,7 @@ suite =
                     "should compute OutOfEuropeEOL complement impact for a fully natural garment"
                     tShirtCotonFrance
                     (\tshirtCotonFrance_ ->
-                        [ testComplementEqual -41.65 tshirtCotonFrance_
+                        [ testComplementEqual 41.65 tshirtCotonFrance_
                             |> asTest "compute OutOfEuropeEOL complement impact for a fully natural garment"
                         ]
                     )
@@ -77,7 +77,7 @@ suite =
                                   }
                                 ]
                           }
-                            |> testComplementEqual -102.85
+                            |> testComplementEqual 102.85
                             |> asTest "compute OutOfEuropeEOL complement impact for a half-natural, half-synthetic garment"
                         ]
                     )
@@ -94,7 +94,7 @@ suite =
                     "should compute Microfibers complement impact for a fully natural garment"
                     tShirtCotonFrance
                     (\tShirtCotonFrance_ ->
-                        [ testComplementEqual -42.5 tShirtCotonFrance_
+                        [ testComplementEqual 42.5 tShirtCotonFrance_
                             |> asTest "compute Microfibers complement impact for a fully natural garment"
                         ]
                     )
@@ -118,7 +118,7 @@ suite =
                                   }
                                 ]
                           }
-                            |> testComplementEqual -90.95
+                            |> testComplementEqual 90.95
                             |> asTest "compute Microfibers complement impact for a half-natural, half-synthetic garment"
                         ]
                     )

--- a/tests/Data/Textile/SimulatorTest.elm
+++ b/tests/Data/Textile/SimulatorTest.elm
@@ -68,7 +68,7 @@ suite =
                         [ { query
                             | countrySpinning = Nothing
                           }
-                            |> expectImpact db ecs 1039.49
+                            |> expectImpact db ecs 1290.7
                             |> asTest "compute a simulation ecs impact"
                         ]
                     )

--- a/tests/Data/Textile/SimulatorTest.elm
+++ b/tests/Data/Textile/SimulatorTest.elm
@@ -68,7 +68,7 @@ suite =
                         [ { query
                             | countrySpinning = Nothing
                           }
-                            |> expectImpact db ecs 1290.7
+                            |> expectImpact db ecs 1039.49
                             |> asTest "compute a simulation ecs impact"
                         ]
                     )


### PR DESCRIPTION
## :wrench: Problem

Textile complements are subtracted instead of being added.

## :cake: Solution

Invert the signs of the complements values


## :rotating_light:  Points to watch/comments

> _If there is anything unusual or some clarifications needed for the reviewer to better understand the PR, discuss it here._

## :desert_island: How to test

> TODO
