### PR TITLE
feat(generic): handle distance to hub

### DIFF
--- a/public/data/components/config.json
+++ b/public/data/components/config.json
@@ -203,7 +203,7 @@
   "transports": {
     "defaultDistance": {
       "air": 10000,
-      "road": null,
+      "road": 2000,
       "sea": 18000
     },
     "modeProcesses": {

--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -538,12 +538,7 @@ applyTransforms requirements transportCooling initialCountry unit transforms mat
                             (\mixes ->
                                 results
                                     |> applyTransportedMassImpacts requirements transportCooling (extractMass results) previousCountry country
-                                    |> Result.map
-                                        (\res ->
-                                            ( country
-                                            , applyTransform process mixes res
-                                            )
-                                        )
+                                    |> Result.map (\results_ -> ( country, applyTransform process mixes results_ ))
                             )
                 )
                 ( initialCountry, materialResults )
@@ -867,7 +862,8 @@ computeShareImpacts mass { process, split } =
         |> Maybe.withDefault Impact.empty
 
 
-{-| Computes the transport distance between two countries, including the distance to hub for each country.
+{-| Computes the transport distance between two countries, including the road distance to hub for each country.
+Fallbacks to default config distances in case a country is not defined.
 
 Notes:
 
@@ -883,24 +879,21 @@ computeTransportDistance { config, db } maybeFrom maybeTo =
                 |> Transport.getTransportBetween2 from to
                 |> Result.map
                     (\transport ->
-                        if from == to then
-                            -- same country, add transport to hub once
-                            { transport
-                                | road =
+                        { transport
+                            | road =
+                                if from == to then
+                                    -- same country, add transport to hub once
                                     transport.road
                                         |> Quantity.plus from.distanceToHub
-                            }
 
-                        else
-                            -- different countries, add distances to hub at both ends
-                            { transport
-                                | road =
+                                else
+                                    -- different countries, add distances to hub at both ends
                                     Quantity.sum
                                         [ from.distanceToHub
                                         , transport.road
                                         , to.distanceToHub
                                         ]
-                            }
+                        }
                     )
 
         _ ->

--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -873,7 +873,7 @@ computeTransportDistance { config, db } maybeFrom maybeTo =
     case ( maybeFrom, maybeTo ) of
         ( Just from, Just to ) ->
             db.distances
-                |> Transport.getTransportBetween Impact.empty from.code to.code
+                |> Transport.getTransportBetween2 Impact.empty from to
 
         _ ->
             config.transports.defaultDistance

--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -876,7 +876,7 @@ computeTransportDistance { config, db } maybeFrom maybeTo =
     case ( maybeFrom, maybeTo ) of
         ( Just from, Just to ) ->
             db.distances
-                |> Transport.getTransportBetween2 from to
+                |> Transport.getTransportBetween from to
                 |> Result.map
                     (\transport ->
                         { transport

--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -872,8 +872,7 @@ computeTransportDistance : Requirements db -> Maybe Country -> Maybe Country -> 
 computeTransportDistance { config, db } maybeFrom maybeTo =
     case ( maybeFrom, maybeTo ) of
         ( Just from, Just to ) ->
-            db.distances
-                |> Transport.getTransportBetween2 Impact.empty from to
+            db.distances |> Transport.getTransportBetween2 from to
 
         _ ->
             config.transports.defaultDistance

--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -533,13 +533,16 @@ applyTransforms requirements transportCooling initialCountry unit transforms mat
             (RE.foldlWhileOk
                 (\{ country, process } ( previousCountry, results ) ->
                     loadEnergyMixes requirements.config country
-                        |> Result.map
+                        |> Result.andThen
                             (\mixes ->
-                                ( country
-                                , results
+                                results
                                     |> applyTransportedMassImpacts requirements transportCooling (extractMass results) previousCountry country
-                                    |> applyTransform process mixes
-                                )
+                                    |> Result.map
+                                        (\res ->
+                                            ( country
+                                            , applyTransform process mixes res
+                                            )
+                                        )
                             )
                 )
                 ( initialCountry, materialResults )
@@ -550,30 +553,30 @@ applyTransforms requirements transportCooling initialCountry unit transforms mat
 {-| Add transport impacts for a mass and two optional countries to a results, falling back to transport config
 defaults when both are unknown.
 -}
-applyTransportedMassImpacts : Requirements db -> TransportCooling -> Mass -> Maybe Country -> Maybe Country -> Results -> Results
+applyTransportedMassImpacts : Requirements db -> TransportCooling -> Mass -> Maybe Country -> Maybe Country -> Results -> Result String Results
 applyTransportedMassImpacts requirements transportCooling mass maybeFrom maybeTo (Results results) =
-    let
-        transport =
-            computeTransportedMassImpacts requirements transportCooling maybeFrom maybeTo mass
-    in
-    Results
-        { results
-            | impacts = Impact.sumImpacts [ results.impacts, transport.impacts ]
-            , items =
-                results.items
-                    ++ [ Results
-                            { amount = results.amount
-                            , complementsImpacts = Complement.emptyComplementsResultsImpacts
-                            , impacts = transport.impacts
-                            , items = []
-                            , label = Just "Transport"
-                            , mass = mass
-                            , materialType = Nothing
-                            , quantity = 1
-                            , stage = Just TransportStage
-                            }
-                       ]
-        }
+    computeTransportedMassImpacts requirements transportCooling maybeFrom maybeTo mass
+        |> Result.map
+            (\transport ->
+                Results
+                    { results
+                        | impacts = Impact.sumImpacts [ results.impacts, transport.impacts ]
+                        , items =
+                            results.items
+                                ++ [ Results
+                                        { amount = results.amount
+                                        , complementsImpacts = Complement.emptyComplementsResultsImpacts
+                                        , impacts = transport.impacts
+                                        , items = []
+                                        , label = Just "Transport"
+                                        , mass = mass
+                                        , materialType = Nothing
+                                        , quantity = 1
+                                        , stage = Just TransportStage
+                                        }
+                                   ]
+                    }
+            )
 
 
 applyWaste : Split -> Amount -> Amount
@@ -868,13 +871,14 @@ computeShareImpacts mass { process, split } =
 Note: this only computes the transport distances, not the impacts (as a transported mass would be required)
 
 -}
-computeTransportDistance : Requirements db -> Maybe Country -> Maybe Country -> Transport
+computeTransportDistance : Requirements db -> Maybe Country -> Maybe Country -> Result String Transport
 computeTransportDistance { config, db } maybeFrom maybeTo =
     case ( maybeFrom, maybeTo ) of
         ( Just from, Just to ) ->
             db.distances
                 |> Transport.getTransportBetween2 from to
-                |> (\transport ->
+                |> Result.map
+                    (\transport ->
                         if from == to then
                             -- same country, add transport to hub once
                             { transport
@@ -893,26 +897,28 @@ computeTransportDistance { config, db } maybeFrom maybeTo =
                                         , to.distanceToHub
                                         ]
                             }
-                   )
+                    )
 
         _ ->
-            config.transports.defaultDistance
+            Ok config.transports.defaultDistance
 
 
 {-| Computes the transport distances and impacts from a transported mass.
 -}
-computeTransportedMassImpacts : Requirements db -> TransportCooling -> Maybe Country -> Maybe Country -> Mass -> Transport
+computeTransportedMassImpacts : Requirements db -> TransportCooling -> Maybe Country -> Maybe Country -> Mass -> Result String Transport
 computeTransportedMassImpacts ({ config } as requirements) (TransportCooling cooled) maybeFrom maybeTo mass =
     computeTransportDistance requirements maybeFrom maybeTo
         -- Note: air transport is not handled for now
-        |> Transport.applyTransportRatios Split.zero
-        |> (if cooled then
-                Transport.makeCooled
+        |> Result.map
+            (Transport.applyTransportRatios Split.zero
+                >> (if cooled then
+                        Transport.makeCooled
 
-            else
-                identity
-           )
-        |> Transport.computeImpacts config.transports.modeProcesses mass
+                    else
+                        identity
+                   )
+            )
+        |> Result.map (Transport.computeImpacts config.transports.modeProcesses mass)
 
 
 {-| Computes transports impacts:
@@ -928,111 +934,86 @@ computeTransportedMassImpacts ({ config } as requirements) (TransportCooling coo
 computeTransports : Requirements db -> Query -> LifeCycle -> Result String LifeCycle
 computeTransports ({ config, db } as requirements) query lifeCycle =
     Result.map2
-        (\expandedItems maybeAssemblyCountry ->
+        (\resultedElements maybeAssemblyCountry ->
             let
-                resultedElements =
-                    getResultedElementList lifeCycle.production expandedItems
+                distributionCountry =
+                    Just config.distribution.country
 
                 totalProductMass =
                     extractMass lifeCycle.production
+
+                transportElements fn =
+                    resultedElements
+                        |> List.map fn
+                        |> RE.combine
+                        |> Result.map Transport.sum
+
+                transportImpacts =
+                    computeTransportedMassImpacts requirements query.transportCooling
+
+                setLifeCycleTransports toAssembly toDistribution =
+                    { lifeCycle | transports = LifeCycleTransport toAssembly toDistribution }
             in
-            case ( expandedItems, maybeAssemblyCountry ) of
-                ( [], Just _ ) ->
+            case ( List.length query.items, maybeAssemblyCountry ) of
+                ( 0, Just _ ) ->
                     Err "Une liste de composants vide ne peut être assemblée"
 
-                ( [ _ ], Just _ ) ->
+                ( 1, Just _ ) ->
                     Err "Un composant unique ne peut pas être assemblé"
 
                 -- Many components assembled; for all components, each elements are individually shipped to assembly,
                 -- then the assembled product mass is transported to distribution
-                ( _ :: _ :: _, Just assemblyCountry ) ->
-                    resultedElements
-                        |> Result.map
-                            (List.map
-                                (\( expandedElement, elementResults ) ->
-                                    extractMass elementResults
-                                        |> computeTransportedMassImpacts requirements
-                                            query.transportCooling
-                                            (getFinalElementCountry expandedElement)
-                                            (Just assemblyCountry)
-                                )
-                                >> Transport.sum
+                ( _, Just assemblyCountry ) ->
+                    Result.map2 setLifeCycleTransports
+                        -- toAssembly
+                        (transportElements
+                            (\( expandedElement, elementResults ) ->
+                                extractMass elementResults
+                                    |> transportImpacts (getFinalElementCountry expandedElement) (Just assemblyCountry)
                             )
-                        |> Result.map
-                            (\toAssembly ->
-                                { lifeCycle
-                                    | transports =
-                                        { toAssembly = toAssembly
-                                        , toDistribution =
-                                            totalProductMass
-                                                |> computeTransportedMassImpacts requirements
-                                                    query.transportCooling
-                                                    maybeAssemblyCountry
-                                                    (Just config.distribution.country)
-                                        }
-                                }
-                            )
+                        )
+                        -- toDistribution
+                        (totalProductMass
+                            |> transportImpacts maybeAssemblyCountry distributionCountry
+                        )
 
                 -- Default state, empty transports
-                ( [], Nothing ) ->
+                ( 0, Nothing ) ->
                     Ok { lifeCycle | transports = emptyLifeCycleTransports }
 
                 -- Single unique component; its elements are directly shipped to distribution individually,
                 -- with no transport to assembly stage
-                ( [ _ ], Nothing ) ->
-                    resultedElements
-                        |> Result.map
-                            (List.map
-                                (\( expandedElement, elementResults ) ->
-                                    extractMass elementResults
-                                        |> computeTransportedMassImpacts requirements
-                                            query.transportCooling
-                                            (getFinalElementCountry expandedElement)
-                                            (Just config.distribution.country)
-                                )
-                                >> Transport.sum
+                ( 1, Nothing ) ->
+                    Result.map2 setLifeCycleTransports
+                        -- toAssembly
+                        (Ok Transport.noTransport)
+                        -- toDistribution
+                        (transportElements
+                            (\( expandedElement, elementResults ) ->
+                                extractMass elementResults
+                                    |> transportImpacts (getFinalElementCountry expandedElement) distributionCountry
                             )
-                        |> Result.map
-                            (\toDistribution ->
-                                { lifeCycle
-                                    | transports = { emptyLifeCycleTransports | toDistribution = toDistribution }
-                                }
-                            )
+                        )
 
                 -- Many items with no assembly country specified; all item elements are individually shipped to
                 -- the assembly stage unique default unknown transport distances,
                 -- then the total mass of the assembled end product is transported to distribution country
-                ( _ :: _ :: _, Nothing ) ->
-                    resultedElements
-                        |> Result.map
-                            (List.map
-                                (\( _, elementResults ) ->
-                                    -- all item elements are individually shipped to the assembly stage using default unknown transport distances
-                                    extractMass elementResults
-                                        |> computeTransportedMassImpacts requirements
-                                            query.transportCooling
-                                            Nothing
-                                            Nothing
-                                )
-                                >> Transport.sum
+                ( _, Nothing ) ->
+                    Result.map2 setLifeCycleTransports
+                        -- toAssembly
+                        (transportElements
+                            (\( _, elementResults ) ->
+                                -- all item elements are individually shipped to the assembly stage using default unknown transport distances
+                                extractMass elementResults
+                                    |> transportImpacts Nothing Nothing
                             )
-                        |> Result.map
-                            (\toAssemblyTransport ->
-                                { lifeCycle
-                                    | transports =
-                                        { toAssembly = toAssemblyTransport
-                                        , toDistribution =
-                                            -- total mass of the assembled end product is transported to the distribution country
-                                            totalProductMass
-                                                |> computeTransportedMassImpacts requirements
-                                                    query.transportCooling
-                                                    Nothing
-                                                    (Just config.distribution.country)
-                                        }
-                                }
-                            )
+                        )
+                        -- toDistribution
+                        (totalProductMass
+                            |> transportImpacts Nothing distributionCountry
+                        )
         )
-        (expandItems db query.items)
+        (query.items |> expandItems db |> Result.andThen (getResultedElementList lifeCycle.production))
         (Country.resolveMaybe query.assemblyCountry db.countries)
         |> RE.join
 

--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -872,7 +872,28 @@ computeTransportDistance : Requirements db -> Maybe Country -> Maybe Country -> 
 computeTransportDistance { config, db } maybeFrom maybeTo =
     case ( maybeFrom, maybeTo ) of
         ( Just from, Just to ) ->
-            db.distances |> Transport.getTransportBetween2 from to
+            db.distances
+                |> Transport.getTransportBetween2 from to
+                |> (\transport ->
+                        if from == to then
+                            -- same country, add transport to hub once
+                            { transport
+                                | road =
+                                    transport.road
+                                        |> Quantity.plus from.distanceToHub
+                            }
+
+                        else
+                            -- different countries, add distances to hub at both ends
+                            { transport
+                                | road =
+                                    Quantity.sum
+                                        [ from.distanceToHub
+                                        , transport.road
+                                        , to.distanceToHub
+                                        ]
+                            }
+                   )
 
         _ ->
             config.transports.defaultDistance

--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -866,9 +866,12 @@ computeShareImpacts mass { process, split } =
         |> Maybe.withDefault Impact.empty
 
 
-{-| Computes the transport distance between two countries.
+{-| Computes the transport distance between two countries, including the distance to hub for each country.
 
-Note: this only computes the transport distances, not the impacts (as a transported mass would be required)
+Notes:
+
+  - this only computes the transport distances, not the impacts (as a transported mass would be required)
+  - the distance to hub computation logic should eventually be backported to non-generic scopes
 
 -}
 computeTransportDistance : Requirements db -> Maybe Country -> Maybe Country -> Result String Transport

--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -34,6 +34,7 @@ module Data.Component exposing
     , computeInitialAmount
     , computeItemResults
     , computeScoring
+    , computeTransportDistance
     , computeTransportedMassImpacts
     , computeVolumeFromMass
     , createItem

--- a/src/Data/Country.elm
+++ b/src/Data/Country.elm
@@ -27,6 +27,7 @@ import Json.Decode as Decode exposing (Decoder)
 import Json.Decode.Extra as DE
 import Json.Decode.Pipeline as Pipe
 import Json.Encode as Encode
+import Length exposing (Length)
 
 
 type Code
@@ -43,6 +44,7 @@ type alias Country =
     { aquaticPollutionScenario : AquaticPollutionScenario
     , code : Code
     , comment : Maybe String
+    , distanceToHub : Length
     , electricityProcess : Process
     , heatProcess : Process
     , name : String
@@ -74,6 +76,7 @@ decode processes =
         |> Pipe.required "aquaticPollutionScenario" decodeAquaticPollutionScenario
         |> Pipe.required "code" decodeCode
         |> DU.strictOptional "comment" Decode.string
+        |> DU.strictOptionalWithDefault "distanceToHub" (Decode.map Length.kilometers Decode.float) (Length.kilometers 0)
         |> Pipe.required "electricityProcessId" (Process.decodeFromId processes)
         |> Pipe.required "heatProcessId" (Process.decodeFromId processes)
         |> Pipe.required "name" Decode.string

--- a/src/Data/Food/Recipe.elm
+++ b/src/Data/Food/Recipe.elm
@@ -374,7 +374,7 @@ computeIngredientTransportForCountry db planeTransport { code } =
 
     else
         db.distances
-            |> Transport.getTransportBetween emptyImpacts code france
+            |> Transport.getTransportBetweenLegacy emptyImpacts code france
             |> Transport.applyTransportRatios planeRatio
             -- For some regions we should always add 2000kms of road
             -- See https://github.com/MTES-MCT/ecobalyse/issues/1982

--- a/src/Data/Textile/Inputs.elm
+++ b/src/Data/Textile/Inputs.elm
@@ -511,7 +511,7 @@ computeMaterialTransport distances nextCountryCode { country, material, share } 
                     |> Maybe.withDefault material.defaultCountry
         in
         distances
-            |> Transport.getTransportBetween emptyImpacts countryCode nextCountryCode
+            |> Transport.getTransportBetweenLegacy emptyImpacts countryCode nextCountryCode
 
     else
         Transport.default Impact.empty

--- a/src/Data/Textile/Stage.elm
+++ b/src/Data/Textile/Stage.elm
@@ -259,7 +259,7 @@ computeTransports db inputs next ({ processInfo } as current) =
 
             else
                 db.distances
-                    |> Transport.getTransportBetween current.transport.impacts current.country.code next.country.code
+                    |> Transport.getTransportBetweenLegacy current.transport.impacts current.country.code next.country.code
                     |> computeTransportSummary current
                     |> computeTransportImpacts current.transport.impacts
                         db.textile.wellKnown

--- a/src/Data/Transport.elm
+++ b/src/Data/Transport.elm
@@ -242,9 +242,8 @@ getTransportBetween impacts cA cB distances =
             erroneous impacts
 
 
-{-| Another version of getTransportBetween, leveraging the distance to hub to compute road
-distances to hub between to fully qualified Country records. Also get rids of the carried
-impacts. This function is to be used in the generic simulator context.
+{-| Another version of getTransportBetween, computing road distances to hub between to fully
+qualified Country records. This function is to be used in the generic simulator context.
 -}
 getTransportBetween2 : Country -> Country -> Distances -> Transport
 getTransportBetween2 cA cB distances =

--- a/src/Data/Transport.elm
+++ b/src/Data/Transport.elm
@@ -248,9 +248,9 @@ getTransportBetween impacts cA cB distances =
             erroneous impacts
 
 
-{-| Another version of getTransportBetween, computing road distances to hub between to fully
-qualified Country records, and returning a Result with an error when a distance couldn't be found.
-This function is to be used in the generic simulator context.
+{-| Another version of getTransportBetween, returning a Result with an error when a distance
+couldn't be found.
+FIXME: the whole codebase should eventually be migrated to use this version.
 -}
 getTransportBetween2 : Country -> Country -> Distances -> Result String Transport
 getTransportBetween2 cA cB distances =

--- a/src/Data/Transport.elm
+++ b/src/Data/Transport.elm
@@ -13,7 +13,7 @@ module Data.Transport exposing
     , default
     , encode
     , getTransportBetween
-    , getTransportBetween2
+    , getTransportBetweenLegacy
     , makeCooled
     , noTransport
     , sum
@@ -231,8 +231,10 @@ roadSeaTransportRatio { road, sea } =
         Split.zero
 
 
-getTransportBetween : Impacts -> Country.Code -> Country.Code -> Distances -> Transport
-getTransportBetween impacts cA cB distances =
+{-| Deprecated, usage should be gradually replaced with getTransportBetween
+-}
+getTransportBetweenLegacy : Impacts -> Country.Code -> Country.Code -> Distances -> Transport
+getTransportBetweenLegacy impacts cA cB distances =
     case
         ( distances |> Dict.get cA |> Maybe.andThen (Dict.get cB)
         , distances |> Dict.get cB |> Maybe.andThen (Dict.get cA)
@@ -248,12 +250,12 @@ getTransportBetween impacts cA cB distances =
             erroneous impacts
 
 
-{-| Another version of getTransportBetween, returning a Result with an error when a distance
+{-| A newer version of getTransportBetweenLegacy, returning a Result with an error when a distance
 couldn't be found.
 FIXME: the whole codebase should eventually be migrated to use this version.
 -}
-getTransportBetween2 : Country -> Country -> Distances -> Result String Transport
-getTransportBetween2 cA cB distances =
+getTransportBetween : Country -> Country -> Distances -> Result String Transport
+getTransportBetween cA cB distances =
     case
         ( distances |> Dict.get cA.code |> Maybe.andThen (Dict.get cB.code)
         , distances |> Dict.get cB.code |> Maybe.andThen (Dict.get cA.code)

--- a/src/Data/Transport.elm
+++ b/src/Data/Transport.elm
@@ -15,6 +15,7 @@ module Data.Transport exposing
     , getTransportBetween
     , getTransportBetween2
     , makeCooled
+    , noTransport
     , sum
     , totalKm
     )
@@ -169,6 +170,11 @@ makeCooled transport =
     }
 
 
+noTransport : Transport
+noTransport =
+    default Impact.empty
+
+
 sum : List Transport -> Transport
 sum =
     List.foldl
@@ -243,9 +249,10 @@ getTransportBetween impacts cA cB distances =
 
 
 {-| Another version of getTransportBetween, computing road distances to hub between to fully
-qualified Country records. This function is to be used in the generic simulator context.
+qualified Country records, and returning a Result with an error when a distance couldn't be found.
+This function is to be used in the generic simulator context.
 -}
-getTransportBetween2 : Country -> Country -> Distances -> Transport
+getTransportBetween2 : Country -> Country -> Distances -> Result String Transport
 getTransportBetween2 cA cB distances =
     case
         ( distances |> Dict.get cA.code |> Maybe.andThen (Dict.get cB.code)
@@ -253,13 +260,17 @@ getTransportBetween2 cA cB distances =
         )
     of
         ( Just transport, _ ) ->
-            transport
+            Ok transport
 
         ( _, Just transport ) ->
-            transport
+            Ok transport
 
         ( Nothing, Nothing ) ->
-            erroneous Impact.empty
+            Err <|
+                "Distances not found between "
+                    ++ Country.codeToString cA.code
+                    ++ " to "
+                    ++ Country.codeToString cB.code
 
 
 decodeKm : Decoder Length

--- a/src/Data/Transport.elm
+++ b/src/Data/Transport.elm
@@ -242,24 +242,25 @@ getTransportBetween impacts cA cB distances =
             erroneous impacts
 
 
-{-| Same as getTransportBetween, but leverages the distance to hub to compute road
-distances to hub between to fully qualified Country records.
+{-| Another version of getTransportBetween, leveraging the distance to hub to compute road
+distances to hub between to fully qualified Country records. Also get rids of the carried
+impacts. This function is to be used in the generic simulator context.
 -}
-getTransportBetween2 : Impacts -> Country -> Country -> Distances -> Transport
-getTransportBetween2 impacts cA cB distances =
+getTransportBetween2 : Country -> Country -> Distances -> Transport
+getTransportBetween2 cA cB distances =
     case
         ( distances |> Dict.get cA.code |> Maybe.andThen (Dict.get cB.code)
         , distances |> Dict.get cB.code |> Maybe.andThen (Dict.get cA.code)
         )
     of
         ( Just transport, _ ) ->
-            { transport | impacts = impacts }
+            transport
 
         ( _, Just transport ) ->
-            { transport | impacts = impacts }
+            transport
 
         ( Nothing, Nothing ) ->
-            erroneous impacts
+            erroneous Impact.empty
 
 
 decodeKm : Decoder Length

--- a/src/Data/Transport.elm
+++ b/src/Data/Transport.elm
@@ -13,12 +13,13 @@ module Data.Transport exposing
     , default
     , encode
     , getTransportBetween
+    , getTransportBetween2
     , makeCooled
     , sum
     , totalKm
     )
 
-import Data.Country as Country
+import Data.Country as Country exposing (Country)
 import Data.Impact as Impact exposing (Impacts)
 import Data.Process as Process exposing (Process)
 import Data.Split as Split exposing (Split)
@@ -229,6 +230,26 @@ getTransportBetween impacts cA cB distances =
     case
         ( distances |> Dict.get cA |> Maybe.andThen (Dict.get cB)
         , distances |> Dict.get cB |> Maybe.andThen (Dict.get cA)
+        )
+    of
+        ( Just transport, _ ) ->
+            { transport | impacts = impacts }
+
+        ( _, Just transport ) ->
+            { transport | impacts = impacts }
+
+        ( Nothing, Nothing ) ->
+            erroneous impacts
+
+
+{-| Same as getTransportBetween, but leverages the distance to hub to compute road
+distances to hub between to fully qualified Country records.
+-}
+getTransportBetween2 : Impacts -> Country -> Country -> Distances -> Transport
+getTransportBetween2 impacts cA cB distances =
+    case
+        ( distances |> Dict.get cA.code |> Maybe.andThen (Dict.get cB.code)
+        , distances |> Dict.get cB.code |> Maybe.andThen (Dict.get cA.code)
         )
     of
         ( Just transport, _ ) ->

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -369,16 +369,21 @@ editorView : Config db msg -> Html msg
 editorView config =
     case config.lifeCycle of
         Err error ->
-            Alert.simple
-                { attributes = []
-                , close = Nothing
-                , content = [ text error ]
-                , level = Alert.Danger
-                , title = Just "Erreur de chargement du calculateur"
-                }
+            error |> simpleError (Just "Erreur de chargement du calculateur")
 
         Ok lifeCycle ->
             lifeCycleView config lifeCycle
+
+
+simpleError : Maybe String -> String -> Html msg
+simpleError title message =
+    Alert.simple
+        { attributes = []
+        , close = Nothing
+        , content = [ text message ]
+        , level = Alert.Danger
+        , title = title
+        }
 
 
 lifeCycleView : Config db msg -> LifeCycle -> Html msg
@@ -438,13 +443,7 @@ lifeCycleView ({ db, docsUrl, explorerRoute, impact, query, scope, title } as co
               else
                 case Component.expandItems db query.items of
                     Err error ->
-                        Alert.simple
-                            { attributes = []
-                            , close = Nothing
-                            , content = [ text error ]
-                            , level = Alert.Danger
-                            , title = Just "Erreur"
-                            }
+                        error |> simpleError (Just "Erreur")
 
                     Ok expandedItems ->
                         div [ class "table-responsive" ]
@@ -910,44 +909,52 @@ elementMaterialView config targetElement materialResults material amount =
 
 elementTransportView : Config db msg -> List (Attribute msg) -> Mass -> Maybe Country -> Maybe Country -> Html msg
 elementTransportView ({ query } as config) attributes transportedMass maybeFrom maybeTo =
-    let
-        transport =
-            transportedMass
-                |> Component.computeTransportedMassImpacts (requirementsFromConfig config)
-                    query.transportCooling
-                    maybeFrom
-                    maybeTo
+    case
+        transportedMass
+            |> Component.computeTransportedMassImpacts (requirementsFromConfig config)
+                query.transportCooling
+                maybeFrom
+                maybeTo
+    of
+        Err error ->
+            tr []
+                [ td [ class "p-2", colspan 7 ]
+                    [ error |> simpleError (Just "Erreur de calcul de distance")
+                    ]
+                ]
 
-        renderCountry =
-            Maybe.map .name >> Maybe.withDefault "Région inconnue"
-    in
-    tr (class "fs-7 text-muted" :: attributes)
-        [ td [ colspan 2 ] []
-        , td []
-            [ text <| "Transport " ++ renderCountry maybeFrom ++ " → " ++ renderCountry maybeTo ]
-        , td [ class "text-end align-middle d-flex justify-content-end align-items-center gap-2 text-nowrap" ] <|
-            (if Component.isTransportCooled query.transportCooling then
-                [ Icon.boatCooled, Format.km transport.seaCooled ]
+        Ok transport ->
+            let
+                renderCountry =
+                    Maybe.map .name >> Maybe.withDefault "Région inconnue"
+            in
+            tr (class "fs-7 text-muted" :: attributes)
+                [ td [ colspan 2 ] []
+                , td []
+                    [ text <| "Transport " ++ renderCountry maybeFrom ++ " → " ++ renderCountry maybeTo ]
+                , td [ class "text-end align-middle d-flex justify-content-end align-items-center gap-2 text-nowrap" ] <|
+                    (if Component.isTransportCooled query.transportCooling then
+                        [ Icon.boatCooled, Format.km transport.seaCooled ]
 
-             else
-                [ Icon.boat, Format.km transport.sea ]
-            )
-                ++ (if Component.isTransportCooled query.transportCooling then
-                        [ Icon.busCooled, Format.km transport.roadCooled ]
+                     else
+                        [ Icon.boat, Format.km transport.sea ]
+                    )
+                        ++ (if Component.isTransportCooled query.transportCooling then
+                                [ Icon.busCooled, Format.km transport.roadCooled ]
 
-                    else
-                        [ Icon.bus, Format.km transport.road ]
-                   )
-                ++ [ Icon.package
-                   , Format.kg transportedMass
-                   ]
-        , td [ colspan 2 ] []
-        , td [ class "text-end align-middle text-nowrap" ]
-            [ transport.impacts
-                |> Format.formatImpact config.impact
-            ]
-        , td [] []
-        ]
+                            else
+                                [ Icon.bus, Format.km transport.road ]
+                           )
+                        ++ [ Icon.package
+                           , Format.kg transportedMass
+                           ]
+                , td [ colspan 2 ] []
+                , td [ class "text-end align-middle text-nowrap" ]
+                    [ transport.impacts
+                        |> Format.formatImpact config.impact
+                    ]
+                , td [] []
+                ]
 
 
 elementTransformsView :

--- a/tests/Data/ComponentTest.elm
+++ b/tests/Data/ComponentTest.elm
@@ -938,15 +938,40 @@ suite =
                             )
                         ]
                     , suiteFromResult2 "computeTransportDistance"
-                        -- Note: exagerating distances to make this test resilient to future data updates
-                        (db.countries |> Country.findByCode (Country.Code "PT") |> Result.map (\c -> { c | distanceToHub = Length.kilometers 10000 }))
-                        (db.countries |> Country.findByCode (Country.Code "FR") |> Result.map (\c -> { c | distanceToHub = Length.kilometers 20000 }))
+                        (db.countries |> Country.findByCode (Country.Code "PT"))
+                        (db.countries |> Country.findByCode (Country.Code "FR"))
                         (\france portugal ->
-                            [ it "should"
+                            [ it "should compute distance between two countries"
                                 (Component.computeTransportDistance requirements (Just portugal) (Just france)
+                                    |> Result.map
+                                        (\{ air, road, sea } ->
+                                            ( Length.inKilometers air > 0
+                                            , Length.inKilometers road > 0
+                                            , Length.inKilometers sea > 0
+                                            )
+                                        )
+                                    |> Expect.equal (Ok ( True, True, True ))
+                                )
+                            , it "should compute distance between two countries accounting transport to hubs"
+                                (Component.computeTransportDistance requirements
+                                    -- Note: exagerating distances to hub, to make this test resilient to future data updates
+                                    (Just { portugal | distanceToHub = Length.kilometers 20000 })
+                                    (Just { france | distanceToHub = Length.kilometers 10000 })
                                     |> Result.map (.road >> Length.inKilometers)
                                     |> Result.withDefault 0
                                     |> Expect.greaterThan 30000
+                                )
+                            , it "should fallback to default distances when the country of departure is undefined"
+                                (Component.computeTransportDistance requirements Nothing (Just france)
+                                    |> Expect.equal (Ok requirements.config.transports.defaultDistance)
+                                )
+                            , it "should fallback to default distances when the destination country is undefined"
+                                (Component.computeTransportDistance requirements (Just portugal) Nothing
+                                    |> Expect.equal (Ok requirements.config.transports.defaultDistance)
+                                )
+                            , it "should fallback to default distances when neither countries are defined"
+                                (Component.computeTransportDistance requirements Nothing Nothing
+                                    |> Expect.equal (Ok requirements.config.transports.defaultDistance)
                                 )
                             ]
                         )

--- a/tests/Data/ComponentTest.elm
+++ b/tests/Data/ComponentTest.elm
@@ -15,6 +15,7 @@ import Dict.Any as AnyDict
 import Expect
 import Json.Decode as Decode exposing (Decoder)
 import Json.Encode as Encode
+import Length
 import List.Extra as LE
 import Mass
 import Quantity
@@ -936,6 +937,19 @@ suite =
                                     |> Expect.greaterThan noTransportCooling
                             )
                         ]
+                    , suiteFromResult2 "computeTransportDistance"
+                        -- Note: exagerating distances to make this test resilient to future data updates
+                        (db.countries |> Country.findByCode (Country.Code "PT") |> Result.map (\c -> { c | distanceToHub = Length.kilometers 10000 }))
+                        (db.countries |> Country.findByCode (Country.Code "FR") |> Result.map (\c -> { c | distanceToHub = Length.kilometers 20000 }))
+                        (\france portugal ->
+                            [ it "should"
+                                (Component.computeTransportDistance requirements (Just portugal) (Just france)
+                                    |> Result.map (.road >> Length.inKilometers)
+                                    |> Result.withDefault 0
+                                    |> Expect.greaterThan 30000
+                                )
+                            ]
+                        )
                     , describe "computeVolumeFromMass"
                         [ it "should compute a volume from a mass"
                             -- Remember, this is a temporary situation until we obtain volume per unit data in processes db

--- a/tests/Data/TransportTest.elm
+++ b/tests/Data/TransportTest.elm
@@ -5,7 +5,7 @@ import Data.Country as Country
 import Data.Impact as Impact
 import Data.Impact.Definition as Definition
 import Data.Split as Split exposing (Split)
-import Data.Transport as Transport exposing (Transport, getTransportBetween)
+import Data.Transport as Transport exposing (Transport, getTransportBetweenLegacy)
 import Data.Unit as Unit
 import Dict.Any as AnyDict
 import Expect
@@ -110,11 +110,11 @@ suite =
                 )
             , describe "getTransportBetween"
                 [ db.distances
-                    |> Transport.getTransportBetween Impact.empty (Country.Code "FR") (Country.Code "CN")
+                    |> Transport.getTransportBetweenLegacy Impact.empty (Country.Code "FR") (Country.Code "CN")
                     |> Expect.equal chinaToFrance
                     |> asTest "should retrieve distance between two countries"
                 , db.distances
-                    |> Transport.getTransportBetween Impact.empty (Country.Code "CN") (Country.Code "FR")
+                    |> Transport.getTransportBetweenLegacy Impact.empty (Country.Code "CN") (Country.Code "FR")
                     |> Expect.equal chinaToFrance
                     |> asTest "should retrieve distance between two swapped countries"
                 , db.countries
@@ -123,7 +123,7 @@ suite =
                     |> List.map
                         (\( cA, cB ) ->
                             db.distances
-                                |> getTransportBetween Impact.empty cA cB
+                                |> getTransportBetweenLegacy Impact.empty cA cB
                         )
                     |> List.filter
                         (\{ road, sea, air } ->


### PR DESCRIPTION
## :wrench: Problem

This is a preliminary implementation of a patch to fix #1531. 

## :cake: Solution

Before we even get the data, the patch assumes a new `distanceToHub` field will be added to each country in the `countries.json` file. Meaning data folks (@cedricr @paulboosz) can commit to this branch/PR the new data and the patch will render the appropriate computation in the deployed review app (well, that's the theory, let's see how it goes 🤣)

Edit: Now I've added tests, I'm pretty confident the patch can land as-is onto production, even without the data available (decoding marks distances to hub as optional).

## :rotating_light:  Points to watch/comments

- The distances to hub computation is implemented in the generic codebase only, in order to preserve legacy food (food1) scoring pristine as requested (added code comments accordingly)
- I still couldn't resist to start tackling a bit of tech debt in the generic engine codebase along the way, eg. by handling distances computation errors when a combination is missing the in matrix, hence the `getDistancesBetween2` function, which use of should be generalized in a future patch (the diff would be too large in this one)

## :desert_island: How to test

- If we want to wait for the data to be available in this branch, once they're in, check that the appropriate distances to hub are added to scores in the UI
- If we prefer landing this patch now so we can iterate further in parallel while the data are crafted and landed separately, review the implementation and tests