### PR TITLE
feat(data): ecospold1 export

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -71,6 +71,10 @@ export-veli:
 export-transports:
     {{ python-cmd-data }} -m common.distances.transports
 
+# Export a Brightway db: `just export-bw-db ecospold1 --activities` or `just export-bw-db simapro`
+export-bw-db *args:
+    {{ python-cmd-data }} run python ./bin/export_bw_db.py {{ args }}
+
 ################################################################################
 ### Data cleaning
 

--- a/.justfile
+++ b/.justfile
@@ -73,7 +73,7 @@ export-transports:
 
 # Export a Brightway db: `just export-bw-db ecospold1 --activities` or `just export-bw-db simapro`
 export-bw-db *args:
-    {{ python-cmd-data }} run python ./bin/export_bw_db.py {{ args }}
+    {{ python-cmd-data }} ./data/bin/export_bw_db.py {{ args }}
 
 ################################################################################
 ### Data cleaning

--- a/data/bin/export_bw_db.py
+++ b/data/bin/export_bw_db.py
@@ -20,7 +20,7 @@ from ecobalyse_data.typer import bw_database_validation, bw_databases_validation
 projects.set_current(settings.bw.project)
 available_bw_databases = ", ".join(bw2data.databases)
 
-app = typer.Typer()
+app = typer.Typer(no_args_is_help=True)
 
 
 @app.command()
@@ -83,35 +83,35 @@ def ecospold1(
             "--output", "-o", help="Output XML file (default: <db_names>.XML)."
         ),
     ] = None,
-    from_activities: Annotated[
+    whole_lci_catalog: Annotated[
         bool,
         typer.Option(
-            "--activities",
+            "--all",
             "-a",
-            help="Export activities defined in the lci_catalog/ tree.",
+            help="Export all activities defined in the lci_catalog/ tree.",
         ),
     ] = False,
 ):
     """Export one or more Brightway databases to EcoSpold 1 XML format."""
-    if from_activities:
+    if whole_lci_catalog:
         lci_catalog = PROJECT_ROOT_DIR / "lci_catalog"
         logger.info(f"Loading activities from {lci_catalog}")
-        eco_activities = []
+        activities = []
         for lci_path in sorted(lci_catalog.glob("*/*.json")):
             with open(lci_path, "r") as f:
-                eco_activities.append(json.load(f))
+                activities.append(json.load(f))
 
         bw_activities = []
-        for eco_activity in eco_activities:
-            if eco_activity.get("impacts"):
+        for activity in activities:
+            if activity.get("impacts"):
                 logger.debug(
-                    f"Skipping '{eco_activity.get('displayName', eco_activity.get('activityName'))}' (hardcoded impacts)"
+                    f"Skipping '{activity.get('displayName', activity.get('activityName'))}' (hardcoded impacts)"
                 )
                 continue
             bw_activity = cached_search_one(
-                eco_activity["source"],
-                eco_activity["activityName"],
-                location=eco_activity.get("location"),
+                activity["source"],
+                activity["activityName"],
+                location=activity.get("location"),
             )
             bw_activities.append(bw_activity)
 

