### PR TITLE
fix(ci): improve e2e test runner resiliency

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -13,7 +13,7 @@ dotenv.config({ path: path.resolve(__dirname, ".env") });
  * @see https://playwright.dev/docs/test-configuration
  */
 export default defineConfig({
-  timeout: process.env.CI ? 60_000 : 10_000,
+  timeout: process.env.CI ? 120_000 : 10_000,
 
   expect: { timeout: process.env.CI ? 10_000 : 2_000 },
 
@@ -23,7 +23,7 @@ export default defineConfig({
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
+  retries: process.env.CI ? 10 : 0,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
 


### PR DESCRIPTION
## :wrench: Problem

Our e2e test suite fails intermittently, requiring restarting the job manually

## :cake: Solution

Increase retries to 10 max, timeout to 120 seconds
