### PR TITLE
chore: exclude data folder from Scalingo image

### DIFF
--- a/.slugignore
+++ b/.slugignore
@@ -4,6 +4,7 @@ src/
 tests/
 styles.scss
 review/
+data/
 
 node_modules/@parcel
 node_modules/@swc


### PR DESCRIPTION
## :wrench: Problem

After merging the `ecobalyse-data` repository, Scalingo image size increased without need.

## :cake: Solution

Add the `data` folder to the `.slugignore` file.