### PR TITLE
fix(generic): do not apply transport ratios to default distances

### DIFF
--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -910,10 +910,11 @@ computeTransportDistance { db } maybeFrom maybeTo =
 computeTransportedMassImpacts : Requirements db -> TransportCooling -> Maybe Country -> Maybe Country -> Mass -> Result String Transport
 computeTransportedMassImpacts ({ config } as requirements) (TransportCooling cooled) maybeFrom maybeTo mass =
     computeTransportDistance requirements maybeFrom maybeTo
-        -- apply transport mode ratios; note: air transport is not handled for now
         |> Result.map
             (Maybe.map (Transport.applyTransportRatios Split.zero)
                 >> Maybe.withDefault config.transports.defaultDistance
+                -- Always reset air transport, which is unhandled by design for now
+                >> (\transport -> { transport | air = Quantity.zero })
             )
         -- remap cooled transportation modes if needed
         |> Result.map

--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -914,6 +914,7 @@ computeTransportedMassImpacts ({ config } as requirements) (TransportCooling coo
             (Maybe.map (Transport.applyTransportRatios Split.zero)
                 >> Maybe.withDefault config.transports.defaultDistance
                 -- Always reset air transport, which is unhandled by design for now
+                -- see https://github.com/MTES-MCT/ecobalyse/issues/2282#issuecomment-4505548371
                 >> (\transport -> { transport | air = Quantity.zero })
             )
         -- remap cooled transportation modes if needed

--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -873,9 +873,10 @@ Notes:
   - the distance to hub computation logic should eventually be backported to non-generic scopes
 
 -}
-computeTransportDistance : Requirements db -> Maybe Country -> Maybe Country -> Result String Transport
-computeTransportDistance { config, db } maybeFrom maybeTo =
+computeTransportDistance : Requirements db -> Maybe Country -> Maybe Country -> Result String (Maybe Transport)
+computeTransportDistance { db } maybeFrom maybeTo =
     case ( maybeFrom, maybeTo ) of
+        -- both countries are know: compute the distance
         ( Just from, Just to ) ->
             db.distances
                 |> Transport.getTransportBetween from to
@@ -897,9 +898,11 @@ computeTransportDistance { config, db } maybeFrom maybeTo =
                                         ]
                         }
                     )
+                |> Result.map Just
 
         _ ->