--- a/data/bin/export_bw_db.py
+++ b/data/bin/export_bw_db.py
@@ -25,7 +25,7 @@ app = typer.Typer(no_args_is_help=True)
 
 @app.command()
 def simapro(
-    output_file: Annotated[
+    output_filename: Annotated[
         Optional[Path],
         typer.Argument(help="The output CSV file."),
     ] = Path("simapro_export.csv"),
@@ -58,7 +58,7 @@ def simapro(
 
     simapro_export.export_db_to_simapro(
         db,
-        output_file,
+        output_filename,
         simapro_units_path=filepath_simapro_units,
         simapro_compartments_path=filepath_simapro_compartments,
         simapro_biosphere_path=simapro_biosphere_path,
@@ -77,7 +77,7 @@ def ecospold1(
             help="Brightway database(s) to export (merged into one file).",
         ),
     ] = None,
-    output_file: Annotated[
+    output_filename: Annotated[
         Optional[Path],
         typer.Option(
             "--output", "-o", help="Output XML file (default: <db_names>.XML)."
@@ -115,23 +115,23 @@ def ecospold1(
             )
             bw_activities.append(bw_activity)
 
-        logger.info(f"Exporting {len(bw_activities)} activities to {output_file}")
+        logger.info(f"Exporting {len(bw_activities)} activities to {output_filename}")
 
-        if output_file is None:
-            output_file = Path("Ecoplus.XML")
+        if output_filename is None:
+            output_filename = Path("Ecoplus.XML")
 
-        ecospold_export.export_db_to_ecospold(bw_activities, output_file)
+        ecospold_export.export_db_to_ecospold(bw_activities, output_filename)
         return
 
     if not db_names:
         logger.error("Provide database name(s), or use --activities.")
         raise typer.Exit(code=1)
 
-    if output_file is None:
-        output_file = Path(f"{'_'.join(n.lower() for n in db_names)}.XML")
+    if output_filename is None:
+        output_filename = Path(f"{'_'.join(n.lower() for n in db_names)}.XML")
 
     activities = [act for name in db_names for act in bw2data.Database(name)]
-    ecospold_export.export_db_to_ecospold(activities, output_file)
+    ecospold_export.export_db_to_ecospold(activities, output_filename)
 
 
 if __name__ == "__main__":

--- a/data/bin/export_bw_db.py
+++ b/data/bin/export_bw_db.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 
+import json
 import os
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional
 
 import bw2data
 import typer
@@ -10,16 +11,20 @@ from bw2data.project import projects
 from typing_extensions import Annotated
 
 from config import DATA_ROOT_DIR, settings
-from ecobalyse_data.bw import simapro_export
+from ecobalyse_data.bw import ecospold_export, simapro_export
+from ecobalyse_data.bw.search import cached_search_one
 from ecobalyse_data.logging import logger
-from ecobalyse_data.typer import bw_database_validation
+from ecobalyse_data.typer import bw_database_validation, bw_databases_validation
 
 # Init BW project
 projects.set_current(settings.bw.project)
 available_bw_databases = ", ".join(bw2data.databases)
 
+app = typer.Typer()
 
-def main(
+
+@app.command()
+def simapro(
     output_file: Annotated[
         Optional[Path],
         typer.Argument(help="The output CSV file."),
@@ -28,7 +33,7 @@ def main(
         Optional[str],
         typer.Argument(
             callback=bw_database_validation,
-            help=f"Brightway databases you want to computate impacts for. Default to all. You can specify multiple `--db`.\n\nAvailable databases are: {available_bw_databases}.",
+            help=f"Brightway databases you want to compute impacts for. Default to all. You can specify multiple `--db`.\n\nAvailable databases are: {available_bw_databases}.",
         ),
     ] = "Ecobalyse_custom_lci",
 ):
@@ -63,5 +68,71 @@ def main(
     )
 
 
+@app.command()
+def ecospold1(
+    db_names: Annotated[
+        Optional[List[str]],
+        typer.Argument(
+            callback=bw_databases_validation,
+            help="Brightway database(s) to export (merged into one file).",
+        ),
+    ] = None,
+    output_file: Annotated[
+        Optional[Path],
+        typer.Option(
+            "--output", "-o", help="Output XML file (default: <db_names>.XML)."
+        ),
+    ] = None,
+    from_activities: Annotated[
+        bool,
+        typer.Option(
+            "--activities",
+            "-a",
+            help="Export activities defined in the lci_catalog/ tree.",
+        ),
+    ] = False,
+):
+    """Export one or more Brightway databases to EcoSpold 1 XML format."""
+    if from_activities:
+        lci_catalog = PROJECT_ROOT_DIR / "lci_catalog"
+        logger.info(f"Loading activities from {lci_catalog}")
+        eco_activities = []
+        for lci_path in sorted(lci_catalog.glob("*/*.json")):
+            with open(lci_path, "r") as f:
+                eco_activities.append(json.load(f))
+
+        bw_activities = []
+        for eco_activity in eco_activities:
+            if eco_activity.get("impacts"):
+                logger.debug(
+                    f"Skipping '{eco_activity.get('displayName', eco_activity.get('activityName'))}' (hardcoded impacts)"
+                )
+                continue
+            bw_activity = cached_search_one(
+                eco_activity["source"],
+                eco_activity["activityName"],
+                location=eco_activity.get("location"),
+            )
+            bw_activities.append(bw_activity)
+
+        logger.info(f"Found {len(bw_activities)} activities to export")
+
+        if output_file is None:
+            output_file = Path("Ecoplus.XML")
+
+        ecospold_export.export_db_to_ecospold(bw_activities, output_file)
+        return
+
+    if not db_names:
+        logger.error("Provide database name(s), or use --activities.")
+        raise typer.Exit(code=1)
+
+    if output_file is None:
+        output_file = Path(f"{'_'.join(n.lower() for n in db_names)}.XML")
+
+    activities = [act for name in db_names for act in bw2data.Database(name)]
+    ecospold_export.export_db_to_ecospold(activities, output_file)
+
+
 if __name__ == "__main__":
-    typer.run(main)
+    app()

--- a/data/bin/export_bw_db.py
+++ b/data/bin/export_bw_db.py
@@ -94,7 +94,7 @@ def ecospold1(
 ):
     """Export one or more Brightway databases to EcoSpold 1 XML format."""
     if whole_lci_catalog:
-        lci_catalog = PROJECT_ROOT_DIR / "lci_catalog"
+        lci_catalog = DATA_ROOT_DIR / "lci_catalog"
         logger.info(f"Loading activities from {lci_catalog}")
         activities = []
         for lci_path in sorted(lci_catalog.glob("*/*.json")):

--- a/data/bin/export_bw_db.py
+++ b/data/bin/export_bw_db.py
@@ -115,7 +115,7 @@ def ecospold1(
             )
             bw_activities.append(bw_activity)
 
-        logger.info(f"Found {len(bw_activities)} activities to export")
+        logger.info(f"Exporting {len(bw_activities)} activities to {output_file}")
 
         if output_file is None:
             output_file = Path("Ecoplus.XML")

--- a/data/bin/export_bw_db.py
+++ b/data/bin/export_bw_db.py
@@ -103,7 +103,7 @@ def ecospold1(
 
         bw_activities = []
         for activity in activities:
-            if activity.get("impacts"):
+            if activity.get("source") == "Ecobalyse_manual_lcia":
                 logger.debug(
                     f"Skipping '{activity.get('displayName', activity.get('activityName'))}' (hardcoded impacts)"
                 )

--- a/data/ecobalyse_data/bw/ecospold_export.py
+++ b/data/ecobalyse_data/bw/ecospold_export.py
@@ -1,0 +1,574 @@
+"""
+EcoSpold 1 Exporter for Brightway2 databases.
+
+Exports Brightway2 datasets to EcoSpold 1 XML format compatible with SimaPro.
+"""
+
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Union
+
+import numpy as np
+from lxml import etree
+from stats_arrays.distributions import (
+    LognormalUncertainty,
+    NormalUncertainty,
+    NoUncertainty,
+    TriangularUncertainty,
+    UndefinedUncertainty,
+    UniformUncertainty,
+)
+
+from ecobalyse_data.logging import logger
+
+# XML namespace configuration
+attr_qname = etree.QName("http://www.w3.org/2001/XMLSchema-instance", "schemaLocation")
+nsmap = {
+    None: "http://www.EcoInvent.org/EcoSpold01",
+    "xsi": "http://www.w3.org/2001/XMLSchema-instance",
+}
+
+# Unit mapping for SimaPro compatibility
+UNITS = {
+    "year": "a",
+    "Becquerel": "Bq",
+    "gram": "g",
+    "gigajoule": "GJ",
+    "hour": "h",
+    "hectare": "ha",
+    "kilo Becquerel": "kBq",
+    "kilogram": "kg",
+    "kilogram kilometer": "kgkm",
+    "kilogram day": "kg*day",
+    "kilometer": "km",
+    "kilojoule": "kJ",
+    "kilowatt hour": "kWh",
+    "litre": "l",
+    "livestock unit": "LU",
+    "meter": "m",
+    "meter-year": "m*a",
+    "square meter": "m2",
+    "square meter-year": "m2a",
+    "cubic meter": "m3",
+    "cubic meter-year": "m3a",
+    "ton kilometer": "tkm",
+    "megajoule": "MJ",
+    "normal cubic meter": "Nm3",
+    "standard cubic meter": "Sm3",
+    "person kilometer": "pkm",
+    "ton": "t",
+    "vehicle kilometer": "vkm",
+    "kilogram separative work unit": "kg SWU",
+    "kilometer-year": "km*a",
+    "watt hour": "Wh",
+    "unit": "p",
+    "piece": "p",
+}
+
+# Location mapping for EcoSpold (max 7 chars)
+LOCATIONS = {
+    "Europe without Switzerland": "RER",
+}
+
+
+def bool_to_text(b: Union[bool, str, None]) -> str:
+    """Convert a boolean-like value to 'true' or 'false' string."""
+    if b in (True, "yes", "Yes", "true", "True"):
+        return "true"
+    elif b in (False, None, "", "False", "false", "No", "no"):
+        return "false"
+    else:
+        raise ValueError(f"Can't convert {b} to boolean string")
+
+
+def stripper(obj: str, prefix: str) -> str:
+    """Strip a prefix from a string if present."""
+    if obj and obj.startswith(prefix):
+        return obj[len(prefix) :]
+    else:
+        return obj or ""
+
+
+def pretty_number(val: float) -> str:
+    """Format a number nicely for XML output."""
+    if 1e-2 < abs(val) < 1e2:
+        return np.format_float_positional(val, precision=6, trim="0")
+    else:
+        return np.format_float_scientific(val, precision=6, trim="0")
+
+
+class Ecospold1Exporter:
+    """Export one or more datasets to Ecospold1 XML."""
+
+    def __init__(self, schema_location: Union[str, None] = None):
+        self.root = etree.Element(
+            "ecoSpold",
+            {
+                attr_qname: schema_location
+                or "https://raw.githubusercontent.com/sami-m-g/pyecospold/main/pyecospold/schemas/v1/EcoSpold01Dataset.xsd"
+            },
+            nsmap=nsmap,
+        )
+        self.count = 0
+
+    def add_dataset(self, node: Dict[str, Any], key_to_dsnum=None) -> None:
+        self.count += 1
+        tags = dict(node.get("tags", []))
+        # Normalize timestamp without microseconds (friendlier to some parsers)
+        timestamp = tags.get(
+            "ecoSpold01timestamp",
+            datetime.now().replace(microsecond=0).isoformat(),
+        )
+
+        dataset = etree.SubElement(
+            self.root,
+            "dataset",
+            attrib={
+                "validCompanyCodes": "CompanyCodes.xml",
+                "validRegionalCodes": "RegionalCodes.xml",
+                "validCategories": "Categories.xml",
+                "validUnits": "Units.xml",
+                "number": str(self.count),
+                "timestamp": timestamp,
+                "generator": "bw2io",
+            },
+        )
+        meta_information = etree.SubElement(dataset, "metaInformation")
+
+        category = tags.get("ecoSpold01category", node.get("category"))
+        subcategory = tags.get(
+            "ecoSpold01subCategory", node.get("subcategory", category)
+        )
+        comments = node.get("comments", {}) or {}
+
+        process_information = etree.SubElement(meta_information, "processInformation")
+
+        ref_attrs = {
+            "datasetRelatesToProduct": bool_to_text(
+                tags.get("ecoSpold01datasetRelatesToProduct", True)
+            ),
+            "name": node["name"],
+            "localName": tags.get("ecoSpold01localName", node["name"]),
+            "infrastructureProcess": bool_to_text(
+                tags.get("ecoSpold01infrastructureProcess")
+            ),
+            "amount": "1.0",
+            "unit": UNITS.get(u := node["unit"], u),
+            "includedProcesses": comments.get("includedProcesses", ""),
+            "generalComment": comments.get("generalComment", ""),
+            "infrastructureIncluded": bool_to_text(
+                tags.get("ecoSpold01infrastructureIncluded")
+            ),
+        }
+
+        # Only include categories if not explicitly omitted AND you have values
+        if not tags.get("ecoSpold01omitCategories", False) and category and subcategory:
+            ref_attrs.update(
+                {
+                    "category": category,
+                    "subCategory": subcategory,
+                    "localCategory": node.get("localCategory", category),
+                    "localSubCategory": node.get("localSubCategory", subcategory),
+                }
+            )
+
+        etree.SubElement(process_information, "referenceFunction", attrib=ref_attrs)
+
+        raw_loc = (
+            tags.get("ecoSpold01geographyLocation") or node.get("location") or "GLO"
+        )
+        geo_loc = LOCATIONS.get(raw_loc, raw_loc)
+        geo_text = (
+            tags.get("ecoSpold01geographyText")
+            or stripper(comments.get("location", ""), "Location: ")
+            or "Unspecified"
+        )
+        etree.SubElement(
+            process_information,
+            "geography",
+            attrib={"location": geo_loc, "text": geo_text},
+        )
+        etree.SubElement(
+            process_information,
+            "technology",
+            attrib={"text": stripper(comments.get("technology", ""), "Technology: ")},
+        )
+        data_valid_entire = tags.get("ecoSpold01dataValidForEntirePeriod", "")
+        time_period = etree.SubElement(
+            process_information,
+            "timePeriod",
+            attrib={
+                "text": stripper(comments.get("timePeriod", ""), "Time period: ")
+                or "Unspecified",
+                "dataValidForEntirePeriod": str(data_valid_entire),
+            },
+        )
+        start = etree.SubElement(time_period, "startDate")
+        start.text = tags.get("ecoSpold01startDate", "1900-01-01")
+        end = etree.SubElement(time_period, "endDate")
+        end.text = tags.get("ecoSpold01endDate", "1900-01-01")
+
+        etree.SubElement(
+            process_information,
+            "dataSetInformation",
+            attrib={
+                "type": str(tags.get("ecoSpold01type", "1")),
+                "impactAssessmentResult": bool_to_text(
+                    tags.get("ecoSpold01impactAssessmentResult")
+                ),
+                "timestamp": timestamp,
+                "version": tags.get("ecoSpold01version", "0.00"),
+                "internalVersion": tags.get("ecoSpold01internalVersion", "0.0"),
+                "energyValues": str(tags.get("ecoSpold01energyValues", "0")),
+                "languageCode": tags.get("ecoSpold01languageCode", "en"),
+                "localLanguageCode": tags.get("ecoSpold01localLanguageCode", "de"),
+            },
+        )
+
+        m_and_v = etree.SubElement(meta_information, "modellingAndValidation")
+        etree.SubElement(
+            m_and_v,
+            "representativeness",
+            attrib={
+                "productionVolume": stripper(
+                    comments.get("productionVolume", "unknown"), "Production volume: "
+                ),
+                "samplingProcedure": stripper(
+                    comments.get("sampling", "unknown"), "Sampling: "
+                ),
+                "extrapolations": stripper(
+                    comments.get("extrapolations", "unknown"), "Extrapolations: "
+                ),
+                "uncertaintyAdjustments": stripper(
+                    comments.get("uncertaintyAdjustments", "unknown"),
+                    "Uncertainty adjustments: ",
+                ),
+            },
+        )
+
+        SOURCE_MAP: Dict[str, str] = {
+            "Undefined (default)": "0",
+            "Article": "1",
+            "Chapters in anthology": "2",
+            "Seperate publication": "3",
+            "Measurement on site": "4",
+            "Oral communication": "5",
+            "Personal written communication": "6",
+            "Questionnaries": "7",
+        }
+
+        SOURCE_FIELDS = {
+            "nameOfEditors": "editors",
+            "pageNumbers": "pages",
+            "year": "year",
+            "title": "title",
+            "titleOfAnthology": "anthology",
+            "placeOfPublications": "place_of_publication",
+            "publisher": "publisher",
+            "journal": "journal",
+            "volumeNo": "volume",
+            "issueNo": "issue",
+            "text": "text",
+        }
+
+        # Build sources; keep track of numbers we used
+        sources: List[Dict[str, Any]] = node.get("references", []) or []
+        for index, source in enumerate(sources):
+            authors = source.get("authors", []) or [""]
+            first_author = authors[0] if authors else ""
+            additional_authors = "; ".join(authors[1:]) if len(authors) > 1 else ""
+            etree.SubElement(
+                m_and_v,
+                "source",
+                attrib={
+                    "number": str(source.get("identifier", index + 1)),
+                    "sourceType": SOURCE_MAP.get(source.get("type"), "0"),
+                    "firstAuthor": first_author,
+                    "additionalAuthors": additional_authors,
+                }
+                | {
+                    k: str(source.get(v))
+                    for k, v in SOURCE_FIELDS.items()
+                    if source.get(v) is not None
+                },
+            )
+
+        admin = etree.SubElement(meta_information, "administrativeInformation")
+
+        # Use a safe, local value (don't rely on loop variables that may not exist)
+        data_entry_number = str(
+            node.get("authors", {}).get("data_entry", {}).get("identifier", 1)
+        )
+        etree.SubElement(
+            admin,
+            "dataEntryBy",
+            attrib={
+                "person": data_entry_number,
+                "qualityNetwork": "1",
+            },
+        )
+
+        etree.SubElement(
+            admin,
+            "dataGeneratorAndPublication",
+            attrib={
+                "person": data_entry_number,
+                "dataPublishedIn": "1",
+                "referenceToPublishedSource": "1",
+                "accessRestrictedTo": "0",
+                "copyright": "true",
+            },
+        )
+
+        PERSON_FIELDS = [
+            ("identifier", "number", "1"),
+            ("address", "address", "Unknown"),
+            ("company", "companyCode", "Unknown"),
+            ("country", "countryCode", "FR"),  # Default to France for Ecobalyse
+            ("email", "email", "unknown@example.com"),
+            ("name", "name", "Unknown"),
+        ]
+
+        people = node.get("authors", {}).get("people", []) or []
+        # Schema requires at least one person element
+        if not people:
+            people = [{"identifier": 1, "name": "Unknown"}]
+
+        for person in people:
+            etree.SubElement(
+                admin,
+                "person",
+                attrib={b: str(person.get(a, c)) for a, b, c in PERSON_FIELDS},
+            )
+
+        RESOURCES = {
+            "natural resource",
+            "natural resources",
+            "resource",
+            "resources",
+            "raw",
+        }
+
+        UNCERTAINTY_MAPPING = {
+            None: "0",
+            NoUncertainty.id: "0",
+            UndefinedUncertainty.id: "0",
+            LognormalUncertainty.id: "1",
+            TriangularUncertainty.id: "3",
+            UniformUncertainty.id: "4",
+        }
+
+        EXCHANGE_FIELDS = {
+            "generalComment": "comment",
+            "CASNumber": "CAS number",
+            "location": "location",
+            "formula": "chemical formula",
+            "referenceToSource": "source_reference",
+            "pageNumbers": "pages",
+        }
+
+        flow_data = etree.SubElement(dataset, "flowData")
+
+        # Reference product exchange (outputGroup=0, number=0)
+        ref_unit = UNITS.get(u := node["unit"], u)
+        ref_exc = etree.SubElement(
+            flow_data,
+            "exchange",
+            attrib={
+                "number": "0",
+                "name": node["name"],
+                "unit": ref_unit,
+                "meanValue": pretty_number(node.get("production amount", 1.0)),
+                "infrastructureProcess": bool_to_text(False),
+                "uncertaintyType": "0",
+            },
+        )
+        etree.SubElement(ref_exc, "outputGroup").text = "0"
+
+        exc_number = 0
+        for exc in node.get("exchanges", []) or []:
+            if exc["type"] == "production":
+                continue  # already emitted as reference product above
+            exc_number += 1
+            # For technosphere inputs, use supplier's dataset number
+            if exc.get("type") == "technosphere" and key_to_dsnum:
+                number = str(key_to_dsnum.get(exc.get("input_key"), 0))
+            else:
+                number = str(exc_number)
+            cats = exc.get("categories") or []
+            attrs = {
+                "number": number,
+                "unit": UNITS.get(u := str(exc.get("unit", "")), u),
+                "name": exc.get("name", ""),
+                "meanValue": pretty_number(exc["amount"]),
+                "infrastructureProcess": bool_to_text(exc.get("infrastructureProcess")),
+            } | {
+                k: exc.get(v)
+                for k, v in EXCHANGE_FIELDS.items()
+                if exc.get(v) is not None
+            }
+
+            # Always include uncertaintyType; default to 0 (none)
+            utype = exc.get("uncertainty type")
+            attrs["uncertaintyType"] = UNCERTAINTY_MAPPING.get(utype, "0")
+
+            if cats and cats[0]:
+                attrs["category"] = cats[0]
+            if len(cats) > 1 and cats[1]:
+                attrs["subCategory"] = cats[1]
+
+            # 95% standard deviation where applicable (preserve zeros)
+            if utype == LognormalUncertainty.id and exc.get("scale") is not None:
+                attrs["standardDeviation95"] = pretty_number(np.exp(exc["scale"]) ** 2)
+            elif utype == NormalUncertainty.id and exc.get("scale") is not None:
+                attrs["standardDeviation95"] = pretty_number(exc["scale"] * 2)
+
+            # Preserve zero min/max
+            if exc.get("minimum") is not None:
+                attrs["minValue"] = pretty_number(exc["minimum"])
+            if exc.get("maximum") is not None:
+                attrs["maxValue"] = pretty_number(exc["maximum"])
+
+            exc_element = etree.SubElement(flow_data, "exchange", attrib=attrs)
+
+            # Group mapping with safe biosphere branch
+            etype = exc["type"]
+            if etype == "technosphere":
+                etree.SubElement(exc_element, "inputGroup").text = "5"
+            elif etype == "substitution":
+                etree.SubElement(exc_element, "outputGroup").text = "1"
+            elif etype == "biosphere":
+                is_resource = bool(cats and cats[0] and cats[0].lower() in RESOURCES)
+                if is_resource:
+                    etree.SubElement(exc_element, "inputGroup").text = "4"
+                else:
+                    etree.SubElement(exc_element, "outputGroup").text = "4"
+            else:
+                raise ValueError(f"Can't map exchange type {etype}")
+
+    @property
+    def bytes(self) -> bytes:
+        return etree.tostring(
+            self.root, encoding="utf-8", xml_declaration=True, pretty_print=True
+        )
+
+    def __repr__(self) -> str:
+        return self.bytes.decode("utf-8")
+
+    def write_to_file(self, filepath: Path) -> None:
+        with open(filepath, "wb") as f:
+            f.write(self.bytes)
+
+
+def _simapro_geography_name(ds):
+    """Builds a SimaPro-like '[LOC] short process name' string."""
+    loc = ds.get("location", "GLO")
+    name = ds.get("name", "")
+    short = name
+    if "|" in name:
+        parts = [p.strip() for p in name.split("|")]
+        if len(parts) >= 2:
+            short = parts[1]
+    short = short.replace("{%s}" % loc, "").strip()
+    return f"[{loc}] {short}"
+
+
+def _prepare_dataset(activity):
+    """Prepare a Brightway activity dict for EcoSpold 1 export."""
+    ds = activity.as_dict()
+
+    # Fetch exchanges (not included in as_dict())
+    ds["exchanges"] = []
+    for exc in activity.exchanges():
+        exc_data = exc.as_dict()
+        exc_data["type"] = exc["type"]
+        exc_data["amount"] = exc["amount"]
+        exc_data["unit"] = exc.get("unit", exc.input.get("unit", ""))
+        exc_data["name"] = exc.input.get("name", "")
+        exc_data["categories"] = exc.input.get("categories", [])
+        if exc["type"] == "technosphere":
+            exc_data["input_key"] = exc["input"]
+        ds["exchanges"].append(exc_data)
+
+    # Add production exchange if missing (required for reference product output)
+    has_production = any(exc.get("type") == "production" for exc in ds["exchanges"])
+    if not has_production:
+        ds["exchanges"].insert(
+            0,
+            {
+                "type": "production",
+                "amount": ds.get("production amount", 1.0),
+                "unit": ds.get("unit", "kilogram"),
+                "name": ds.get("name", ""),
+                "categories": [],
+            },
+        )
+
+    # Skip datasets without exchanges (EcoSpold schema requires at least one)
+    if not ds["exchanges"]:
+        logger.warning(f"Skipping '{ds['name']}' (no exchanges)")
+        return None
+
+    # Patch category fields to SimaPro-ish buckets
+    if isinstance(ds.get("tags"), list):
+        ds["tags"] = dict(ds["tags"])
+    ds.setdefault("tags", {})
+    ds["tags"]["ecoSpold01category"] = "Others"
+    ds["tags"]["ecoSpold01subCategory"] = "Carbon content biogenic materials"
+
+    ds["category"] = ds["tags"]["ecoSpold01category"]
+    ds["localCategory"] = ds["tags"]["ecoSpold01category"]
+    ds["localSubCategory"] = ds["tags"]["ecoSpold01subCategory"]
+
+    # Geography
+    ds["tags"]["ecoSpold01geographyLocation"] = ds.get("location", "GLO")
+    ds["tags"]["ecoSpold01geographyText"] = _simapro_geography_name(ds)
+
+    # Time period defaults like SimaPro sample
+    ds["tags"]["ecoSpold01dataValidForEntirePeriod"] = "true"
+    ds["tags"]["ecoSpold01startDate"] = "1900-01-01"
+    ds["tags"]["ecoSpold01endDate"] = "1900-01-01"
+
+    # Dataset info defaults to align formatting
+    ds["tags"]["ecoSpold01version"] = "0.00"
+    ds["tags"]["ecoSpold01internalVersion"] = "0.0"
+    ds["tags"]["ecoSpold01languageCode"] = "en"
+    ds["tags"]["ecoSpold01localLanguageCode"] = "de"
+
+    # Provide a minimal default source (SimaPro file has one)
+    if not ds.get("references"):
+        ds["references"] = [
+            {
+                "identifier": 1,
+                "type": "Undefined (default)",
+                "authors": ["SimaPro"],
+                "year": 2025,
+                "title": "Dummy",
+                "place_of_publication": "Unspecified",
+            }
+        ]
+
+    return ds
+
+
+def export_db_to_ecospold(activities, filepath):
+    """Export an iterable of Brightway activities to a single EcoSpold 1 XML file."""
+    exporter = Ecospold1Exporter()
+
+    # First pass: prepare datasets and assign dataset numbers
+    prepared = []
+    key_to_dsnum = {}
+    for activity in activities:
+        ds = _prepare_dataset(activity)
+        if ds is not None:
+            exporter.count += 1
+            key_to_dsnum[activity.key] = exporter.count
+            prepared.append(ds)
+
+    # Second pass: write with correct supplier references
+    exporter.count = 0
+    for ds in prepared:
+        exporter.add_dataset(ds, key_to_dsnum)
+
+    exporter.write_to_file(filepath)
+    logger.info(f"Exported {exporter.count} datasets to '{filepath}'")

--- a/data/ecobalyse_data/bw/ecospold_export.py
+++ b/data/ecobalyse_data/bw/ecospold_export.py
@@ -354,6 +354,7 @@ class Ecospold1Exporter:
             NoUncertainty.id: "0",
             UndefinedUncertainty.id: "0",
             LognormalUncertainty.id: "1",
+            NormalUncertainty.id: "2",
             TriangularUncertainty.id: "3",
             UniformUncertainty.id: "4",
         }
@@ -370,6 +371,9 @@ class Ecospold1Exporter:
         flow_data = etree.SubElement(dataset, "flowData")
 
         # Reference product exchange (outputGroup=0, number=0)
+        # `infrastructureProcess` mirrors the dataset-level tag so a
+        # capital-goods process's reference flow isn't silently flagged as
+        # operational.
         ref_unit = UNITS.get(u := node["unit"], u)
         ref_exc = etree.SubElement(
             flow_data,
@@ -379,7 +383,9 @@ class Ecospold1Exporter:
                 "name": node["name"],
                 "unit": ref_unit,
                 "meanValue": pretty_number(node.get("production amount", 1.0)),
-                "infrastructureProcess": bool_to_text(False),
+                "infrastructureProcess": bool_to_text(
+                    tags.get("ecoSpold01infrastructureProcess")
+                ),
                 "uncertaintyType": "0",
             },
         )
@@ -390,8 +396,11 @@ class Ecospold1Exporter:
             if exc["type"] == "production":
                 continue  # already emitted as reference product above
             exc_number += 1
-            # For technosphere inputs, use supplier's dataset number
-            if exc.get("type") == "technosphere" and key_to_dsnum:
+            # For technosphere inputs and avoided-product substitutions, the
+            # EcoSpold1 `number` references the supplier dataset's `number`.
+            # Falls back to 0 when the supplier isn't part of this export
+            # (downstream linkers then resolve by name).
+            if exc.get("type") in ("technosphere", "substitution") and key_to_dsnum:
                 number = str(key_to_dsnum.get(exc.get("input_key"), 0))
             else:
                 number = str(exc_number)
@@ -486,7 +495,7 @@ def _prepare_dataset(activity):
         exc_data["unit"] = exc.get("unit", exc.input.get("unit", ""))
         exc_data["name"] = exc.input.get("name", "")
         exc_data["categories"] = exc.input.get("categories", [])
-        if exc["type"] == "technosphere":
+        if exc["type"] in ("technosphere", "substitution"):
             exc_data["input_key"] = exc["input"]
         ds["exchanges"].append(exc_data)
 
@@ -509,16 +518,23 @@ def _prepare_dataset(activity):
         logger.warning(f"Skipping '{ds['name']}' (no exchanges)")
         return None
 
-    # Patch category fields to SimaPro-ish buckets
+    # Preserve the activity's real category; fall back to a generic SimaPro
+    # bucket only when Brightway has none. Previously every dataset was forced
+    # to "Others / Carbon content biogenic materials", which erased the
+    # taxonomy and made downstream filtering by domain impossible.
     if isinstance(ds.get("tags"), list):
         ds["tags"] = dict(ds["tags"])
     ds.setdefault("tags", {})
-    ds["tags"]["ecoSpold01category"] = "Others"
-    ds["tags"]["ecoSpold01subCategory"] = "Carbon content biogenic materials"
+    activity_category = ds.get("category") or "Others"
+    activity_subcategory = ds.get("subcategory") or activity_category
+    ds["tags"].setdefault("ecoSpold01category", activity_category)
+    ds["tags"].setdefault("ecoSpold01subCategory", activity_subcategory)
 
     ds["category"] = ds["tags"]["ecoSpold01category"]
-    ds["localCategory"] = ds["tags"]["ecoSpold01category"]
-    ds["localSubCategory"] = ds["tags"]["ecoSpold01subCategory"]
+    ds["localCategory"] = ds.get("localCategory") or ds["tags"]["ecoSpold01category"]
+    ds["localSubCategory"] = (
+        ds.get("localSubCategory") or ds["tags"]["ecoSpold01subCategory"]
+    )
 
     # Geography
     ds["tags"]["ecoSpold01geographyLocation"] = ds.get("location", "GLO")

--- a/data/ecobalyse_data/typer.py
+++ b/data/ecobalyse_data/typer.py
@@ -9,13 +9,14 @@ from common.impacts import main_method
 
 
 def bw_databases_validation(values: Optional[List[str]]):
-    available_bw_databases = ", ".join(bw2data.databases)
+    if values:
+        available_bw_databases = ", ".join(bw2data.databases)
 
-    for value in values:
-        if value not in bw2data.databases:
-            raise typer.BadParameter(
-                f"Database not present in Brightway. Available databases are: {available_bw_databases}."
-            )
+        for value in values:
+            if value not in bw2data.databases:
+                raise typer.BadParameter(
+                    f"Database not present in Brightway. Available databases are: {available_bw_databases}."
+                )
 
     return values
 

--- a/data/ecobalyse_data/typer.py
+++ b/data/ecobalyse_data/typer.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List
 
 import bw2data
 import typer
@@ -8,7 +8,7 @@ from common.impacts import impacts as impacts_py
 from common.impacts import main_method
 
 
-def bw_databases_validation(values: Optional[List[str]]):
+def bw_databases_validation(values: List[str] | None):
     if values:
         available_bw_databases = ", ".join(bw2data.databases)
 
@@ -21,14 +21,14 @@ def bw_databases_validation(values: Optional[List[str]]):
     return values
 
 
-def bw_database_validation(value: Optional[str]):
+def bw_database_validation(value: str | None):
     if value:
         return bw_databases_validation([value])[0]
 
     return value
 
 
-def ecobalyse_impact_validation(values: Optional[List[str]]):
+def ecobalyse_impact_validation(values: List[str] | None):
     if values:
         for value in values:
             if value not in IMPACTS_JSON:
@@ -40,7 +40,7 @@ def ecobalyse_impact_validation(values: Optional[List[str]]):
     return values
 
 
-def method_impact_validation(value: Optional[str]):
+def method_impact_validation(value: str | None):
     if value and value not in impacts_py:
         available_impacts = ", ".join(impacts_py.keys())
         raise typer.BadParameter(

--- a/data/tests/test_bin_scripts.py
+++ b/data/tests/test_bin_scripts.py
@@ -6,7 +6,7 @@ from pytest import approx
 
 from bin import export_bw_db, export_lcia, lcia_info
 from config import settings
-from ecobalyse_data.bw import simapro_export
+from ecobalyse_data.bw import ecospold_export, simapro_export
 from models.process import ComputedBy, Impacts
 
 
@@ -59,9 +59,13 @@ def test_export_bw_db(mocker):
     # Just check that the imports are ok
 
     mocker.patch("ecobalyse_data.bw.simapro_export.export_db_to_simapro")
+    mocker.patch("ecobalyse_data.bw.ecospold_export.export_db_to_ecospold")
     with tempfile.NamedTemporaryFile(delete=False) as fp:
-        export_bw_db.main(fp, "")
+        export_bw_db.simapro(fp, "")
         simapro_export.export_db_to_simapro.assert_called_once()
+    with tempfile.NamedTemporaryFile(delete=False) as fp:
+        export_bw_db.ecospold1(["Ecobalyse"], fp.name)
+        ecospold_export.export_db_to_ecospold.assert_called_once()
 
 
 def test_forwast_restore(forwast):

--- a/data/tests/test_bin_scripts.py
+++ b/data/tests/test_bin_scripts.py
@@ -64,7 +64,7 @@ def test_export_bw_db(mocker):
         export_bw_db.simapro(fp, "")
         simapro_export.export_db_to_simapro.assert_called_once()
     with tempfile.NamedTemporaryFile(delete=False) as fp:
-        export_bw_db.ecospold1(["Ecobalyse"], fp.name)
+        export_bw_db.ecospold1(["Ecobalyse_custom_lci"], fp.name)
         ecospold_export.export_db_to_ecospold.assert_called_once()
 
 


### PR DESCRIPTION
## :wrench: Problem

We needs an ecospold1 export so that people can reuse Ecobalyse source data. (a.k.a `Ecoplus`)
Fix #2644 

## :cake: Solution

Revived and updated the ecospold1 export that was waiting in ecobalyse-data.

## :rotating_light:  Points to watch/comments

The export is needed by the transformed ingredients generation script.

## :desert_island: How to test

- `just export_bw_db ecospold1 <dbname>` (exports one DB → db.XML)
- `just export_bw_db ecospold1 --all` (exports all the Ecobalyse lci_catalog → Ecoplus.XML)
- Try to import the generated files at least into OpenLCA and Volca.