### PR TITLE
fix(generic): handle hub distance when one country is known

### DIFF
--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -938,10 +938,9 @@ computeTransportedMassImpacts ({ config } as requirements) (TransportCooling coo
     in
     computeTransportDistance requirements maybeFrom maybeTo
         |> Result.map
-            (Maybe.map (Transport.applyTransportRatios Split.zero)
-                -- default road transport to hub must be doubled when no distance could be determined
-                -- @see https://github.com/MTES-MCT/ecobalyse/issues/2345
-                >> Maybe.withDefault { defaultDistance | road = defaultDistance.road |> Quantity.multiplyBy 2 }
+            -- default road transport to hub must be doubled when no distance could be determined
+            -- @see https://github.com/MTES-MCT/ecobalyse/issues/2345
+            (Maybe.withDefault { defaultDistance | road = defaultDistance.road |> Quantity.multiplyBy 2 }
                 -- Always reset air transport, which is unhandled by design for now
                 -- see https://github.com/MTES-MCT/ecobalyse/issues/2282#issuecomment-4505548371
                 >> (\transport -> { transport | air = Quantity.zero })

--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -872,9 +872,32 @@ Notes:
 
 -}
 computeTransportDistance : Requirements db -> Maybe Country -> Maybe Country -> Result String (Maybe Transport)
-computeTransportDistance { db } maybeFrom maybeTo =
+computeTransportDistance { config, db } maybeFrom maybeTo =
+    let
+        { defaultDistance } =
+            config.transports
+
+        -- When a single country is known (departure or destination), sum its distance to hub and default
+        -- road transport
+        handleSingleKnownCountry country =
+            Just
+                { defaultDistance
+                  -- Always reset air transport, which is unhandled by design for now
+                  -- see https://github.com/MTES-MCT/ecobalyse/issues/2282#issuecomment-4505548371
+                    | air = Quantity.zero
+                    , road = Quantity.sum [ defaultDistance.road, country.distanceToHub ]
+                }
+    in
     case ( maybeFrom, maybeTo ) of
-        -- both countries are know: compute the distance
+        -- only departure country is known
+        ( Just from, Nothing ) ->
+            Ok <| handleSingleKnownCountry from
+
+        -- only destination country is known
+        ( Nothing, Just to ) ->
+            Ok <| handleSingleKnownCountry to
+
+        -- both countries are known
         ( Just from, Just to ) ->
             db.distances
                 |> Transport.getTransportBetween from to
@@ -900,8 +923,8 @@ computeTransportDistance { db } maybeFrom maybeTo =
                     )
                 |> Result.map Just
 
-        _ ->
-            -- at least one country is unknown; no distances returned
+        -- no countries are known; no distances returned
+        ( Nothing, Nothing ) ->
             Ok Nothing
 
 
@@ -909,10 +932,17 @@ computeTransportDistance { db } maybeFrom maybeTo =
 -}
 computeTransportedMassImpacts : Requirements db -> TransportCooling -> Maybe Country -> Maybe Country -> Mass -> Result String Transport
 computeTransportedMassImpacts ({ config } as requirements) (TransportCooling cooled) maybeFrom maybeTo mass =
+    let
+        { defaultDistance } =
+            config.transports
+    in
     computeTransportDistance requirements maybeFrom maybeTo
         |> Result.map
-            (Maybe.withDefault config.transports.defaultDistance
-                -- Reset default air transport distance
+            (Maybe.map (Transport.applyTransportRatios Split.zero)
+                -- default road transport to hub must be doubled when no distance could be determined
+                -- @see https://github.com/MTES-MCT/ecobalyse/issues/2345
+                >> Maybe.withDefault { defaultDistance | road = defaultDistance.road |> Quantity.multiplyBy 2 }
+                -- Always reset air transport, which is unhandled by design for now
                 -- see https://github.com/MTES-MCT/ecobalyse/issues/2282#issuecomment-4505548371
                 >> (\transport -> { transport | air = Quantity.zero })
             )

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -874,14 +874,7 @@ elementMaterialView config targetElement materialResults material amount =
             [ Component.getTotalImpacts materialResults
                 |> Format.formatImpact config.impact
             ]
-        , td [ class "pe-3 text-nowrap" ]
-            [ button
-                [ type_ "button"
-                , class "btn btn-sm btn-outline-secondary"
-                , onClick (config.removeElement targetElement)
-                ]
-                [ Icon.trash ]
-            ]
+        , td [ class "pe-3 text-nowrap" ] []
         ]
     , if complementsImpacts /= Complement.emptyComplementsResultsImpacts then
         tr [ class "fs-7" ]

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -1117,7 +1117,7 @@ regionSelector config =
             , onInput <|
                 \str ->
                     config.select <|