-            Ok config.transports.defaultDistance
+            -- at least one country is unknown; no distances returned
+            Ok Nothing
 
 
 {-| Computes the transport distances and impacts from a transported mass.
@@ -907,16 +910,20 @@ computeTransportDistance { config, db } maybeFrom maybeTo =
 computeTransportedMassImpacts : Requirements db -> TransportCooling -> Maybe Country -> Maybe Country -> Mass -> Result String Transport
 computeTransportedMassImpacts ({ config } as requirements) (TransportCooling cooled) maybeFrom maybeTo mass =
     computeTransportDistance requirements maybeFrom maybeTo
-        -- Note: air transport is not handled for now
+        -- apply transport mode ratios; note: air transport is not handled for now
         |> Result.map
-            (Transport.applyTransportRatios Split.zero
-                >> (if cooled then
-                        Transport.makeCooled
-
-                    else
-                        identity
-                   )
+            (Maybe.map (Transport.applyTransportRatios Split.zero)
+                >> Maybe.withDefault config.transports.defaultDistance
             )
+        -- remap cooled transportation modes if needed
+        |> Result.map
+            (if cooled then
+                Transport.makeCooled
+
+             else
+                identity
+            )
+        -- compute resulting impacts
         |> Result.map (Transport.computeImpacts config.transports.modeProcesses mass)
 
 

--- a/tests/Data/ComponentTest.elm
+++ b/tests/Data/ComponentTest.elm
@@ -10,6 +10,7 @@ import Data.Process as Process exposing (Process)
 import Data.Process.Category as Category
 import Data.Scope as Scope
 import Data.Split as Split exposing (Split)
+import Data.Transport as Transport
 import Data.Unit as Unit
 import Dict.Any as AnyDict
 import Expect
@@ -943,6 +944,7 @@ suite =
                         (\france portugal ->
                             [ it "should compute distance between two countries"
                                 (Component.computeTransportDistance requirements (Just portugal) (Just france)
+                                    |> Result.map (Maybe.withDefault Transport.noTransport)
                                     |> Result.map
                                         (\{ air, road, sea } ->
                                             ( Length.inKilometers air > 0
@@ -957,21 +959,22 @@ suite =
                                     -- Note: exagerating distances to hub, to make this test resilient to future data updates
                                     (Just { portugal | distanceToHub = Length.kilometers 20000 })
                                     (Just { france | distanceToHub = Length.kilometers 10000 })
+                                    |> Result.map (Maybe.withDefault Transport.noTransport)
                                     |> Result.map (.road >> Length.inKilometers)
                                     |> Result.withDefault 0
                                     |> Expect.greaterThan 30000
                                 )
-                            , it "should fallback to default distances when the country of departure is undefined"
+                            , it "should handle unknown country of departure"
                                 (Component.computeTransportDistance requirements Nothing (Just france)
-                                    |> Expect.equal (Ok requirements.config.transports.defaultDistance)
+                                    |> Expect.equal (Ok Nothing)
                                 )
-                            , it "should fallback to default distances when the destination country is undefined"
+                            , it "should handle unknown country of destination"
                                 (Component.computeTransportDistance requirements (Just portugal) Nothing
-                                    |> Expect.equal (Ok requirements.config.transports.defaultDistance)
+                                    |> Expect.equal (Ok Nothing)
                                 )
-                            , it "should fallback to default distances when neither countries are defined"
+                            , it "should handle both countries unknown"
                                 (Component.computeTransportDistance requirements Nothing Nothing
-                                    |> Expect.equal (Ok requirements.config.transports.defaultDistance)
+                                    |> Expect.equal (Ok Nothing)
                                 )
                             ]
                         )

--- a/tests/Data/ComponentTest.elm
+++ b/tests/Data/ComponentTest.elm
@@ -1,7 +1,14 @@
 module Data.ComponentTest exposing (..)
 
 import Data.Complement as Complement
-import Data.Component as Component exposing (Component, Item, LifeCycle, Requirements)
+import Data.Component as Component
+    exposing
+        ( Component
+        , Item
+        , LifeCycle
+        , Requirements
+        , defaultTransportCooling
+        )
 import Data.Component.Amount as Amount
 import Data.Country as Country
 import Data.Impact as Impact exposing (Impacts)
@@ -145,7 +152,7 @@ suite =
                                     , stage = Nothing
                                     }
                                     |> Component.applyTransforms requirements
-                                        Component.defaultTransportCooling
+                                        defaultTransportCooling
                                         Nothing
                                         Process.Kilogram
                                         (List.map Component.nonLocalizedExpandedProcess transforms)
@@ -181,7 +188,7 @@ suite =
                                     , stage = Nothing
                                     }
                                     |> Component.applyTransforms requirements
-                                        Component.defaultTransportCooling
+                                        defaultTransportCooling
                                         Nothing
                                         Process.Kilogram
                                         (List.map Component.nonLocalizedExpandedProcess transforms)
@@ -238,7 +245,7 @@ suite =
                                                 , stage = Nothing
                                                 }
                                                 |> Component.applyTransforms requirements
-                                                    Component.defaultTransportCooling
+                                                    defaultTransportCooling
                                                     Nothing
                                                     Process.Kilogram
                                                     steps
@@ -284,7 +291,7 @@ suite =
                                         , stage = Nothing
                                         }
                                         |> Component.applyTransforms requirements
-                                            Component.defaultTransportCooling
+                                            defaultTransportCooling
                                             Nothing
                                             Process.CubicMeter
                                             [ Component.nonLocalizedExpandedProcess transformInKg ]
@@ -306,7 +313,7 @@ suite =
                                     , stage = Nothing
                                     }
                                     |> Component.applyTransforms requirements
-                                        Component.defaultTransportCooling
+                                        defaultTransportCooling
                                         Nothing
                                         Process.Kilogram
                                         (List.map Component.nonLocalizedExpandedProcess transforms)
