### PR TITLE
fix(generic): remove any air transport between transform steps

### DIFF
--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -539,7 +539,12 @@ applyTransforms requirements transportOptions initialCountry unit transforms mat
                         |> Result.andThen
                             (\mixes ->
                                 results
-                                    |> applyTransportedMassImpacts requirements transportOptions (extractMass results) previousCountry country
+                                    |> applyTransportedMassImpacts requirements
+                                        -- no intermediary transport to transformation can ever feature air transport
+                                        { transportOptions | byAir = Split.zero }
+                                        (extractMass results)
+                                        previousCountry
+                                        country
                                     |> Result.map (\results_ -> ( country, applyTransform process mixes results_ ))
                             )
                 )

--- a/tests/Data/ComponentTest.elm
+++ b/tests/Data/ComponentTest.elm
@@ -440,6 +440,22 @@ suite =
                                         , Component.TransformStage
                                         ]
                                 )
+                            , itFromResult "should never feature air transport for intermediary transport, even when byAir is set"
+                                (db.countries |> Country.findByCode (Country.Code "FR"))
+                                (\france ->
+                                    let
+                                        getEcsForByAir byAir =
+                                            getResults { defaultTransportOptions | byAir = byAir }
+                                                [ { country = Just france, process = fading }
+                                                , { country = Just france, process = fading }
+                                                ]
+                                                |> extractEcsImpact
+                                    in
+                                    -- forcing air transport ratio to full must not change the result, as it's always
+                                    -- reset to zero at the transform step level
+                                    getEcsForByAir Split.full
+                                        |> Expect.within (Expect.Absolute 0.00001) (getEcsForByAir Split.zero)
+                                )
                             ]
                         ]
                     , describe "compute"


### PR DESCRIPTION
## :wrench: Problem

When air transport is enabled for shipping to distribution, plane transport was computed and added between element transforms (at the production stage): it shouldn't.

## :cake: Solution

Remove that

## 🔍 Comments, context

Interesting discusssion on how and why the patch fixes the current issue https://mattermost.incubateur.net/fabnum-mte/pl/48syggsgqtfm3ynnmna7x4hftc

## :desert_island: How to test

Check that air transport is never added bewteen element transform steps.