### PR TITLE
chore: update dependabot settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,31 +4,37 @@ updates:
   # master (current version)
   - package-ecosystem: "npm"
     directory: "/"
-    schedule:
-      interval: "daily"
-    cooldown:
-      default-days: 7
     target-branch: "master"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      semver-major-days: 90 # it’s the maximum allowed by dependabot, 3 months
+    groups: # Group updates by patch type in the same PR
+      minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
   - package-ecosystem: "uv"
     directory: "/"
-    schedule:
-      interval: "daily"
-    cooldown:
-      default-days: 7
     target-branch: "master"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      semver-major-days: 90 # it’s the maximum allowed by dependabot, 3 months
+    groups:
+      minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
 
   # stable/textile (regulatory version)
   - package-ecosystem: "npm"
     directory: "/"
-    schedule:
-      interval: "daily"
-    cooldown:
-      default-days: 7
     target-branch: "stable/textile"
-  - package-ecosystem: "uv"
-    directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     cooldown:
-      default-days: 7
-    target-branch: "stable/textile"
+      semver-major-days: 90 # it’s the maximum allowed by dependabot, 3 months
+    groups:
+      minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]


### PR DESCRIPTION
fixes https://github.com/MTES-MCT/ecobalyse/issues/2326

Security updates are handled in the Github settings by default. I’ve removed updates for `uv` in the `stable/textile` branch as they are not used anymore.