### PR TITLE
fix: only migrate auth

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -107,6 +107,9 @@ jobs:
     - name: Run client tests
       run: npm run test:client
 
+    - name: Run jslib tests
+      run: npm run test:jslib
+
     - name: Run server tests
       run: npm run test:server && npm run test:backend
 

--- a/lib/store.js
+++ b/lib/store.js
@@ -4,21 +4,28 @@ const stableVersionKey = "store";
 const ongoingVersionKey = "ecobalyse";
 
 function initializeStoreKey(localStorage = window.localStorage) {
-  if (
-    !localStorage[stableVersionKey] ||
-    (!JSON.parse(localStorage[stableVersionKey] || "{}")?.auth && localStorage[ongoingVersionKey])
+  if (localStorage[stableVersionKey] && !localStorage[ongoingVersionKey]) {
+    // Ongoing version store has never been initialized, while the stable version one has already
+    // => Initialize current storage with stable version session data
+    // Note: the ongoing version can always handle and parse old bookmark formats
+    localStorage[ongoingVersionKey] = localStorage[stableVersionKey];
+  } else if (
+    !JSON.parse(localStorage[stableVersionKey] || "{}")?.auth &&
+    localStorage[ongoingVersionKey]
   ) {
-    // Stable version store has never been initialized, while the ongoing version one has already
+    // Stable version store has no valid auth, while the ongoing version one has already
     // => Backport only auth data, as other stuff is highly unlikely to be compatible
     try {
       const { auth } = JSON.parse(localStorage[ongoingVersionKey]);
-      localStorage[stableVersionKey] = JSON.stringify({ auth });
+      stableVersionDict = JSON.parse(localStorage[stableVersionKey] || "{}");
+      stableVersionDict.auth = auth;
+      localStorage[stableVersionKey] = JSON.stringify(stableVersionDict);
     } catch (e) {
       console.error("Unable to retrieve previous valid legacy session data", e);
     }
   }
 
-  return stableVersionKey;
+  return ongoingVersionKey;
 }
 
 function exportBookmarks(localStorage = window.localStorage) {
@@ -68,6 +75,7 @@ function importVersionBookmarks(results, key, localStorage = window.localStorage
     const bookmarks = results[key];
     if (Array.isArray(bookmarks) && bookmarks.length > 0) {
       initializeStoreKey(localStorage);
+
       const previousStore = JSON.parse(localStorage[key] || "{}");
       const updatedStore = JSON.stringify({ ...previousStore, bookmarks });
       localStorage[key] = updatedStore;

--- a/tests/lib/store.spec.js
+++ b/tests/lib/store.spec.js
@@ -22,7 +22,7 @@ describe("lib.store", () => {
   describe("initializeStoreKey", () => {
     test("should initialize ongoing store with auth only when only stable store exists", () => {
       const authStableStore = {
-        auth2: { token: "stable-session-token" },
+        auth: { token: "stable-session-token" },
         bookmarks: anonStableStore.bookmarks,
       };
       const localStorage = {
@@ -37,7 +37,7 @@ describe("lib.store", () => {
 
     test("should backport auth only to stable store when only ongoing store exists", () => {
       const authOngoingStore = {
-        auth2: { token: "ongoing-session-token" },
+        auth: { token: "ongoing-session-token" },
         bookmarks: anonOngoingStore.bookmarks,
       };
       const localStorage = {
@@ -47,12 +47,12 @@ describe("lib.store", () => {
       const key = initializeStoreKey(localStorage);
 
       expect(key).toBe("ecobalyse");
-      expect(JSON.parse(localStorage.store)).toEqual({ auth2: authOngoingStore.auth2 });
+      expect(JSON.parse(localStorage.store)).toEqual({ auth: authOngoingStore.auth });
     });
 
     test("should not alter stores when both stable and ongoing stores exist", () => {
-      const stableSession = { auth2: { token: "stable-session-token" } };
-      const ongoingSession = { auth2: { token: "ongoing-session-token" } };
+      const stableSession = { auth: { token: "stable-session-token" } };
+      const ongoingSession = { auth: { token: "ongoing-session-token" } };
       const localStorage = {
         ecobalyse: JSON.stringify(ongoingSession),
         store: JSON.stringify(stableSession),


### PR DESCRIPTION
## :wrench: Problem

Tests were failing on the `stable/textile` branch.

## :cake: Solution

Backport some of the old behavior of `initializeStoreKey` to make the test pass and adapt the tests to the `auth` instead of `auth2`.


## :rotating_light:  Points to watch/comments

I can’t explain how the previous PR was merged with failing tests… Edit: the jslib tests were not run by the CI

## :desert_island: How to test

Use the corresponding « current version » PR linked to this one : https://ecobalyse-staging-pr2168.osc-fr1.scalingo.io/

Be sure to be disconnected, login with your account and switch to the stable version : you should still be connected.

Do the opposite, be sure to be disconnected, login on the stable version first: https://ecobalyse-staging-pr2168.osc-fr1.scalingo.io/versions/v7.0.0/

Then go to the current version: you should still be authenticated.
