### PR TITLE
fix(ui): route to the current URL when the component config is received

### DIFF
--- a/e2e/auth.spec.js
+++ b/e2e/auth.spec.js
@@ -6,6 +6,7 @@ import {
   extractUrlsFromText,
   loginUser,
   registerAndLoginUser,
+  reloadAndSettle,
 } from "./lib";
 
 import impacts from "../public/data/impacts.json";
@@ -80,14 +81,15 @@ test.describe("auth", () => {
     });
 
     await test.step("browser reload and auto-login", async () => {
-      await page.reload();
+      await reloadAndSettle(page);
 
       await expect(page.getByRole("heading", { name: "Mon compte" })).toBeVisible();
     });
 
     await test.step("api tokens", async () => {
-      await page.getByRole("link", { name: "Mon compte" }).click();
-
+      // We're already on the account page: re-clicking the "Mon compte" link would
+      // re-route to the same page, and the async page re-init would race the tab
+      // selection below and reset it.
       await page.getByRole("button", { name: "Jetons d’API" }).click();
 
       await expect(page.getByText("Aucun jeton d’API actif")).toBeVisible();
@@ -123,7 +125,7 @@ test.describe("auth", () => {
       const apiResponseJson = await apiResponse.json();
       expect(apiResponseJson.impacts.cch).toBeGreaterThan(0);
 
-      await page.reload();
+      await reloadAndSettle(page);
       await page.getByRole("button", { name: "Jetons d’API" }).click();
 
       await expect(apiTokensTable.locator("tbody tr td:nth-child(2)")).not.toHaveText(

--- a/e2e/auth.spec.js
+++ b/e2e/auth.spec.js
@@ -15,7 +15,9 @@ test.describe("auth", () => {
   // One stateful journey: Alice registers once. A retry would replay it against a
   // DB that still has her (state isn't reset between attempts) and hang — so we keep
   // this run deterministic and disable retries instead of masking flakiness.
-  test.describe.configure({ mode: "serial", retries: 0 });
+  // The journey spans a dozen steps and waits for the app boot chain several
+  // times, so it needs more than the default local test timeout.
+  test.describe.configure({ mode: "serial", retries: 0, timeout: 120_000 });
 
   test.beforeEach(async () => {
     await deleteAllEmails();
@@ -77,7 +79,11 @@ test.describe("auth", () => {
 
       await page.getByTestId("auth-login-confirm").click();
 
-      await expect(page.getByRole("heading", { name: "Mon compte" })).toBeVisible();
+      // Logging in triggers the detailed processes download, so allow more than
+      // the default expect timeout before the account page shows up.
+      await expect(page.getByRole("heading", { name: "Mon compte" })).toBeVisible({
+        timeout: 15_000,
+      });
     });
 
     await test.step("browser reload and auto-login", async () => {

--- a/e2e/lib.js
+++ b/e2e/lib.js
@@ -21,6 +21,17 @@ export function extractUrlsFromText(text) {
   return text.match(/\bhttps?:\/\/\S+/gi);
 }
 
+// On every full page load the app runs an async boot chain (detailed processes
+// for a logged-in user, then the component config) and re-initializes the
+// current page once the config lands, discarding any in-page state (selected
+// tab, etc.) touched in the meantime. Interacting before that re-init is a race:
+// wait for the network to go idle, which covers the whole chain including the
+// fetches issued by the re-initialized page itself.
+export async function reloadAndSettle(page) {
+  await page.reload();
+  await page.waitForLoadState("networkidle");
+}
+
 export async function loginUser(page, email) {
   await page.goto("/#/auth");
 

--- a/e2e/lib.js
+++ b/e2e/lib.js
@@ -12,7 +12,9 @@ export async function deleteAllEmails() {
 }
 
 export async function expectNotification(page, message) {
-  await expect(page.locator(".ToastTray").getByText(message)).toBeVisible();
+  // Some notifications conclude a slow chain (e.g. the detailed processes
+  // download after login), so allow more than the default expect timeout.
+  await expect(page.locator(".ToastTray").getByText(message)).toBeVisible({ timeout: 15_000 });
   // immediately close the notification to avoid unwanted accumulation
   await page.locator(".ToastTray").locator("button", { name: "Fermer" }).nth(0).click();
 }

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -90,8 +90,8 @@ type Msg
     | AppMsg App.Msg
     | AuthMsg Auth.Msg
     | ComponentAdminMsg ComponentAdmin.Msg
-    | ComponentConfigReceived Url (WebData Component.Config)
-    | DetailedProcessesReceived Url (BackendHttp.WebData String)
+    | ComponentConfigReceived (WebData Component.Config)
+    | DetailedProcessesReceived (BackendHttp.WebData String)
     | EditorialMsg Editorial.Msg
     | ExploreMsg Explore.Msg
     | FoodBuilderMsg FoodBuilder.Msg
@@ -143,11 +143,11 @@ init flags requestedUrl navKey =
                     [ Ports.appStarted ()
                     , Request.Version.loadVersion VersionReceived
                     , if Session.isAuthenticated session then
-                        Request.Auth.processes session (DetailedProcessesReceived requestedUrl)
+                        Request.Auth.processes session DetailedProcessesReceived
 
                       else
                         ComponentConfig.decode db
-                            |> Http.get "/data/components/config.json" (ComponentConfigReceived requestedUrl)
+                            |> Http.get "/data/components/config.json" ComponentConfigReceived
                     , Plausible.send session <| Plausible.PageViewed requestedUrl
                     ]
                 )
@@ -391,23 +391,26 @@ update rawMsg ({ state } as model) =
                     ( { model | tray = newTray }, Cmd.map (AppMsg << App.ToastMsg) newToastMsg )
 
                 -- Components
-                ( ComponentConfigReceived requestedUrl (RemoteData.Success componentConfig), currentPage ) ->
-                    setRoute requestedUrl
+                ( ComponentConfigReceived (RemoteData.Success componentConfig), currentPage ) ->
+                    -- Re-route to the *current* url, not the one requested at boot time: the user
+                    -- may have navigated elsewhere while the data was loading, and must not be
+                    -- redirected back to where they started.
+                    setRoute model.url
                         ( { model | state = currentPage |> Loaded { session | componentConfig = componentConfig } }
                         , Cmd.none
                         )
 
-                ( ComponentConfigReceived _ (RemoteData.Failure _), _ ) ->
+                ( ComponentConfigReceived (RemoteData.Failure _), _ ) ->
                     -- FIXME: log the error to the console, or as details of the error in the UI
                     notifyError model "Erreur" <|
                         "Impossible de charger la configuration des composants. Une configuration par défaut sera"
                             ++ " utilisée, les résultats fournis sont probablement invalides ou incomplets."
 
-                ( ComponentConfigReceived _ _, _ ) ->
+                ( ComponentConfigReceived _, _ ) ->
                     ( model, Cmd.none )
 
                 -- Detailed processes
-                ( DetailedProcessesReceived requestedUrl (RemoteData.Success rawDetailedProcessesJson), currentPage ) ->
+                ( DetailedProcessesReceived (RemoteData.Success rawDetailedProcessesJson), currentPage ) ->
                     -- When detailed processes are received, rebuild the entire static db using them
                     case StaticDb.db rawDetailedProcessesJson of
                         Err _ ->
@@ -417,10 +420,10 @@ update rawMsg ({ state } as model) =
                         Ok detailedDb ->
                             ( { model | state = currentPage |> Loaded { session | db = detailedDb } }
                             , ComponentConfig.decode detailedDb
-                                |> Http.get "/data/components/config.json" (ComponentConfigReceived requestedUrl)
+                                |> Http.get "/data/components/config.json" ComponentConfigReceived
                             )
 
-                ( DetailedProcessesReceived _ (RemoteData.Failure _), _ ) ->
+                ( DetailedProcessesReceived (RemoteData.Failure _), _ ) ->
                     notifyError model "Erreur" <|
                         "Impossible de charger les impacts détaillés; les impacts agrégés seront utilisés."
 


### PR DESCRIPTION
## :wrench: Problem

The auth e2e journey fails intermittently in CI (related to #2408), e.g. [this run](https://github.com/MTES-MCT/ecobalyse/actions/runs/27259767298/job/80502370611). When the component config is received, `Main` re-routes to the URL requested at boot time. After login the config lands late (behind the detailed processes download), so the user (or the test) gets redirected back to the landing page, and the elements the test reads are detached from the DOM.

## :cake: Solution

- **fix(ui)**: route to the current URL (`model.url`) instead of the boot-time one.
- **test(e2e)**: wait for the boot chain to settle after a reload before clicking a tab (`reloadAndSettle`), drop a redundant account re-click.
- **test(e2e)**: align timeouts with the slow post-login chain.

## :rotating_light:  Points to watch/comments

The page re-initialization on config arrival is kept as-is (pages must pick up the new db); removing it would be a deeper refactor.

## :desert_island: How to test

- CI should be green without retries (the auth spec previously failed about one run out of two).
- Locally: `npx playwright test e2e/auth.spec.js` (about 22s).
- On master, with a throttled network: log in, then navigate while data is still loading, and you are redirected back to where you started. With this PR you stay on the current page.