-                        if String.isEmpty str then
+                        if String.isEmpty str || str == "---" then
                             Nothing
 
                         else

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -779,7 +779,7 @@ elementEditModalView ({ query } as config) (( _, elementIndex ) as targetElement
 {-| Render transports from last transform step to assembly or distribution stage
 -}
 finalElementTransportView : Config db msg -> Maybe Country -> Mass -> Html msg
-finalElementTransportView ({ componentConfig, db, query } as config) elementCountry mass =
+finalElementTransportView ({ componentConfig, db, query, scope } as config) elementCountry mass =
     let
         maybeDestinationCountryCode =
             case ( List.length query.items > 1, query.assemblyCountry ) of
@@ -796,6 +796,7 @@ finalElementTransportView ({ componentConfig, db, query } as config) elementCoun
                     Nothing
     in
     db.countries
+        |> Scope.anyOf [ scope ]
         |> Country.resolveMaybe maybeDestinationCountryCode
         |> Result.map (elementTransportView config [ class "subdued" ] mass elementCountry)
         |> Result.withDefault (text "")
@@ -1072,12 +1073,12 @@ type alias RegionSelector msg =
 regionSelector : RegionSelector msg -> Html msg
 regionSelector config =
     let
-        countries =
+        scopedCountries =
             config.countries
                 |> Scope.anyOf [ config.scope ]
                 |> List.sortBy .name
     in
-    countries
+    scopedCountries
         |> List.map (\{ code, name } -> ( name, Just code ))
         |> (::) ( "Par défaut", Nothing )
         |> List.map
@@ -1105,7 +1106,8 @@ regionSelector config =
             , config.selected
                 |> Maybe.andThen
                     (\code ->
-                        Country.findByCode code countries
+                        scopedCountries
+                            |> Country.findByCode code
                             |> Result.map .name
                             |> Result.toMaybe
                     )

--- a/tests/Data/ComponentTest.elm
+++ b/tests/Data/ComponentTest.elm
@@ -212,7 +212,7 @@ suite =
                                         |> resetProcessElecAndHeat
                                         |> setProcessEcsImpact (Unit.impact 10)
                                     ]
-                                    |> Expect.within (Expect.Absolute 1) 33
+                                    |> Expect.within (Expect.Absolute 1) 95
                                 )
                             , it "should add impacts when one transform is passed (including elec and heat)"
                                 (getTestEcsImpact
@@ -222,7 +222,7 @@ suite =
                                                 |> Impact.insertWithoutAggregateComputation Definition.Ecs (Unit.impact 10)
                                       }
                                     ]
-                                    |> Expect.within (Expect.Absolute 1) 443
+                                    |> Expect.within (Expect.Absolute 1) 504
                                 )
                             , itFromResult "should compute apply custom mix impacts when a transform step country is set"
                                 -- fetch first country with mixes different from defaults
@@ -271,14 +271,14 @@ suite =
                                     [ fading |> resetProcessElecAndHeat |> setProcessEcsImpact (Unit.impact 10)
                                     , fading |> resetProcessElecAndHeat |> setProcessEcsImpact (Unit.impact 20)
                                     ]
-                                    |> Expect.within (Expect.Absolute 1) 76
+                                    |> Expect.within (Expect.Absolute 1) 200
                                 )
                             , it "should add impacts when multiple transforms are passed (including elec and heat)"
                                 (getTestEcsImpact
                                     [ fading |> setProcessEcsImpact (Unit.impact 10)
                                     , fading |> setProcessEcsImpact (Unit.impact 20)
                                     ]
-                                    |> Expect.within (Expect.Absolute 1) 896
+                                    |> Expect.within (Expect.Absolute 1) 1019
                                 )
                             ]
                         , suiteFromResult "unit mismatch"
@@ -345,7 +345,7 @@ suite =
                                   it "should handle impacts+qtyVariationRatio when applying transforms: impacts"
                                     (noElecAndNoHeat
                                         |> extractEcsImpact
-                                        |> Expect.within (Expect.Absolute 1) 155.13510000000002
+                                        |> Expect.within (Expect.Absolute 1) 247
                                     )
 
                                 -- (1kg * 0.5) * 0.5 == 0.25
