### PR TITLE
chore: add processes_generic to ecobalyse_data sync

### DIFF
--- a/bin/check-ecobalyse-data-sync.sh
+++ b/bin/check-ecobalyse-data-sync.sh
@@ -20,6 +20,7 @@ FILES=(
     "public/data/food/ingredients.json"
     "public/data/textile/materials.json"
     "public/data/processes.json"
+    "public/data/processes_generic.json"
 )
 
 echo "Downloading files from ecobalyse-data repository (branch: ${ECOBALYSE_DATA_BRANCH})..."


### PR DESCRIPTION
## :wrench: Problem

`processes_generic.json` is not in gh workflow ecobalyse-data sync so we can't see the diff on this file between data and main repo


## :cake: Solution

add it 