### PR TITLE
chore: fix CI

### DIFF
--- a/.github/workflows/ci-data.yml
+++ b/.github/workflows/ci-data.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: [master]
 
 env:
   EB_OUTPUT_DIR: ./public/data


### PR DESCRIPTION
## :wrench: Problem

When merging the data repository, the CI workflow was not correctly reported ; it still references the “main” branch, instead of “master”