@@ -401,7 +408,7 @@ suite =
                                         |> Result.withDefault Component.emptyResults
                             in
                             [ it "should add one transport stage per transform step"
-                                (getResults Component.defaultTransportCooling
+                                (getResults defaultTransportCooling
                                     [ Component.nonLocalizedExpandedProcess fading
                                     , Component.nonLocalizedExpandedProcess fading
                                     ]
@@ -409,12 +416,12 @@ suite =
                                     |> Expect.equal 2
                                 )
                             , it "should add no transport stage when no transform is applied"
-                                (getResults Component.defaultTransportCooling []
+                                (getResults defaultTransportCooling []
                                     |> extractTransportStagesCount Component.TransportStage
                                     |> Expect.equal 0
                                 )
                             , it "should insert transport before each transform stage"
-                                (getResults Component.defaultTransportCooling
+                                (getResults defaultTransportCooling
                                     [ Component.nonLocalizedExpandedProcess fading
                                     , Component.nonLocalizedExpandedProcess fading
                                     ]
@@ -575,7 +582,7 @@ suite =
                                 |> Result.andThen
                                     (\cottonId ->
                                         Component.computeElementResults requirements
-                                            Component.defaultTransportCooling
+                                            defaultTransportCooling
                                             { amount = Amount.fromFloat 1
                                             , material = { country = Nothing, id = cottonId }
 
@@ -612,7 +619,7 @@ suite =
                                         , material = { country = Nothing, id = materialInCubicMeters.id }
                                         , transforms = [ Component.nonLocalizedProcess transformInCubicMeters.id ]
                                         }
-                                            |> Component.computeElementResults requirements Component.defaultTransportCooling
+                                            |> Component.computeElementResults requirements defaultTransportCooling
                                 in
                                 [ it "should compute impacts according on material unit"
                                     (results
@@ -638,7 +645,7 @@ suite =
                                         , material = { country = Nothing, id = materialInCubicMeters.id }
                                         , transforms = [ Component.nonLocalizedProcess transformInCubicMeters.id ]
                                         }
-                                            |> Component.computeElementResults requirements Component.defaultTransportCooling
+                                            |> Component.computeElementResults requirements defaultTransportCooling
                                 in
                                 [ it "should compute complements impacts according on material unit"
                                     (results
@@ -671,7 +678,7 @@ suite =
                         (let
                             toComputedResults =
                                 decodeJsonThen Component.decodeItem
-                                    (Component.computeItemResults requirements Component.defaultTransportCooling)
+                                    (Component.computeItemResults requirements defaultTransportCooling)
 
                             combineMapBoth_ fn =
                                 -- RE.combineMapBoth with fn applied to the two tuple members
@@ -912,7 +919,7 @@ suite =
                                       }
                                     ]
                                 }
-                                    |> Component.computeElementResults requirements Component.defaultTransportCooling
+                                    |> Component.computeElementResults requirements defaultTransportCooling
                                     |> Result.map Component.extractItems
                                     |> Result.map (List.any (Component.extractStage >> (==) (Just Component.TransportStage)))
                                     |> Expect.equal (Ok True)
@@ -977,6 +984,28 @@ suite =
                                     |> Expect.equal (Ok Nothing)
                                 )
                             ]
+                        )
+                    , suiteFromResult2 "computeTransportedMassImpacts"
+                        (db.countries |> Country.findByCode (Country.Code "PT"))
+                        (db.countries |> Country.findByCode (Country.Code "FR"))
+                        (\portugal france ->
+                            Mass.kilogram
+                                |> Component.computeTransportedMassImpacts requirements defaultTransportCooling (Just portugal) (Just france)
+                                |> (\transport ->
+                                        [ it "should compute transported mass impacts"
+                                            (transport
+                                                |> Result.map (.impacts >> getEcsImpact)
+                                                |> Result.withDefault 0
+                                                |> Expect.greaterThan 0
+                                            )
+                                        , it "should never include air transport"
+                                            (transport
+                                                |> Result.map (.air >> Length.inKilometers)
+                                                |> Result.withDefault 1
+                                                |> Expect.equal 0
+                                            )
+                                        ]
+                                   )
                         )
                     , describe "computeVolumeFromMass"
                         [ it "should compute a volume from a mass"


### PR DESCRIPTION
fix #2282

Also always force muting air transport

