### PR TITLE
chore: display alias in explorer

### DIFF
--- a/src/Data/Process.elm
+++ b/src/Data/Process.elm
@@ -49,6 +49,7 @@ type Id
 -}
 type alias Process =
     { activityName : ActivityName
+    , alias : Maybe String
     , categories : List Category
     , comment : String
     , displayName : Maybe String
@@ -132,6 +133,7 @@ decode : Decoder Impact.Impacts -> Decoder Process
 decode impactsDecoder =
     Decode.succeed Process
         |> Pipe.required "activityName" (DU.decodeNonEmptyString |> Decode.map activityNameFromString)
+        |> DU.strictOptional "alias" DU.decodeNonEmptyString
         |> Pipe.required "categories" Category.decodeList
         |> Pipe.required "comment" Decode.string
         |> DU.strictOptional "displayName" DU.decodeNonEmptyString
@@ -155,6 +157,7 @@ encode : Process -> Encode.Value
 encode process =
     Encode.object
         [ ( "activityName", encodeActivityName process.activityName )
+        , ( "alias", EncodeExtra.maybe Encode.string process.alias )
         , ( "categories", Encode.list Category.encode process.categories )
         , ( "comment", Encode.string process.comment )
         , ( "displayName", EncodeExtra.maybe Encode.string process.displayName )

--- a/src/Page/Explore/Processes.elm
+++ b/src/Page/Explore/Processes.elm
@@ -61,6 +61,10 @@ baseColumns detailed scope =
                     a [ Route.href (Route.Explore scope (Dataset.Processes scope (Just process.id))) ]
                         [ code [] [ text (Process.idToString process.id) ] ]
       }
+    , { label = "Alias"
+      , toValue = Table.StringValue <| .alias >> Maybe.withDefault "N/A"
+      , toCell = .alias >> Maybe.map (\alias -> code [] [ text alias ]) >> Maybe.withDefault (text "N/A")
+      }
     , { label = "Nom"
       , toValue = Table.StringValue Process.getDisplayName
       , toCell = Process.getDisplayName >> tooltipedCell

--- a/src/Page/Explore/Processes.elm
+++ b/src/Page/Explore/Processes.elm
@@ -61,13 +61,15 @@ baseColumns detailed scope =
                     a [ Route.href (Route.Explore scope (Dataset.Processes scope (Just process.id))) ]
                         [ code [] [ text (Process.idToString process.id) ] ]
       }
-    , { label = "Alias"
-      , toValue = Table.StringValue <| .alias >> Maybe.withDefault "N/A"
-      , toCell = .alias >> Maybe.map (\alias -> code [] [ text alias ]) >> Maybe.withDefault (text "N/A")
-      }
     , { label = "Nom"
       , toValue = Table.StringValue Process.getDisplayName
-      , toCell = Process.getDisplayName >> tooltipedCell
+      , toCell =
+            \process ->
+                [ Just <| text <| Process.getDisplayName process
+                , process.alias |> Maybe.map (\alias_ -> code [ class "fs-9" ] [ text alias_ ])
+                ]
+                    |> List.filterMap identity
+                    |> div [ class "d-flex flex-column", title <| Process.getDisplayName process ]
       }
     , { label = "Nom technique"
       , toValue = Table.StringValue Process.getTechnicalName


### PR DESCRIPTION
Fix https://github.com/MTES-MCT/ecobalyse/issues/2443

## :rotating_light:  Points to watch/comments

- Alias is for now not present for every generic processes but could be in the future
- in old explorer, alias isn't present so its `N/A` 

## :desert_island: How to test