@@ -371,7 +371,7 @@ suite =
                                 [ it "should handle impacts+qtyVariationRatio when applying transforms: impacts"
                                     (withElecAndHeat
                                         |> extractEcsImpact
-                                        |> Expect.within (Expect.Absolute 1) 769.7222644999999
+                                        |> Expect.within (Expect.Absolute 1) 862
                                     )
                                 , it "should handle impacts+qtyVariationRatio when applying transforms: mass"
                                     (withElecAndHeat
@@ -605,7 +605,7 @@ suite =
                                 [ it "should compute element impacts"
                                     (elementResults
                                         |> extractEcsImpact
-                                        |> Expect.within (Expect.Absolute 1) 2261
+                                        |> Expect.within (Expect.Absolute 1) 2389
                                     )
                                 , it "should compute element mass"
                                     (elementResults
@@ -631,7 +631,7 @@ suite =
                                     (results
                                         |> Result.map extractEcsImpact
                                         |> Result.withDefault 0
-                                        |> Expect.within (Expect.Absolute 1) 69261
+                                        |> Expect.within (Expect.Absolute 1) 150900
                                     )
                                 , it "should compute mass according on material unit"
                                     (results
@@ -977,17 +977,21 @@ suite =
                                     |> Result.withDefault 0
                                     |> Expect.greaterThan 30000
                                 )
-                            , it "should handle unknown country of departure"
-                                (Component.computeTransportDistance requirements Nothing (Just france)
-                                    |> Expect.equal (Ok Nothing)
-                                )
-                            , it "should handle unknown country of destination"
-                                (Component.computeTransportDistance requirements (Just portugal) Nothing
-                                    |> Expect.equal (Ok Nothing)
-                                )
                             , it "should handle both countries unknown"
                                 (Component.computeTransportDistance requirements Nothing Nothing
                                     |> Expect.equal (Ok Nothing)
+                                )
+                            , it "should handle unknown country of departure"
+                                (Component.computeTransportDistance requirements Nothing (Just france)
+                                    |> Result.map (Maybe.map (.road >> Length.inKilometers) >> Maybe.withDefault -99)
+                                    |> Result.withDefault -99
+                                    |> Expect.greaterThan 0
+                                )
+                            , it "should handle unknown country of destination"
+                                (Component.computeTransportDistance requirements (Just portugal) Nothing
+                                    |> Result.map (Maybe.map (.road >> Length.inKilometers) >> Maybe.withDefault -99)
+                                    |> Result.withDefault -99
+                                    |> Expect.greaterThan 0
                                 )
                             ]
                         )
@@ -1671,7 +1675,7 @@ testComponentConfig db =
             "transports": {
                 "defaultDistance": {
                     "air": 10000,
-                    "road": null,
+                    "road": 2000,
                     "sea": 18000
                 },
                 "modeProcesses": {

--- a/tests/Data/ComponentTest.elm
+++ b/tests/Data/ComponentTest.elm
@@ -981,18 +981,30 @@ suite =
                                 (Component.computeTransportDistance requirements Nothing Nothing
                                     |> Expect.equal (Ok Nothing)
                                 )
-                            , it "should handle unknown country of departure"
-                                (Component.computeTransportDistance requirements Nothing (Just france)
-                                    |> Result.map (Maybe.map (.road >> Length.inKilometers) >> Maybe.withDefault -99)
-                                    |> Result.withDefault -99
-                                    |> Expect.greaterThan 0
-                                )
-                            , it "should handle unknown country of destination"
-                                (Component.computeTransportDistance requirements (Just portugal) Nothing
-                                    |> Result.map (Maybe.map (.road >> Length.inKilometers) >> Maybe.withDefault -99)
-                                    |> Result.withDefault -99
-                                    |> Expect.greaterThan 0
-                                )
+                            , let
+                                getRoad from to =
+                                    Component.computeTransportDistance requirements from to
+                                        |> Result.map (Maybe.map (.road >> Length.inKilometers) >> Maybe.withDefault -99)
+                                        |> Result.withDefault -99
+                              in
+                              describe "single unknown country"
+                                [ it "should handle unknown country of departure"
+                                    (getRoad Nothing (Just france)
+                                        |> Expect.within (Expect.Absolute 1)
+                                            ([ france.distanceToHub, requirements.config.transports.defaultDistance.road ]
+                                                |> Quantity.sum
+                                                |> Length.inKilometers
+                                            )
+                                    )
+                                , it "should handle unknown country of destination"
+                                    (getRoad (Just portugal) Nothing
+                                        |> Expect.within (Expect.Absolute 1)
+                                            ([ portugal.distanceToHub, requirements.config.transports.defaultDistance.road ]
+                                                |> Quantity.sum
+                                                |> Length.inKilometers
+                                            )
+                                    )
+                                ]
                             ]
                         )
                     , suiteFromResult2 "computeTransportedMassImpacts"


### PR DESCRIPTION
Fixes #2345 

---

### 🚨 Notes

- impacts in tests have been updated not because the computation formula changed them, but because tests now use transport config defaults featuring 2000km of road transport instead of zero previously.