### PR TITLE
fix(generic,contrib): consistent generic examples sorting.

### DIFF
--- a/backend/src/app/domain/contrib/services.py
+++ b/backend/src/app/domain/contrib/services.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import json
+from operator import itemgetter
 from uuid import uuid4
 
 import structlog
@@ -36,6 +37,11 @@ def format_example_contrib_pr(data: ExampleContribCreate, user: m.User) -> str:
 {format_json(data.query)}
 ```
 """
+
+
+def insert_example_sorted(examples: list[dict], example: dict) -> list[dict]:
+    """Insert an example and return the list ordered by id."""
+    return sorted([*examples, example], key=itemgetter("id"))
 
 
 async def github_request(
@@ -123,17 +129,19 @@ async def create_example_contrib_pr(
 
         file_sha = file_content["sha"]
         decoded_content = base64.b64decode(file_content["content"]).decode("utf-8")
-        examples = json.loads(decoded_content)
 
-        # append the new example to the examples list
-        examples.append(
+        # Note: we keep examples sorted by id to ensure each contribution is
+        #       inserted at a stable position and prevent constant merge conflicts
+        #       between concurrent contributions (see #2564)
+        examples = insert_example_sorted(
+            json.loads(decoded_content),
             {
                 "category": "",  # Note: example categories are currently unused
                 "id": example_id,
                 "name": name,
                 "query": data.query,
                 "scope": data.scope.value,
-            }
+            },
         )
         updated_examples_json = format_json(examples)
         updated_examples_base64 = base64.b64encode(

--- a/bin/sort_generic_examples.py
+++ b/bin/sort_generic_examples.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Sort generic examples.json files by ascending id.
+
+Usage:
+    $ uv run python bin/sort_generic_examples.py
+"""
+
+import json
+from pathlib import Path
+
+from app.lib.json import format_json
+
+SCOPES = ("food2", "object", "veli")
+
+
+def sort_examples_file(path):
+    examples = json.loads(path.read_text(encoding="utf-8"))
+    sorted_examples = sorted(examples, key=lambda example: example["id"])
+    path.write_text(format_json(sorted_examples), encoding="utf-8")
+    print(f"sorted {len(sorted_examples)} examples in {path}")
+
+
+for scope in SCOPES:
+    sort_examples_file(Path("public/data") / scope / "examples.json")

--- a/public/data/food2/examples.json
+++ b/public/data/food2/examples.json
@@ -1,6 +1,43 @@
 [
   {
     "category": "",
+    "id": "230897cd-a061-47e9-a945-5acec568de8e",
+    "name": "Farine de blé FR (1kg)",
+    "query": {
+      "assemblyCountry": "FR",
+      "components": [
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 1,
+                "material": {
+                  "country": "FR",
+                  "id": "d57e50ef-b40e-4abf-ab50-1edf4916a3e4"
+                },
+                "transforms": []
+              }
+            ],
+            "name": "Farine de blé FR"
+          },
+          "quantity": 1
+        }
+      ],
+      "packagings": [
+        {
+          "amount": 1,
+          "processId": "4f441c18-5f86-4a6b-945d-d559ac0780d3"
+        }
+      ],
+      "recyclable": true,
+      "transportOptions": {
+        "cooling": true
+      }
+    },
+    "scope": "food2"
+  },
+  {
+    "category": "",
     "id": "66b02aae-9c0c-48c4-aba4-e0ee191b5aca",
     "name": "Pizza bolognese Bio (350g)",
     "query": {
@@ -98,6 +135,43 @@
         {
           "amount": 1,
           "processId": "fa775270-4bc7-4f6d-a9d3-c80ed05ed90c"
+        }
+      ],
+      "recyclable": true,
+      "transportOptions": {
+        "cooling": true
+      }
+    },
+    "scope": "food2"
+  },
+  {
+    "category": "",
+    "id": "766efdbc-5102-4c60-bf3d-6ab32482ec28",
+    "name": "Farine de blé bio FR (1kg)",
+    "query": {
+      "assemblyCountry": "FR",
+      "components": [
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 1,
+                "material": {
+                  "country": "FR",
+                  "id": "3436324c-7835-4e9b-86c6-e9ca68a5e2af"
+                },
+                "transforms": []
+              }
+            ],
+            "name": "Farine de blé biologique FR"
+          },
+          "quantity": 1
+        }
+      ],
+      "packagings": [
+        {
+          "amount": 1,
+          "processId": "4f441c18-5f86-4a6b-945d-d559ac0780d3"
         }
       ],
       "recyclable": true,
@@ -216,6 +290,54 @@
   },
   {
     "category": "",
+    "id": "cb3576d3-703f-47f4-ae0c-de4f87c4c429",
+    "name": "Filet de poulet FR (250g)",
+    "query": {
+      "assemblyCountry": "FR",
+      "components": [
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 0.25,
+                "material": {
+                  "country": "FR",
+                  "id": "a360871c-fc35-4cb3-af2c-5eeb8bd6f984"
+                },
+                "transforms": []
+              }
+            ],
+            "name": "Blanc de poulet"
+          },
+          "quantity": 1
+        }
+      ],
+      "consumptions": [
+        {
+          "amount": 0.25,
+          "processId": "0048f6f5-5f8f-4a34-acde-4e0d909883d4"
+        },
+        {
+          "amount": 0.25,
+          "processId": "a49670fc-0642-43f6-a673-fe15dc7d88da"
+        }
+      ],
+      "distribution": "be66b80b-1500-4e3b-bfd2-87a89ff54031",
+      "packagings": [
+        {
+          "amount": 1,
+          "processId": "fd569276-f8b5-41aa-8005-e533ac16b9bc"
+        }
+      ],
+      "recyclable": true,
+      "transportOptions": {
+        "cooling": true
+      }
+    },
+    "scope": "food2"
+  },
+  {
+    "category": "",
     "id": "faff660e-2785-438e-ba1b-b04ab806b0cc",
     "name": "Pizza végétal (350g)",
     "query": {
@@ -320,128 +442,6 @@
         {
           "amount": 1,
           "processId": "fa775270-4bc7-4f6d-a9d3-c80ed05ed90c"
-        }
-      ],
-      "recyclable": true,
-      "transportOptions": {
-        "cooling": true
-      }
-    },
-    "scope": "food2"
-  },
-  {
-    "category": "",
-    "id": "cb3576d3-703f-47f4-ae0c-de4f87c4c429",
-    "name": "Filet de poulet FR (250g)",
-    "query": {
-      "assemblyCountry": "FR",
-      "components": [
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 0.25,
-                "material": {
-                  "country": "FR",
-                  "id": "a360871c-fc35-4cb3-af2c-5eeb8bd6f984"
-                },
-                "transforms": []
-              }
-            ],
-            "name": "Blanc de poulet"
-          },
-          "quantity": 1
-        }
-      ],
-      "consumptions": [
-        {
-          "amount": 0.25,
-          "processId": "0048f6f5-5f8f-4a34-acde-4e0d909883d4"
-        },
-        {
-          "amount": 0.25,
-          "processId": "a49670fc-0642-43f6-a673-fe15dc7d88da"
-        }
-      ],
-      "distribution": "be66b80b-1500-4e3b-bfd2-87a89ff54031",
-      "packagings": [
-        {
-          "amount": 1,
-          "processId": "fd569276-f8b5-41aa-8005-e533ac16b9bc"
-        }
-      ],
-      "recyclable": true,
-      "transportOptions": {
-        "cooling": true
-      }
-    },
-    "scope": "food2"
-  },
-   {
-    "category": "",
-    "id": "766efdbc-5102-4c60-bf3d-6ab32482ec28",
-    "name": "Farine de blé bio FR (1kg)",
-    "query": {
-      "assemblyCountry": "FR",
-      "components": [
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 1,
-                "material": {
-                  "country": "FR",
-                  "id": "3436324c-7835-4e9b-86c6-e9ca68a5e2af"
-                },
-                "transforms": []
-              }
-            ],
-            "name": "Farine de blé biologique FR"
-          },
-          "quantity": 1
-        }
-      ],
-      "packagings": [
-        {
-          "amount": 1,
-          "processId": "4f441c18-5f86-4a6b-945d-d559ac0780d3"
-        }
-      ],
-      "recyclable": true,
-      "transportOptions": {
-        "cooling": true
-      }
-    },
-    "scope": "food2"
-  },
-  {
-    "category": "",
-    "id": "230897cd-a061-47e9-a945-5acec568de8e",
-    "name": "Farine de blé FR (1kg)",
-    "query": {
-      "assemblyCountry": "FR",
-      "components": [
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 1,
-                "material": {
-                  "country": "FR",
-                  "id": "d57e50ef-b40e-4abf-ab50-1edf4916a3e4"
-                },
-                "transforms": []
-              }
-            ],
-            "name": "Farine de blé FR"
-          },
-          "quantity": 1
-        }
-      ],
-      "packagings": [
-        {
-          "amount": 1,
-          "processId": "4f441c18-5f86-4a6b-945d-d559ac0780d3"
         }
       ],
       "recyclable": true,

--- a/public/data/object/examples.json
+++ b/public/data/object/examples.json
@@ -1,120 +1,6 @@
 [
   {
     "category": "",
-    "id": "78dfebcb-9eab-4f83-a260-5c5dd24d4fac",
-    "name": "Table 4p chêne et acier (250 x 100)",
-    "query": {
-      "components": [
-        {
-          "id": "ad9d7f23-076b-49c5-93a4-ee1cd7b53973",
-          "quantity": 4
-        },
-        {
-          "id": "260bdfe2-1bef-4fd6-bf68-6e6174686d0d",
-          "quantity": 1
-        }
-      ]
-    },
-    "scope": "object"
-  },
-  {
-    "category": "",
-    "id": "ce3c8c63-aef7-4090-bbab-479e826fe4b9",
-    "name": "Boite plastique 45L (Chine)",
-    "query": {
-      "assemblyCountry": "CN",
-      "components": [
-        {
-          "id": "10e199b6-7e5f-47d9-bc85-9959c4e9ee62",
-          "quantity": 1,
-          "custom": {
-            "elements": [
-              {
-                "amount": 1.26,
-                "material": {
-                  "country": "CN",
-                  "id": "01d21ed5-9fc6-4d36-a0ea-cfea8035385b"
-                },
-                "transforms": [
-                  {
-                    "country": "CN",
-                    "id": "85b74ce2-2cbc-4d73-a5a2-5c5ffde16319"
-                  }
-                ]
-              }
-            ]
-          }
-        }
-      ]
-    },
-    "scope": "object"
-  },
-  {
-    "category": "",
-    "id": "6ab8769d-24d9-4990-8f00-ae1b5823946e",
-    "name": "Boite plastique 45L (France)",
-    "query": {
-      "assemblyCountry": "FR",
-      "components": [
-        {
-          "id": "10e199b6-7e5f-47d9-bc85-9959c4e9ee62",
-          "quantity": 1,
-          "custom": {
-            "elements": [
-              {
-                "amount": 1.26,
-                "material": {
-                  "country": "FR",
-                  "id": "01d21ed5-9fc6-4d36-a0ea-cfea8035385b"
-                },
-                "transforms": [
-                  {
-                    "country": "FR",
-                    "id": "85b74ce2-2cbc-4d73-a5a2-5c5ffde16319"
-                  }
-                ]
-              }
-            ]
-          }
-        }
-      ]
-    },
-    "scope": "object"
-  },
-  {
-    "category": "",
-    "id": "ebbff4dc-e52d-42e7-916b-ac191605b474",
-    "name": "Lot de 3 boîtes plastiques PP 45L",
-    "query": {
-      "components": [
-        {
-          "id": "10e199b6-7e5f-47d9-bc85-9959c4e9ee62",
-          "quantity": 3
-        }
-      ]
-    },
-    "scope": "object"
-  },
-  {
-    "category": "",
-    "id": "ffea421b-03b4-42f1-bf39-f17362d23cb0",
-    "name": "Jardinière d'extérieur en bois (séchage bois au four)",
-    "query": {
-      "components": [
-        {
-          "id": "6ff284b4-976d-4cf4-a4be-164f1c46ede2",
-          "quantity": 1
-        },
-        {
-          "id": "c5d86519-e56a-4ad7-aada-d4f7fffd5628",
-          "quantity": 1
-        }
-      ]
-    },
-    "scope": "object"
-  },
-  {
-    "category": "",
     "id": "141eea6d-5ebb-434b-9b02-da99db1d0a28",
     "name": "Jardinière d'extérieur en bois (séchage bois en extérieur)",
     "query": {
@@ -140,6 +26,56 @@
         {
           "id": "f27f7f37-5165-49b8-9f41-36d4f15a9170",
           "quantity": 2
+        }
+      ]
+    },
+    "scope": "object"
+  },
+  {
+    "category": "",
+    "id": "6ab8769d-24d9-4990-8f00-ae1b5823946e",
+    "name": "Boite plastique 45L (France)",
+    "query": {
+      "assemblyCountry": "FR",
+      "components": [
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 1.26,
+                "material": {
+                  "country": "FR",
+                  "id": "01d21ed5-9fc6-4d36-a0ea-cfea8035385b"
+                },
+                "transforms": [
+                  {
+                    "country": "FR",
+                    "id": "85b74ce2-2cbc-4d73-a5a2-5c5ffde16319"
+                  }
+                ]
+              }
+            ]
+          },
+          "id": "10e199b6-7e5f-47d9-bc85-9959c4e9ee62",
+          "quantity": 1
+        }
+      ]
+    },
+    "scope": "object"
+  },
+  {
+    "category": "",
+    "id": "78dfebcb-9eab-4f83-a260-5c5dd24d4fac",
+    "name": "Table 4p chêne et acier (250 x 100)",
+    "query": {
+      "components": [
+        {
+          "id": "ad9d7f23-076b-49c5-93a4-ee1cd7b53973",
+          "quantity": 4
+        },
+        {
+          "id": "260bdfe2-1bef-4fd6-bf68-6e6174686d0d",
+          "quantity": 1
         }
       ]
     },
@@ -202,8 +138,9 @@
                 "amount": 0.2,
                 "material": "ac028973-5dfa-47bc-868c-e49be116f53e",
                 "transforms": [
-                "ea284007-49a8-4be1-95fc-452ea180285a",
-                "7319ac9c-5796-412f-a1eb-58e01afa7708"]
+                  "ea284007-49a8-4be1-95fc-452ea180285a",
+                  "7319ac9c-5796-412f-a1eb-58e01afa7708"
+                ]
               }
             ],
             "name": "Charnières en acier"
@@ -230,6 +167,70 @@
         {
           "id": "53dc3966-c0c5-4ce2-86da-74583fda95ae",
           "quantity": 15
+        }
+      ]
+    },
+    "scope": "object"
+  },
+  {
+    "category": "",
+    "id": "ce3c8c63-aef7-4090-bbab-479e826fe4b9",
+    "name": "Boite plastique 45L (Chine)",
+    "query": {
+      "assemblyCountry": "CN",
+      "components": [
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 1.26,
+                "material": {
+                  "country": "CN",
+                  "id": "01d21ed5-9fc6-4d36-a0ea-cfea8035385b"
+                },
+                "transforms": [
+                  {
+                    "country": "CN",
+                    "id": "85b74ce2-2cbc-4d73-a5a2-5c5ffde16319"
+                  }
+                ]
+              }
+            ]
+          },
+          "id": "10e199b6-7e5f-47d9-bc85-9959c4e9ee62",
+          "quantity": 1
+        }
+      ]
+    },
+    "scope": "object"
+  },
+  {
+    "category": "",
+    "id": "ebbff4dc-e52d-42e7-916b-ac191605b474",
+    "name": "Lot de 3 boîtes plastiques PP 45L",
+    "query": {
+      "components": [
+        {
+          "id": "10e199b6-7e5f-47d9-bc85-9959c4e9ee62",
+          "quantity": 3
+        }
+      ]
+    },
+    "scope": "object"
+  },
+  {
+    "category": "",
+    "id": "ffea421b-03b4-42f1-bf39-f17362d23cb0",
+    "name": "Jardinière d'extérieur en bois (séchage bois au four)",
+    "query": {
+      "components": [
+        {
+          "id": "6ff284b4-976d-4cf4-a4be-164f1c46ede2",
+          "quantity": 1
+        },
+        {
+          "id": "c5d86519-e56a-4ad7-aada-d4f7fffd5628",
+          "quantity": 1
         }
       ]
     },

--- a/public/data/veli/examples.json
+++ b/public/data/veli/examples.json
@@ -1,509 +1,254 @@
 [
   {
-    "category": "Vélo",
-    "id": "cefc2585-7125-4610-aadc-69970a3d67d1",
-    "name": "Vélo à assistance électrique, majorant par défaut",
-    "query": {
-      "components": [
-        {
-          "id": "49a16258-22eb-4700-88c4-5e3d1af071e7",
-          "quantity": 1
-        },
-        {
-          "id": "990f4263-3b6c-48ce-92e8-566584edf5b2",
-          "quantity": 1
-        },
-        {
-          "id": "20b35f34-166f-4da7-abc4-54d2a64de367",
-          "quantity": 1
-        },
-        {
-          "id": "1bd0f5c3-c368-4a2f-b404-2214a6c9b677",
-          "quantity": 1
-        },
-        {
-          "id": "8e38b6a5-1c95-43f6-987f-2e368fc74edc",
-          "quantity": 2
-        },
-        {
-          "id": "a94918a7-8915-4841-9cdc-deec0536c724",
-          "quantity": 2
-        },
-        {
-          "id": "6ab7bcdf-7648-43b5-beb6-b4fa11c2d5d3",
-          "quantity": 1
-        },
-        {
-          "id": "b4d552ed-6a9b-4b29-b293-50349c62e1c0",
-          "quantity": 1
-        },
-        {
-          "id": "c4a8eb8f-b4c6-42b8-bd04-0f68e9083424",
-          "quantity": 1
-        },
-        {
-          "id": "4a273102-9973-4352-8683-2503aea7bfbb",
-          "quantity": 1
-        },
-        {
-          "id": "29a80ed1-26c9-419e-9f46-9c9b77d06458",
-          "quantity": 1
-        },
-        {
-          "id": "892ba9b4-e6d4-408c-87b9-5eef455f5b4f",
-          "quantity": 1
-        }
-      ],
-      "consumptions": [
-        {
-          "amount": 150,
-          "processId": "eec31f13-d00a-4741-a84f-85d887026f8c"
-        }
-      ]
-    },
-    "scope": "veli"
-  },
-  {
-    "category": "Vélo",
-    "id": "3d248bde-1c32-4a63-9dfe-8fb38acd7317",
-    "name": "Vélo à assistance électrique, assemblage France",
+    "category": "Veli",
+    "id": "1d70182c-53aa-4358-bc2c-9cd754be1ec4",
+    "name": "Veli actif, 25km/h max, 2.5kWh/100km, assemblage France",
     "query": {
       "assemblyCountry": "FR",
       "components": [
         {
-          "country": "CN",
-          "id": "49a16258-22eb-4700-88c4-5e3d1af071e7",
-          "quantity": 1
-        },
-        {
-          "country": "CN",
-          "id": "990f4263-3b6c-48ce-92e8-566584edf5b2",
-          "quantity": 1
-        },
-        {
-          "country": "DE",
-          "id": "20b35f34-166f-4da7-abc4-54d2a64de367",
-          "quantity": 1
-        },
-        {
-          "country": "CN",
-          "id": "1bd0f5c3-c368-4a2f-b404-2214a6c9b677",
-          "quantity": 1
-        },
-        {
-          "country": "CN",
-          "id": "8e38b6a5-1c95-43f6-987f-2e368fc74edc",
-          "quantity": 2
-        },
-        {
-          "country": "CN",
-          "id": "a94918a7-8915-4841-9cdc-deec0536c724",
-          "quantity": 2
-        },
-        {
-          "country": "CN",
-          "id": "6ab7bcdf-7648-43b5-beb6-b4fa11c2d5d3",
-          "quantity": 1
-        },
-        {
-          "country": "RAS",
-          "id": "b4d552ed-6a9b-4b29-b293-50349c62e1c0",
-          "quantity": 1
-        },
-        {
-          "country": "CN",
-          "id": "c4a8eb8f-b4c6-42b8-bd04-0f68e9083424",
-          "quantity": 1
-        },
-        {
-          "country": "RAS",
-          "id": "4a273102-9973-4352-8683-2503aea7bfbb",
-          "quantity": 1
-        },
-        {
-          "country": "RAS",
-          "id": "29a80ed1-26c9-419e-9f46-9c9b77d06458",
-          "quantity": 1
-        },
-        {
-          "country": "FR",
-          "id": "892ba9b4-e6d4-408c-87b9-5eef455f5b4f",
-          "quantity": 1
-        }
-      ],
-      "consumptions": [
-        {
-          "amount": 150,
-          "processId": "eec31f13-d00a-4741-a84f-85d887026f8c"
-        }
-      ]
-    },
-    "scope": "veli"
-  },
-  {
-    "category": "Vélo",
-    "id": "45c8f837-45ea-48d8-9de7-e9e58ea81acd",
-    "name": "Vélo à assistance électrique, fabrication France",
-    "query": {
-      "assemblyCountry": "FR",
-      "components": [
-        {
-          "country": "CN",
           "custom": {
             "elements": [
               {
-                "amount": 3,
-                "material": "4b4e1204-48ac-48ac-a0e2-ee2176202a5a",
+                "amount": 50,
+                "material": {
+                  "country": "RAS",
+                  "id": "3e514eac-185c-449e-bdc2-e1082ca0576d"
+                },
                 "transforms": [
-                  "d693bd0d-88d4-4370-81ee-597956bb58f0",
-                  "d935e937-35e7-471d-8d78-f5c6c1685adf"
-                ]
-              }
-            ]
-          },
-          "id": "49a16258-22eb-4700-88c4-5e3d1af071e7",
-          "quantity": 1
-        },
-        {
-          "country": "REE",
-          "id": "990f4263-3b6c-48ce-92e8-566584edf5b2",
-          "quantity": 1
-        },
-        {
-          "country": "DE",
-          "id": "20b35f34-166f-4da7-abc4-54d2a64de367",
-          "quantity": 1
-        },
-        {
-          "country": "FR",
-          "custom": {
-            "elements": [
-              {
-                "amount": 0.5,
-                "material": "baae8572-db4a-4cb8-8f74-e72ba5ef0116",
-                "transforms": [
-                  "d693bd0d-88d4-4370-81ee-597956bb58f0",
-                  "d935e937-35e7-471d-8d78-f5c6c1685adf"
-                ]
-              }
-            ]
-          },
-          "id": "1bd0f5c3-c368-4a2f-b404-2214a6c9b677",
-          "quantity": 1
-        },
-        {
-          "country": "RAS",
-          "id": "8e38b6a5-1c95-43f6-987f-2e368fc74edc",
-          "quantity": 2
-        },
-        {
-          "country": "FR",
-          "custom": {
-            "elements": [
-              {
-                "amount": 0.6,
-                "material": "4b4e1204-48ac-48ac-a0e2-ee2176202a5a",
-                "transforms": [
-                  "d693bd0d-88d4-4370-81ee-597956bb58f0",
-                  "d935e937-35e7-471d-8d78-f5c6c1685adf"
+                  {
+                    "country": "RAS",
+                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
+                  },
+                  {
+                    "country": "FR",
+                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
+                  }
                 ]
               },
               {
-                "amount": 0.5,
-                "material": "4b4e1204-48ac-48ac-a0e2-ee2176202a5a",
+                "amount": 5,
+                "material": {
+                  "country": "RAS",
+                  "id": "01d21ed5-9fc6-4d36-a0ea-cfea8035385b"
+                },
                 "transforms": [
-                  "d693bd0d-88d4-4370-81ee-597956bb58f0",
-                  "971df5fa-c32e-4a7e-b1aa-14ce9f240b5c"
+                  {
+                    "country": "RAS",
+                    "id": "85b74ce2-2cbc-4d73-a5a2-5c5ffde16319"
+                  }
                 ]
+              },
+              {
+                "amount": 0.002,
+                "material": {
+                  "country": "RAS",
+                  "id": "fba45d5f-64fc-44ae-ac75-9301c95c4657"
+                },
+                "transforms": [
+                  {
+                    "country": "RAS",
+                    "id": "e232270f-3a08-4536-8d8d-dcb4a2031e7b"
+                  }
+                ]
+              }
+            ],
+            "name": "Chassis-carosserie - veli actif (majorité acier, Asie)"
+          },
+          "id": "f50ff677-3501-49cb-b69d-e826d4114681",
+          "quantity": 1
+        },
+        {
+          "id": "7cfe659e-3764-4a8c-a25b-201396cbc09f",
+          "quantity": 1
+        },
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 5,
+                "material": {
+                  "country": "RAS",
+                  "id": "97a70d45-d7d5-4ee5-86b4-ee506300cdaa"
+                },
+                "transforms": []
               }
             ]
           },
-          "id": "a94918a7-8915-4841-9cdc-deec0536c724",
-          "quantity": 2
-        },
-        {
-          "country": "RAS",
-          "id": "6ab7bcdf-7648-43b5-beb6-b4fa11c2d5d3",
+          "id": "059f0f35-099d-4305-8a60-1666222dadb2",
           "quantity": 1
         },
         {
-          "country": "RAS",
-          "id": "b4d552ed-6a9b-4b29-b293-50349c62e1c0",
-          "quantity": 1
-        },
-        {
-          "country": "CN",
-          "id": "c4a8eb8f-b4c6-42b8-bd04-0f68e9083424",
-          "quantity": 1
-        },
-        {
-          "country": "RAS",
-          "id": "4a273102-9973-4352-8683-2503aea7bfbb",
-          "quantity": 1
-        },
-        {
-          "country": "REO",
           "custom": {
             "elements": [
               {
                 "amount": 0.3,
-                "material": "baae8572-db4a-4cb8-8f74-e72ba5ef0116",
+                "material": {
+                  "country": "RAS",
+                  "id": "63e8a99a-d6e5-4aa5-8fe4-71c3d0ca2107"
+                },
                 "transforms": [
-                  "d693bd0d-88d4-4370-81ee-597956bb58f0",
-                  "d935e937-35e7-471d-8d78-f5c6c1685adf"
+                  {
+                    "country": "RAS",
+                    "id": "971df5fa-c32e-4a7e-b1aa-14ce9f240b5c"
+                  },
+                  {
+                    "country": "RAS",
+                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
+                  }
                 ]
               },
               {
-                "amount": 0.05,
-                "material": "c5295f47-0307-48a6-8552-3705063af767",
+                "amount": 0.5,
+                "material": {
+                  "country": "FR",
+                  "id": "4b4e1204-48ac-48ac-a0e2-ee2176202a5a"
+                },
                 "transforms": [
-                  "85b74ce2-2cbc-4d73-a5a2-5c5ffde16319"
+                  {
+                    "country": "FR",
+                    "id": "d693bd0d-88d4-4370-81ee-597956bb58f0"
+                  }
                 ]
               }
             ]
           },
-          "id": "29a80ed1-26c9-419e-9f46-9c9b77d06458",
-          "quantity": 1
+          "id": "9d294fb5-b42a-4a9f-adc6-ff38f6d27e65",
+          "quantity": 4
         },
         {
-          "country": "FR",
           "custom": {
             "elements": [
               {
                 "amount": 0.8,
-                "material": "4b4e1204-48ac-48ac-a0e2-ee2176202a5a",
-                "transforms": [
-                  "d693bd0d-88d4-4370-81ee-597956bb58f0",
-                  "d935e937-35e7-471d-8d78-f5c6c1685adf"
-                ]
+                "material": {
+                  "country": "RAS",
+                  "id": "5f837a69-839d-4a49-9a30-19e1501ad51e"
+                },
+                "transforms": []
+              },
+              {
+                "amount": 0.2,
+                "material": {
+                  "country": "RAS",
+                  "id": "9c5a7a8e-6483-4da8-9cc2-0a90a30cb93a"
+                },
+                "transforms": []
               }
             ]
           },
-          "id": "892ba9b4-e6d4-408c-87b9-5eef455f5b4f",
+          "id": "8e38b6a5-1c95-43f6-987f-2e368fc74edc",
+          "quantity": 4
+        },
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 0.5,
+                "material": {
+                  "country": "RAS",
+                  "id": "c5295f47-0307-48a6-8552-3705063af767"
+                },
+                "transforms": [
+                  {
+                    "country": "RAS",
+                    "id": "85b74ce2-2cbc-4d73-a5a2-5c5ffde16319"
+                  }
+                ]
+              },
+              {
+                "amount": 2,
+                "material": {
+                  "id": "21a0d5b0-861e-4bed-98a9-46c61d2a0618"
+                },
+                "transforms": [
+                  {
+                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
+                  },
+                  {
+                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
+                  }
+                ]
+              },
+              {
+                "amount": 0.5,
+                "material": {
+                  "id": "20f5db04-a4c7-48ab-9903-38c65cd70be0"
+                },
+                "transforms": []
+              }
+            ]
+          },
+          "id": "ae9c83de-71bf-4f21-9030-afbfd4ad3b3a",
+          "quantity": 2
+        },
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 4,
+                "material": {
+                  "id": "30212fbf-5912-40eb-b2ab-87837361c462"
+                },
+                "transforms": [
+                  {
+                    "id": "981e74ea-ef7d-40d1-b25e-c5534446474e"
+                  },
+                  {
+                    "country": "RAS",
+                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
+                  }
+                ]
+              },
+              {
+                "amount": 4,
+                "material": {
+                  "id": "c5295f47-0307-48a6-8552-3705063af767"
+                },
+                "transforms": [
+                  {
+                    "country": "FR",
+                    "id": "85b74ce2-2cbc-4d73-a5a2-5c5ffde16319"
+                  }
+                ]
+              },
+              {
+                "amount": 1,
+                "material": {
+                  "country": "RAS",
+                  "id": "51956fb2-304d-4e63-a3ef-b3eed44fde38"
+                },
+                "transforms": []
+              }
+            ]
+          },
+          "id": "f134b3fd-0439-4b25-a06e-f1b8fd6e201c",
+          "quantity": 1
+        },
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 10,
+                "material": {
+                  "country": "RAS",
+                  "id": "6445c1fa-13a6-4058-8978-bcf2be63cd56"
+                },
+                "transforms": []
+              }
+            ]
+          },
+          "id": "6cb4338a-4663-4325-90b6-f7279a498c9b",
           "quantity": 1
         }
       ],
       "consumptions": [
         {
-          "amount": 150,
+          "amount": 850,
           "processId": "eec31f13-d00a-4741-a84f-85d887026f8c"
         }
-      ]
-    },
-    "scope": "veli"
-  },
-  {
-    "category": "Vélo",
-    "id": "611c25c4-46a8-4f07-acff-b0ce9c99b86c",
-    "name": "Vélo de ville, cadre aluminium, majorant par défaut",
-    "query": {
-      "assemblyCountry": "FR",
-      "components": [
-        {
-          "id": "1bd0f5c3-c368-4a2f-b404-2214a6c9b677",
-          "quantity": 1
-        },
-        {
-          "id": "8e38b6a5-1c95-43f6-987f-2e368fc74edc",
-          "quantity": 2
-        },
-        {
-          "id": "a94918a7-8915-4841-9cdc-deec0536c724",
-          "quantity": 2
-        },
-        {
-          "id": "6ab7bcdf-7648-43b5-beb6-b4fa11c2d5d3",
-          "quantity": 1
-        },
-        {
-          "id": "c4a8eb8f-b4c6-42b8-bd04-0f68e9083424",
-          "quantity": 1
-        },
-        {
-          "id": "892ba9b4-e6d4-408c-87b9-5eef455f5b4f",
-          "quantity": 1
-        },
-        {
-          "id": "658611b7-4b76-4f1d-aed7-55ec11f299e3",
-          "quantity": 1
-        },
-        {
-          "id": "347629ff-e7e9-4822-a948-d8c7757b2a9a",
-          "quantity": 1
-        },
-        {
-          "id": "d2228b50-8187-4940-92a5-6dffe2a2ba85",
-          "quantity": 1
-        }
-      ]
-    },
-    "scope": "veli"
-  },
-  {
-    "category": "Vélo",
-    "id": "b616ba6d-26bf-4624-8835-f70f35cdbd17",
-    "name": "Vélo de ville, cadre aluminium, assemblage France",
-    "query": {
-      "assemblyCountry": "FR",
-      "components": [
-        {
-          "country": "CN",
-          "id": "1bd0f5c3-c368-4a2f-b404-2214a6c9b677",
-          "quantity": 1
-        },
-        {
-          "country": "CN",
-          "id": "8e38b6a5-1c95-43f6-987f-2e368fc74edc",
-          "quantity": 2
-        },
-        {
-          "country": "CN",
-          "id": "a94918a7-8915-4841-9cdc-deec0536c724",
-          "quantity": 2
-        },
-        {
-          "country": "CN",
-          "id": "6ab7bcdf-7648-43b5-beb6-b4fa11c2d5d3",
-          "quantity": 1
-        },
-        {
-          "country": "CN",
-          "id": "c4a8eb8f-b4c6-42b8-bd04-0f68e9083424",
-          "quantity": 1
-        },
-        {
-          "country": "CN",
-          "id": "892ba9b4-e6d4-408c-87b9-5eef455f5b4f",
-          "quantity": 1
-        },
-        {
-          "country": "RAS",
-          "id": "658611b7-4b76-4f1d-aed7-55ec11f299e3",
-          "quantity": 1
-        },
-        {
-          "country": "RAS",
-          "id": "347629ff-e7e9-4822-a948-d8c7757b2a9a",
-          "quantity": 1
-        },
-        {
-          "country": "RAS",
-          "id": "d2228b50-8187-4940-92a5-6dffe2a2ba85",
-          "quantity": 1
-        }
-      ]
-    },
-    "scope": "veli"
-  },
-  {
-    "category": "Vélo",
-    "id": "e5fc4df5-e0be-49a0-a661-10f6e15773f1",
-    "name": "Vélo de ville, cadre aluminium, fabrication France",
-    "query": {
-      "assemblyCountry": "FR",
-      "components": [
-        {
-          "country": "FR",
-          "custom": {
-            "elements": [
-              {
-                "amount": 0.5,
-                "material": "baae8572-db4a-4cb8-8f74-e72ba5ef0116",
-                "transforms": [
-                  "d693bd0d-88d4-4370-81ee-597956bb58f0",
-                  "d935e937-35e7-471d-8d78-f5c6c1685adf"
-                ]
-              }
-            ]
-          },
-          "id": "1bd0f5c3-c368-4a2f-b404-2214a6c9b677",
-          "quantity": 1
-        },
-        {
-          "country": "RAS",
-          "id": "8e38b6a5-1c95-43f6-987f-2e368fc74edc",
-          "quantity": 2
-        },
-        {
-          "country": "FR",
-          "custom": {
-            "elements": [
-              {
-                "amount": 0.6,
-                "material": "4b4e1204-48ac-48ac-a0e2-ee2176202a5a",
-                "transforms": [
-                  "d693bd0d-88d4-4370-81ee-597956bb58f0",
-                  "d935e937-35e7-471d-8d78-f5c6c1685adf"
-                ]
-              },
-              {
-                "amount": 0.5,
-                "material": "4b4e1204-48ac-48ac-a0e2-ee2176202a5a",
-                "transforms": [
-                  "d693bd0d-88d4-4370-81ee-597956bb58f0",
-                  "971df5fa-c32e-4a7e-b1aa-14ce9f240b5c"
-                ]
-              }
-            ]
-          },
-          "id": "a94918a7-8915-4841-9cdc-deec0536c724",
-          "quantity": 2
-        },
-        {
-          "country": "RAS",
-          "id": "6ab7bcdf-7648-43b5-beb6-b4fa11c2d5d3",
-          "quantity": 1
-        },
-        {
-          "country": "RAS",
-          "id": "c4a8eb8f-b4c6-42b8-bd04-0f68e9083424",
-          "quantity": 1
-        },
-        {
-          "country": "FR",
-          "custom": {
-            "elements": [
-              {
-                "amount": 0.8,
-                "material": "4b4e1204-48ac-48ac-a0e2-ee2176202a5a",
-                "transforms": [
-                  "d693bd0d-88d4-4370-81ee-597956bb58f0",
-                  "d935e937-35e7-471d-8d78-f5c6c1685adf"
-                ]
-              }
-            ]
-          },
-          "id": "892ba9b4-e6d4-408c-87b9-5eef455f5b4f",
-          "quantity": 1
-        },
-        {
-          "country": "CN",
-          "custom": {
-            "elements": [
-              {
-                "amount": 2,
-                "material": "4b4e1204-48ac-48ac-a0e2-ee2176202a5a",
-                "transforms": [
-                  "d693bd0d-88d4-4370-81ee-597956bb58f0",
-                  "d935e937-35e7-471d-8d78-f5c6c1685adf"
-                ]
-              }
-            ]
-          },
-          "id": "49a16258-22eb-4700-88c4-5e3d1af071e7",
-          "quantity": 1
-        },
-        {
-          "country": "RAS",
-          "id": "347629ff-e7e9-4822-a948-d8c7757b2a9a",
-          "quantity": 1
-        },
-        {
-          "country": "RAS",
-          "id": "d2228b50-8187-4940-92a5-6dffe2a2ba85",
-          "quantity": 1
-        }
-      ]
+      ],
+      "recyclable": true
     },
     "scope": "veli"
   },
@@ -757,8 +502,8 @@
   },
   {
     "category": "Veli",
-    "id": "1d70182c-53aa-4358-bc2c-9cd754be1ec4",
-    "name": "Veli actif, 25km/h max, 2.5kWh/100km, assemblage France",
+    "id": "351a0340-2be5-49e1-a7e2-4d843e860fc5",
+    "name": "Veli, 90km/h max, 6kWh/100km, assemblage France",
     "query": {
       "assemblyCountry": "FR",
       "components": [
@@ -766,7 +511,20 @@
           "custom": {
             "elements": [
               {
-                "amount": 50,
+                "amount": 40,
+                "material": {
+                  "country": "RAS",
+                  "id": "01d21ed5-9fc6-4d36-a0ea-cfea8035385b"
+                },
+                "transforms": [
+                  {
+                    "country": "RAS",
+                    "id": "85b74ce2-2cbc-4d73-a5a2-5c5ffde16319"
+                  }
+                ]
+              },
+              {
+                "amount": 180,
                 "material": {
                   "country": "RAS",
                   "id": "3e514eac-185c-449e-bdc2-e1082ca0576d"
@@ -781,48 +539,21 @@
                     "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
                   }
                 ]
-              },
-              {
-                "amount": 5,
-                "material": {
-                  "country": "RAS",
-                  "id": "01d21ed5-9fc6-4d36-a0ea-cfea8035385b"
-                },
-                "transforms": [
-                  {
-                    "country": "RAS",
-                    "id": "85b74ce2-2cbc-4d73-a5a2-5c5ffde16319"
-                  }
-                ]
-              },
-              {
-                "amount": 0.002,
-                "material": {
-                  "country": "RAS",
-                  "id": "fba45d5f-64fc-44ae-ac75-9301c95c4657"
-                },
-                "transforms": [
-                  {
-                    "country": "RAS",
-                    "id": "e232270f-3a08-4536-8d8d-dcb4a2031e7b"
-                  }
-                ]
               }
-            ],
-            "name": "Chassis-carosserie - veli actif (majorité acier, Asie)"
+            ]
           },
-          "id": "f50ff677-3501-49cb-b69d-e826d4114681",
+          "id": "189674e0-737e-4d6d-aab0-3fdfc19839ed",
           "quantity": 1
         },
         {
-          "id": "7cfe659e-3764-4a8c-a25b-201396cbc09f",
+          "id": "57df64a3-278e-4e93-b836-9ba44b880fb5",
           "quantity": 1
         },
         {
           "custom": {
             "elements": [
               {
-                "amount": 5,
+                "amount": 50,
                 "material": {
                   "country": "RAS",
                   "id": "97a70d45-d7d5-4ee5-86b4-ee506300cdaa"
@@ -831,22 +562,67 @@
               }
             ]
           },
-          "id": "059f0f35-099d-4305-8a60-1666222dadb2",
+          "id": "da06c70f-5b61-4de7-bb51-5761818aa0dd",
           "quantity": 1
         },
         {
           "custom": {
             "elements": [
               {
-                "amount": 0.3,
+                "amount": 8,
                 "material": {
                   "country": "RAS",
-                  "id": "63e8a99a-d6e5-4aa5-8fe4-71c3d0ca2107"
+                  "id": "3e514eac-185c-449e-bdc2-e1082ca0576d"
                 },
                 "transforms": [
                   {
                     "country": "RAS",
-                    "id": "971df5fa-c32e-4a7e-b1aa-14ce9f240b5c"
+                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
+                  },
+                  {
+                    "country": "RAS",
+                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
+                  }
+                ]
+              }
+            ]
+          },
+          "id": "d4583813-5f80-47e0-b028-df438f59cfe2",
+          "quantity": 4
+        },
+        {
+          "id": "6b3d7f30-e87b-426c-93ed-3a1179238583",
+          "quantity": 4
+        },
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 20,
+                "material": {
+                  "country": "REO",
+                  "id": "42748244-0939-4da2-ad5f-206ce541d7ee"
+                },
+                "transforms": []
+              }
+            ]
+          },
+          "id": "d3ef64c0-3deb-4ef2-838d-015d8ece019e",
+          "quantity": 1
+        },
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 3,
+                "material": {
+                  "country": "RAS",
+                  "id": "3e514eac-185c-449e-bdc2-e1082ca0576d"
+                },
+                "transforms": [
+                  {
+                    "country": "RAS",
+                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
                   },
                   {
                     "country": "RAS",
@@ -855,79 +631,18 @@
                 ]
               },
               {
-                "amount": 0.5,
+                "amount": 3,
                 "material": {
-                  "country": "FR",
-                  "id": "4b4e1204-48ac-48ac-a0e2-ee2176202a5a"
-                },
-                "transforms": [
-                  {
-                    "country": "FR",
-                    "id": "d693bd0d-88d4-4370-81ee-597956bb58f0"
-                  }
-                ]
-              }
-            ]
-          },
-          "id": "9d294fb5-b42a-4a9f-adc6-ff38f6d27e65",
-          "quantity": 4
-        },
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 0.8,
-                "material": {
-                  "country": "RAS",
-                  "id": "5f837a69-839d-4a49-9a30-19e1501ad51e"
-                },
-                "transforms": []
-              },
-              {
-                "amount": 0.2,
-                "material": {
-                  "country": "RAS",
-                  "id": "9c5a7a8e-6483-4da8-9cc2-0a90a30cb93a"
-                },
-                "transforms": []
-              }
-            ]
-          },
-          "id": "8e38b6a5-1c95-43f6-987f-2e368fc74edc",
-          "quantity": 4
-        },
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 0.5,
-                "material": {
-                  "country": "RAS",
                   "id": "c5295f47-0307-48a6-8552-3705063af767"
                 },
                 "transforms": [
                   {
-                    "country": "RAS",
                     "id": "85b74ce2-2cbc-4d73-a5a2-5c5ffde16319"
                   }
                 ]
               },
               {
-                "amount": 2,
-                "material": {
-                  "id": "21a0d5b0-861e-4bed-98a9-46c61d2a0618"
-                },
-                "transforms": [
-                  {
-                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
-                  },
-                  {
-                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
-                  }
-                ]
-              },
-              {
-                "amount": 0.5,
+                "amount": 1,
                 "material": {
                   "id": "20f5db04-a4c7-48ab-9903-38c65cd70be0"
                 },
@@ -935,14 +650,352 @@
               }
             ]
           },
-          "id": "ae9c83de-71bf-4f21-9030-afbfd4ad3b3a",
+          "id": "1d2de15a-53d9-465d-a2cf-fa2c5f68f5e9",
           "quantity": 2
+        },
+        {
+          "id": "71086438-51a9-4980-ac3b-f24d5baa4cd5",
+          "quantity": 1
+        }
+      ],
+      "consumptions": [
+        {
+          "amount": 12000,
+          "processId": "eec31f13-d00a-4741-a84f-85d887026f8c"
+        }
+      ],
+      "recyclable": true
+    },
+    "scope": "veli"
+  },
+  {
+    "category": "Vélo",
+    "id": "3d248bde-1c32-4a63-9dfe-8fb38acd7317",
+    "name": "Vélo à assistance électrique, assemblage France",
+    "query": {
+      "assemblyCountry": "FR",
+      "components": [
+        {
+          "country": "CN",
+          "id": "49a16258-22eb-4700-88c4-5e3d1af071e7",
+          "quantity": 1
+        },
+        {
+          "country": "CN",
+          "id": "990f4263-3b6c-48ce-92e8-566584edf5b2",
+          "quantity": 1
+        },
+        {
+          "country": "DE",
+          "id": "20b35f34-166f-4da7-abc4-54d2a64de367",
+          "quantity": 1
+        },
+        {
+          "country": "CN",
+          "id": "1bd0f5c3-c368-4a2f-b404-2214a6c9b677",
+          "quantity": 1
+        },
+        {
+          "country": "CN",
+          "id": "8e38b6a5-1c95-43f6-987f-2e368fc74edc",
+          "quantity": 2
+        },
+        {
+          "country": "CN",
+          "id": "a94918a7-8915-4841-9cdc-deec0536c724",
+          "quantity": 2
+        },
+        {
+          "country": "CN",
+          "id": "6ab7bcdf-7648-43b5-beb6-b4fa11c2d5d3",
+          "quantity": 1
+        },
+        {
+          "country": "RAS",
+          "id": "b4d552ed-6a9b-4b29-b293-50349c62e1c0",
+          "quantity": 1
+        },
+        {
+          "country": "CN",
+          "id": "c4a8eb8f-b4c6-42b8-bd04-0f68e9083424",
+          "quantity": 1
+        },
+        {
+          "country": "RAS",
+          "id": "4a273102-9973-4352-8683-2503aea7bfbb",
+          "quantity": 1
+        },
+        {
+          "country": "RAS",
+          "id": "29a80ed1-26c9-419e-9f46-9c9b77d06458",
+          "quantity": 1
+        },
+        {
+          "country": "FR",
+          "id": "892ba9b4-e6d4-408c-87b9-5eef455f5b4f",
+          "quantity": 1
+        }
+      ],
+      "consumptions": [
+        {
+          "amount": 150,
+          "processId": "eec31f13-d00a-4741-a84f-85d887026f8c"
+        }
+      ]
+    },
+    "scope": "veli"
+  },
+  {
+    "category": "Voiture",
+    "id": "4582eb3a-e6fd-40e2-9c0c-fd65ac222ea8",
+    "name": "Voiture électrique CatB, 15kWh/100km, fabrication Europe de l'Ouest",
+    "query": {
+      "assemblyCountry": "REO",
+      "components": [
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 400,
+                "material": {
+                  "country": "REO",
+                  "id": "7cd80a58-6d07-4abc-ab41-624c0d1487c7"
+                },
+                "transforms": [
+                  {
+                    "country": "REO",
+                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
+                  },
+                  {
+                    "country": "REO",
+                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
+                  }
+                ]
+              },
+              {
+                "amount": 20,
+                "material": {
+                  "country": "REO",
+                  "id": "baae8572-db4a-4cb8-8f74-e72ba5ef0116"
+                },
+                "transforms": [
+                  {
+                    "country": "REO",
+                    "id": "971df5fa-c32e-4a7e-b1aa-14ce9f240b5c"
+                  },
+                  {
+                    "country": "REO",
+                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
+                  }
+                ]
+              },
+              {
+                "amount": 10,
+                "material": {
+                  "country": "REO",
+                  "id": "baae8572-db4a-4cb8-8f74-e72ba5ef0116"
+                },
+                "transforms": [
+                  {
+                    "country": "REO",
+                    "id": "d693bd0d-88d4-4370-81ee-597956bb58f0"
+                  },
+                  {
+                    "country": "REO",
+                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
+                  }
+                ]
+              },
+              {
+                "amount": 10,
+                "material": {
+                  "country": "REO",
+                  "id": "a363f079-bc3f-424a-a2e1-06b9c76b4fc3"
+                },
+                "transforms": []
+              },
+              {
+                "amount": 20,
+                "material": {
+                  "country": "REO",
+                  "id": "42748244-0939-4da2-ad5f-206ce541d7ee"
+                },
+                "transforms": []
+              },
+              {
+                "amount": 10,
+                "material": {
+                  "country": "REO",
+                  "id": "29b1a0f9-4887-49f7-910f-e50ad9e1b572"
+                },
+                "transforms": []
+              },
+              {
+                "amount": 220,
+                "material": {
+                  "country": "REO",
+                  "id": "c5295f47-0307-48a6-8552-3705063af767"
+                },
+                "transforms": [
+                  {
+                    "country": "REO",
+                    "id": "4a08bcab-5c25-4dec-961a-0f7208f40084"
+                  }
+                ]
+              }
+            ],
+            "name": "Carosserie"
+          },
+          "quantity": 1
         },
         {
           "custom": {
             "elements": [
               {
-                "amount": 4,
+                "amount": 80,
+                "material": {
+                  "country": "REO",
+                  "id": "97a70d45-d7d5-4ee5-86b4-ee506300cdaa"
+                },
+                "transforms": []
+              }
+            ],
+            "name": "Moteur"
+          },
+          "quantity": 1
+        },
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 10,
+                "material": {
+                  "country": "REO",
+                  "id": "7cd80a58-6d07-4abc-ab41-624c0d1487c7"
+                },
+                "transforms": [
+                  {
+                    "country": "REO",
+                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
+                  },
+                  {
+                    "country": "REO",
+                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
+                  }
+                ]
+              }
+            ],
+            "name": "Système de transmission"
+          },
+          "quantity": 1
+        },
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 220,
+                "material": {
+                  "country": "REO",
+                  "id": "7cd80a58-6d07-4abc-ab41-624c0d1487c7"
+                },
+                "transforms": [
+                  {
+                    "country": "REO",
+                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
+                  },
+                  {
+                    "country": "REO",
+                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
+                  }
+                ]
+              },
+              {
+                "amount": 15,
+                "material": {
+                  "country": "REO",
+                  "id": "30212fbf-5912-40eb-b2ab-87837361c462"
+                },
+                "transforms": [
+                  {
+                    "country": "REO",
+                    "id": "981e74ea-ef7d-40d1-b25e-c5534446474e"
+                  }
+                ]
+              },
+              {
+                "amount": 70,
+                "material": {
+                  "country": "REO",
+                  "id": "baae8572-db4a-4cb8-8f74-e72ba5ef0116"
+                },
+                "transforms": [
+                  {
+                    "country": "REO",
+                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
+                  }
+                ]
+              },
+              {
+                "amount": 15,
+                "material": {
+                  "country": "REO",
+                  "id": "baae8572-db4a-4cb8-8f74-e72ba5ef0116"
+                },
+                "transforms": [
+                  {
+                    "country": "REO",
+                    "id": "d693bd0d-88d4-4370-81ee-597956bb58f0"
+                  },
+                  {
+                    "country": "REO",
+                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
+                  }
+                ]
+              }
+            ],
+            "name": "Chassis"
+          },
+          "quantity": 1
+        },
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 8,
+                "material": {
+                  "country": "REO",
+                  "id": "5f837a69-839d-4a49-9a30-19e1501ad51e"
+                },
+                "transforms": []
+              }
+            ],
+            "name": "Pneus"
+          },
+          "quantity": 4
+        },
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 10,
+                "material": {
+                  "id": "c5295f47-0307-48a6-8552-3705063af767"
+                },
+                "transforms": [
+                  {
+                    "id": "4a08bcab-5c25-4dec-961a-0f7208f40084"
+                  }
+                ]
+              },
+              {
+                "amount": 10,
+                "material": {
+                  "id": "51956fb2-304d-4e63-a3ef-b3eed44fde38"
+                },
+                "transforms": []
+              },
+              {
+                "amount": 1,
                 "material": {
                   "id": "30212fbf-5912-40eb-b2ab-87837361c462"
                 },
@@ -951,14 +1004,328 @@
                     "id": "981e74ea-ef7d-40d1-b25e-c5534446474e"
                   },
                   {
-                    "country": "RAS",
+                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
+                  }
+                ]
+              }
+            ],
+            "name": "Composants divers"
+          },
+          "quantity": 1
+        },
+        {
+          "id": "52e25580-d83a-4de6-9632-da4303d5211d",
+          "quantity": 1
+        }
+      ],
+      "consumptions": [
+        {
+          "amount": 45000,
+          "processId": "eec31f13-d00a-4741-a84f-85d887026f8c"
+        }
+      ],
+      "recyclable": true
+    },
+    "scope": "veli"
+  },
+  {
+    "category": "Vélo",
+    "id": "45c8f837-45ea-48d8-9de7-e9e58ea81acd",
+    "name": "Vélo à assistance électrique, fabrication France",
+    "query": {
+      "assemblyCountry": "FR",
+      "components": [
+        {
+          "country": "CN",
+          "custom": {
+            "elements": [
+              {
+                "amount": 3,
+                "material": "4b4e1204-48ac-48ac-a0e2-ee2176202a5a",
+                "transforms": [
+                  "d693bd0d-88d4-4370-81ee-597956bb58f0",
+                  "d935e937-35e7-471d-8d78-f5c6c1685adf"
+                ]
+              }
+            ]
+          },
+          "id": "49a16258-22eb-4700-88c4-5e3d1af071e7",
+          "quantity": 1
+        },
+        {
+          "country": "REE",
+          "id": "990f4263-3b6c-48ce-92e8-566584edf5b2",
+          "quantity": 1
+        },
+        {
+          "country": "DE",
+          "id": "20b35f34-166f-4da7-abc4-54d2a64de367",
+          "quantity": 1
+        },
+        {
+          "country": "FR",
+          "custom": {
+            "elements": [
+              {
+                "amount": 0.5,
+                "material": "baae8572-db4a-4cb8-8f74-e72ba5ef0116",
+                "transforms": [
+                  "d693bd0d-88d4-4370-81ee-597956bb58f0",
+                  "d935e937-35e7-471d-8d78-f5c6c1685adf"
+                ]
+              }
+            ]
+          },
+          "id": "1bd0f5c3-c368-4a2f-b404-2214a6c9b677",
+          "quantity": 1
+        },
+        {
+          "country": "RAS",
+          "id": "8e38b6a5-1c95-43f6-987f-2e368fc74edc",
+          "quantity": 2
+        },
+        {
+          "country": "FR",
+          "custom": {
+            "elements": [
+              {
+                "amount": 0.6,
+                "material": "4b4e1204-48ac-48ac-a0e2-ee2176202a5a",
+                "transforms": [
+                  "d693bd0d-88d4-4370-81ee-597956bb58f0",
+                  "d935e937-35e7-471d-8d78-f5c6c1685adf"
+                ]
+              },
+              {
+                "amount": 0.5,
+                "material": "4b4e1204-48ac-48ac-a0e2-ee2176202a5a",
+                "transforms": [
+                  "d693bd0d-88d4-4370-81ee-597956bb58f0",
+                  "971df5fa-c32e-4a7e-b1aa-14ce9f240b5c"
+                ]
+              }
+            ]
+          },
+          "id": "a94918a7-8915-4841-9cdc-deec0536c724",
+          "quantity": 2
+        },
+        {
+          "country": "RAS",
+          "id": "6ab7bcdf-7648-43b5-beb6-b4fa11c2d5d3",
+          "quantity": 1
+        },
+        {
+          "country": "RAS",
+          "id": "b4d552ed-6a9b-4b29-b293-50349c62e1c0",
+          "quantity": 1
+        },
+        {
+          "country": "CN",
+          "id": "c4a8eb8f-b4c6-42b8-bd04-0f68e9083424",
+          "quantity": 1
+        },
+        {
+          "country": "RAS",
+          "id": "4a273102-9973-4352-8683-2503aea7bfbb",
+          "quantity": 1
+        },
+        {
+          "country": "REO",
+          "custom": {
+            "elements": [
+              {
+                "amount": 0.3,
+                "material": "baae8572-db4a-4cb8-8f74-e72ba5ef0116",
+                "transforms": [
+                  "d693bd0d-88d4-4370-81ee-597956bb58f0",
+                  "d935e937-35e7-471d-8d78-f5c6c1685adf"
+                ]
+              },
+              {
+                "amount": 0.05,
+                "material": "c5295f47-0307-48a6-8552-3705063af767",
+                "transforms": [
+                  "85b74ce2-2cbc-4d73-a5a2-5c5ffde16319"
+                ]
+              }
+            ]
+          },
+          "id": "29a80ed1-26c9-419e-9f46-9c9b77d06458",
+          "quantity": 1
+        },
+        {
+          "country": "FR",
+          "custom": {
+            "elements": [
+              {
+                "amount": 0.8,
+                "material": "4b4e1204-48ac-48ac-a0e2-ee2176202a5a",
+                "transforms": [
+                  "d693bd0d-88d4-4370-81ee-597956bb58f0",
+                  "d935e937-35e7-471d-8d78-f5c6c1685adf"
+                ]
+              }
+            ]
+          },
+          "id": "892ba9b4-e6d4-408c-87b9-5eef455f5b4f",
+          "quantity": 1
+        }
+      ],
+      "consumptions": [
+        {
+          "amount": 150,
+          "processId": "eec31f13-d00a-4741-a84f-85d887026f8c"
+        }
+      ]
+    },
+    "scope": "veli"
+  },
+  {
+    "category": "Veli",
+    "id": "48545a07-026b-46ca-8440-4bfaa036cce6",
+    "name": "Veli, 90km/h max, 6kWh/100km, fabrication France",
+    "query": {
+      "assemblyCountry": "FR",
+      "components": [
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 40,
+                "material": {
+                  "country": "FR",
+                  "id": "01d21ed5-9fc6-4d36-a0ea-cfea8035385b"
+                },
+                "transforms": [
+                  {
+                    "country": "FR",
+                    "id": "85b74ce2-2cbc-4d73-a5a2-5c5ffde16319"
+                  }
+                ]
+              },
+              {
+                "amount": 180,
+                "material": {
+                  "country": "FR",
+                  "id": "21a0d5b0-861e-4bed-98a9-46c61d2a0618"
+                },
+                "transforms": [
+                  {
+                    "country": "FR",
+                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
+                  },
+                  {
+                    "country": "FR",
+                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
+                  }
+                ]
+              }
+            ]
+          },
+          "id": "189674e0-737e-4d6d-aab0-3fdfc19839ed",
+          "quantity": 1
+        },
+        {
+          "id": "3b15918f-d21c-4251-96a8-548ac8444a04",
+          "quantity": 1
+        },
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 50,
+                "material": {
+                  "country": "REO",
+                  "id": "97a70d45-d7d5-4ee5-86b4-ee506300cdaa"
+                },
+                "transforms": []
+              }
+            ]
+          },
+          "id": "da06c70f-5b61-4de7-bb51-5761818aa0dd",
+          "quantity": 1
+        },
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 8,
+                "material": {
+                  "country": "FR",
+                  "id": "21a0d5b0-861e-4bed-98a9-46c61d2a0618"
+                },
+                "transforms": [
+                  {
+                    "country": "FR",
+                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
+                  },
+                  {
+                    "country": "FR",
+                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
+                  }
+                ]
+              }
+            ]
+          },
+          "id": "d4583813-5f80-47e0-b028-df438f59cfe2",
+          "quantity": 4
+        },
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 6,
+                "material": {
+                  "country": "FR",
+                  "id": "5f837a69-839d-4a49-9a30-19e1501ad51e"
+                },
+                "transforms": []
+              }
+            ]
+          },
+          "id": "6b3d7f30-e87b-426c-93ed-3a1179238583",
+          "quantity": 4
+        },
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 20,
+                "material": {
+                  "country": "FR",
+                  "id": "42748244-0939-4da2-ad5f-206ce541d7ee"
+                },
+                "transforms": []
+              }
+            ]
+          },
+          "id": "d3ef64c0-3deb-4ef2-838d-015d8ece019e",
+          "quantity": 1
+        },
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 3,
+                "material": {
+                  "country": "FR",
+                  "id": "21a0d5b0-861e-4bed-98a9-46c61d2a0618"
+                },
+                "transforms": [
+                  {
+                    "country": "FR",
+                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
+                  },
+                  {
+                    "country": "FR",
                     "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
                   }
                 ]
               },
               {
-                "amount": 4,
+                "amount": 3,
                 "material": {
+                  "country": "FR",
                   "id": "c5295f47-0307-48a6-8552-3705063af767"
                 },
                 "transforms": [
@@ -971,6 +1338,52 @@
               {
                 "amount": 1,
                 "material": {
+                  "country": "FR",
+                  "id": "20f5db04-a4c7-48ab-9903-38c65cd70be0"
+                },
+                "transforms": []
+              }
+            ]
+          },
+          "id": "1d2de15a-53d9-465d-a2cf-fa2c5f68f5e9",
+          "quantity": 2
+        },
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 16,
+                "material": {
+                  "country": "RAS",
+                  "id": "30212fbf-5912-40eb-b2ab-87837361c462"
+                },
+                "transforms": [
+                  {
+                    "country": "RAS",
+                    "id": "981e74ea-ef7d-40d1-b25e-c5534446474e"
+                  },
+                  {
+                    "country": "RAS",
+                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
+                  }
+                ]
+              },
+              {
+                "amount": 16,
+                "material": {
+                  "country": "RAS",
+                  "id": "c5295f47-0307-48a6-8552-3705063af767"
+                },
+                "transforms": [
+                  {
+                    "country": "RAS",
+                    "id": "85b74ce2-2cbc-4d73-a5a2-5c5ffde16319"
+                  }
+                ]
+              },
+              {
+                "amount": 4,
+                "material": {
                   "country": "RAS",
                   "id": "51956fb2-304d-4e63-a3ef-b3eed44fde38"
                 },
@@ -978,29 +1391,13 @@
               }
             ]
           },
-          "id": "f134b3fd-0439-4b25-a06e-f1b8fd6e201c",
-          "quantity": 1
-        },
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 10,
-                "material": {
-                  "country": "RAS",
-                  "id": "6445c1fa-13a6-4058-8978-bcf2be63cd56"
-                },
-                "transforms": []
-              }
-            ]
-          },
-          "id": "6cb4338a-4663-4325-90b6-f7279a498c9b",
+          "id": "71086438-51a9-4980-ac3b-f24d5baa4cd5",
           "quantity": 1
         }
       ],
       "consumptions": [
         {
-          "amount": 850,
+          "amount": 12000,
           "processId": "eec31f13-d00a-4741-a84f-85d887026f8c"
         }
       ],
@@ -1261,6 +1658,1713 @@
         }
       ],
       "recyclable": true
+    },
+    "scope": "veli"
+  },
+  {
+    "category": "Vélo",
+    "id": "611c25c4-46a8-4f07-acff-b0ce9c99b86c",
+    "name": "Vélo de ville, cadre aluminium, majorant par défaut",
+    "query": {
+      "assemblyCountry": "FR",
+      "components": [
+        {
+          "id": "1bd0f5c3-c368-4a2f-b404-2214a6c9b677",
+          "quantity": 1
+        },
+        {
+          "id": "8e38b6a5-1c95-43f6-987f-2e368fc74edc",
+          "quantity": 2
+        },
+        {
+          "id": "a94918a7-8915-4841-9cdc-deec0536c724",
+          "quantity": 2
+        },
+        {
+          "id": "6ab7bcdf-7648-43b5-beb6-b4fa11c2d5d3",
+          "quantity": 1
+        },
+        {
+          "id": "c4a8eb8f-b4c6-42b8-bd04-0f68e9083424",
+          "quantity": 1
+        },
+        {
+          "id": "892ba9b4-e6d4-408c-87b9-5eef455f5b4f",
+          "quantity": 1
+        },
+        {
+          "id": "658611b7-4b76-4f1d-aed7-55ec11f299e3",
+          "quantity": 1
+        },
+        {
+          "id": "347629ff-e7e9-4822-a948-d8c7757b2a9a",
+          "quantity": 1
+        },
+        {
+          "id": "d2228b50-8187-4940-92a5-6dffe2a2ba85",
+          "quantity": 1
+        }
+      ]
+    },
+    "scope": "veli"
+  },
+  {
+    "category": "Veli",
+    "id": "78517d8b-65cb-4205-accc-3bbab581176d",
+    "name": "Veli, 45km/h max, 5kWh/100km, fabrication France",
+    "query": {
+      "assemblyCountry": "FR",
+      "components": [
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 40,
+                "material": {
+                  "country": "FR",
+                  "id": "01d21ed5-9fc6-4d36-a0ea-cfea8035385b"
+                },
+                "transforms": [
+                  {
+                    "country": "FR",
+                    "id": "85b74ce2-2cbc-4d73-a5a2-5c5ffde16319"
+                  }
+                ]
+              },
+              {
+                "amount": 180,
+                "material": {
+                  "country": "FR",
+                  "id": "21a0d5b0-861e-4bed-98a9-46c61d2a0618"
+                },
+                "transforms": [
+                  {
+                    "country": "FR",
+                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
+                  },
+                  {
+                    "country": "FR",
+                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
+                  }
+                ]
+              }
+            ]
+          },
+          "id": "189674e0-737e-4d6d-aab0-3fdfc19839ed",
+          "quantity": 1
+        },
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 3.57,
+                "material": {
+                  "country": "FR",
+                  "id": "a1f6f8a2-5398-4b32-a3d6-fc0d88ca7a28"
+                },
+                "transforms": [
+                  {
+                    "country": "FR",
+                    "id": "7f217ecc-5de8-4ce1-b2c2-b5d192c6cdb9"
+                  }
+                ]
+              },
+              {
+                "amount": 1.5,
+                "material": {
+                  "country": "FR",
+                  "id": "baae8572-db4a-4cb8-8f74-e72ba5ef0116"
+                },
+                "transforms": [
+                  {
+                    "country": "FR",
+                    "id": "971df5fa-c32e-4a7e-b1aa-14ce9f240b5c"
+                  }
+                ]
+              },
+              {
+                "amount": 0.3,
+                "material": {
+                  "country": "FR",
+                  "id": "a363f079-bc3f-424a-a2e1-06b9c76b4fc3"
+                },
+                "transforms": [
+                  {
+                    "country": "FR",
+                    "id": "d077f06e-4ae9-48b7-8019-64523e577b95"
+                  }
+                ]
+              },
+              {
+                "amount": 1.9,
+                "material": {
+                  "country": "FR",
+                  "id": "21a0d5b0-861e-4bed-98a9-46c61d2a0618"
+                },
+                "transforms": [
+                  {
+                    "country": "FR",
+                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
+                  }
+                ]
+              },
+              {
+                "amount": 0.8,
+                "material": {
+                  "country": "FR",
+                  "id": "30212fbf-5912-40eb-b2ab-87837361c462"
+                },
+                "transforms": [
+                  {
+                    "country": "FR",
+                    "id": "981e74ea-ef7d-40d1-b25e-c5534446474e"
+                  }
+                ]
+              },
+              {
+                "amount": 0.9,
+                "material": {
+                  "country": "FR",
+                  "id": "c5295f47-0307-48a6-8552-3705063af767"
+                },
+                "transforms": [
+                  {
+                    "country": "FR",
+                    "id": "85b74ce2-2cbc-4d73-a5a2-5c5ffde16319"
+                  }
+                ]
+              },
+              {
+                "amount": 0.6,
+                "material": {
+                  "country": "RAS",
+                  "id": "51956fb2-304d-4e63-a3ef-b3eed44fde38"
+                },
+                "transforms": []
+              }
+            ],
+            "name": "Batterie Li-ion 1.2kWh, NMC811, France"
+          },
+          "id": "7cfe659e-3764-4a8c-a25b-201396cbc09f",
+          "quantity": 2
+        },
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 20,
+                "material": {
+                  "country": "REO",
+                  "id": "97a70d45-d7d5-4ee5-86b4-ee506300cdaa"
+                },
+                "transforms": []
+              }
+            ]
+          },
+          "id": "edca4c52-b34a-4906-b2e0-4f726bfcc8f7",
+          "quantity": 1
+        },
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 8,
+                "material": {
+                  "country": "REO",
+                  "id": "21a0d5b0-861e-4bed-98a9-46c61d2a0618"
+                },
+                "transforms": [
+                  {
+                    "country": "REO",
+                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
+                  },
+                  {
+                    "country": "REO",
+                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
+                  }
+                ]
+              }
+            ]
+          },
+          "id": "d4583813-5f80-47e0-b028-df438f59cfe2",
+          "quantity": 4
+        },
+        {
+          "id": "6b3d7f30-e87b-426c-93ed-3a1179238583",
+          "quantity": 4
+        },
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 20,
+                "material": {
+                  "country": "FR",
+                  "id": "42748244-0939-4da2-ad5f-206ce541d7ee"
+                },
+                "transforms": []
+              }
+            ]
+          },
+          "id": "d3ef64c0-3deb-4ef2-838d-015d8ece019e",
+          "quantity": 1
+        },
+        {
+          "id": "1d2de15a-53d9-465d-a2cf-fa2c5f68f5e9",
+          "quantity": 2
+        },
+        {
+          "id": "71086438-51a9-4980-ac3b-f24d5baa4cd5",
+          "quantity": 1
+        }
+      ],
+      "consumptions": [
+        {
+          "amount": 5000,
+          "processId": "eec31f13-d00a-4741-a84f-85d887026f8c"
+        }
+      ],
+      "recyclable": true
+    },
+    "scope": "veli"
+  },
+  {
+    "category": "Veli",
+    "id": "8d5768cb-dd06-4dbf-a6d8-62c1429beaf7",
+    "name": "Veli actif, 45km/h max, 4kWh/100km, Asie",
+    "query": {
+      "assemblyCountry": "RAS",
+      "components": [
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 50,
+                "material": {
+                  "country": "RAS",
+                  "id": "3e514eac-185c-449e-bdc2-e1082ca0576d"
+                },
+                "transforms": [
+                  {
+                    "country": "RAS",
+                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
+                  },
+                  {
+                    "country": "RAS",
+                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
+                  }
+                ]
+              },
+              {
+                "amount": 20,
+                "material": {
+                  "country": "RAS",
+                  "id": "01d21ed5-9fc6-4d36-a0ea-cfea8035385b"
+                },
+                "transforms": [
+                  {
+                    "country": "RAS",
+                    "id": "85b74ce2-2cbc-4d73-a5a2-5c5ffde16319"
+                  }
+                ]
+              },
+              {
+                "amount": 0.002,
+                "material": {
+                  "country": "RAS",
+                  "id": "fba45d5f-64fc-44ae-ac75-9301c95c4657"
+                },
+                "transforms": [
+                  {
+                    "country": "RAS",
+                    "id": "e232270f-3a08-4536-8d8d-dcb4a2031e7b"
+                  }
+                ]
+              },
+              {
+                "amount": 20,
+                "material": {
+                  "country": "RAS",
+                  "id": "63e8a99a-d6e5-4aa5-8fe4-71c3d0ca2107"
+                },
+                "transforms": [
+                  {
+                    "country": "RAS",
+                    "id": "971df5fa-c32e-4a7e-b1aa-14ce9f240b5c"
+                  },
+                  {
+                    "country": "RAS",
+                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
+                  }
+                ]
+              }
+            ],
+            "name": "Chassis-carosserie - veli actif, Asie"
+          },
+          "id": "f50ff677-3501-49cb-b69d-e826d4114681",
+          "quantity": 1
+        },
+        {
+          "id": "7cfe659e-3764-4a8c-a25b-201396cbc09f",
+          "quantity": 2
+        },
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 8,
+                "material": {
+                  "country": "RAS",
+                  "id": "97a70d45-d7d5-4ee5-86b4-ee506300cdaa"
+                },
+                "transforms": []
+              }
+            ],
+            "name": "Moteur électrique"
+          },
+          "id": "059f0f35-099d-4305-8a60-1666222dadb2",
+          "quantity": 1
+        },
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 0.3,
+                "material": {
+                  "country": "RAS",
+                  "id": "63e8a99a-d6e5-4aa5-8fe4-71c3d0ca2107"
+                },
+                "transforms": [
+                  {
+                    "country": "RAS",
+                    "id": "971df5fa-c32e-4a7e-b1aa-14ce9f240b5c"
+                  },
+                  {
+                    "country": "RAS",
+                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
+                  }
+                ]
+              },
+              {
+                "amount": 0.5,
+                "material": {
+                  "country": "RAS",
+                  "id": "63e8a99a-d6e5-4aa5-8fe4-71c3d0ca2107"
+                },
+                "transforms": [
+                  {
+                    "country": "RAS",
+                    "id": "d693bd0d-88d4-4370-81ee-597956bb58f0"
+                  }
+                ]
+              }
+            ]
+          },
+          "id": "9d294fb5-b42a-4a9f-adc6-ff38f6d27e65",
+          "quantity": 4
+        },
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 0.8,
+                "material": {
+                  "country": "RAS",
+                  "id": "5f837a69-839d-4a49-9a30-19e1501ad51e"
+                },
+                "transforms": []
+              },
+              {
+                "amount": 0.2,
+                "material": {
+                  "country": "RAS",
+                  "id": "9c5a7a8e-6483-4da8-9cc2-0a90a30cb93a"
+                },
+                "transforms": []
+              }
+            ]
+          },
+          "id": "8e38b6a5-1c95-43f6-987f-2e368fc74edc",
+          "quantity": 4
+        },
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 0.5,
+                "material": {
+                  "country": "RAS",
+                  "id": "c5295f47-0307-48a6-8552-3705063af767"
+                },
+                "transforms": [
+                  {
+                    "country": "RAS",
+                    "id": "85b74ce2-2cbc-4d73-a5a2-5c5ffde16319"
+                  }
+                ]
+              },
+              {
+                "amount": 2,
+                "material": {
+                  "country": "RAS",
+                  "id": "3e514eac-185c-449e-bdc2-e1082ca0576d"
+                },
+                "transforms": [
+                  {
+                    "country": "RAS",
+                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
+                  },
+                  {
+                    "country": "RAS",
+                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
+                  }
+                ]
+              },
+              {
+                "amount": 0.5,
+                "material": {
+                  "id": "20f5db04-a4c7-48ab-9903-38c65cd70be0"
+                },
+                "transforms": []
+              }
+            ]
+          },
+          "id": "ae9c83de-71bf-4f21-9030-afbfd4ad3b3a",
+          "quantity": 2
+        },
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 6,
+                "material": {
+                  "id": "30212fbf-5912-40eb-b2ab-87837361c462"
+                },
+                "transforms": [
+                  {
+                    "id": "981e74ea-ef7d-40d1-b25e-c5534446474e"
+                  },
+                  {
+                    "country": "RAS",
+                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
+                  }
+                ]
+              },
+              {
+                "amount": 5,
+                "material": {
+                  "id": "c5295f47-0307-48a6-8552-3705063af767"
+                },
+                "transforms": [
+                  {
+                    "country": "FR",
+                    "id": "85b74ce2-2cbc-4d73-a5a2-5c5ffde16319"
+                  }
+                ]
+              },
+              {
+                "amount": 1.5,
+                "material": {
+                  "country": "RAS",
+                  "id": "51956fb2-304d-4e63-a3ef-b3eed44fde38"
+                },
+                "transforms": []
+              }
+            ]
+          },
+          "id": "f134b3fd-0439-4b25-a06e-f1b8fd6e201c",
+          "quantity": 1
+        },
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 10,
+                "material": {
+                  "country": "RAS",
+                  "id": "6445c1fa-13a6-4058-8978-bcf2be63cd56"
+                },
+                "transforms": []
+              }
+            ]
+          },
+          "id": "6cb4338a-4663-4325-90b6-f7279a498c9b",
+          "quantity": 1
+        }
+      ],
+      "consumptions": [
+        {
+          "amount": 3800,
+          "processId": "eec31f13-d00a-4741-a84f-85d887026f8c"
+        }
+      ],
+      "recyclable": true
+    },
+    "scope": "veli"
+  },
+  {
+    "category": "Veli",
+    "id": "a6a45e4e-c92c-4382-98b4-76ae7f95d1c5",
+    "name": "Veli, 90km/h max, 6kWh/100km, Asie",
+    "query": {
+      "assemblyCountry": "RAS",
+      "components": [
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 40,
+                "material": {
+                  "country": "RAS",
+                  "id": "01d21ed5-9fc6-4d36-a0ea-cfea8035385b"
+                },
+                "transforms": [
+                  {
+                    "country": "RAS",
+                    "id": "85b74ce2-2cbc-4d73-a5a2-5c5ffde16319"
+                  }
+                ]
+              },
+              {
+                "amount": 180,
+                "material": {
+                  "country": "RAS",
+                  "id": "3e514eac-185c-449e-bdc2-e1082ca0576d"
+                },
+                "transforms": [
+                  {
+                    "country": "RAS",
+                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
+                  },
+                  {
+                    "country": "RAS",
+                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
+                  }
+                ]
+              }
+            ]
+          },
+          "id": "189674e0-737e-4d6d-aab0-3fdfc19839ed",
+          "quantity": 1
+        },
+        {
+          "id": "57df64a3-278e-4e93-b836-9ba44b880fb5",
+          "quantity": 1
+        },
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 50,
+                "material": {
+                  "country": "RAS",
+                  "id": "97a70d45-d7d5-4ee5-86b4-ee506300cdaa"
+                },
+                "transforms": []
+              }
+            ]
+          },
+          "id": "da06c70f-5b61-4de7-bb51-5761818aa0dd",
+          "quantity": 1
+        },
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 8,
+                "material": {
+                  "country": "RAS",
+                  "id": "3e514eac-185c-449e-bdc2-e1082ca0576d"
+                },
+                "transforms": [
+                  {
+                    "country": "RAS",
+                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
+                  },
+                  {
+                    "country": "RAS",
+                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
+                  }
+                ]
+              }
+            ]
+          },
+          "id": "d4583813-5f80-47e0-b028-df438f59cfe2",
+          "quantity": 4
+        },
+        {
+          "id": "6b3d7f30-e87b-426c-93ed-3a1179238583",
+          "quantity": 4
+        },
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 20,
+                "material": {
+                  "country": "REO",
+                  "id": "42748244-0939-4da2-ad5f-206ce541d7ee"
+                },
+                "transforms": []
+              }
+            ]
+          },
+          "id": "d3ef64c0-3deb-4ef2-838d-015d8ece019e",
+          "quantity": 1
+        },
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 3,
+                "material": {
+                  "country": "RAS",
+                  "id": "3e514eac-185c-449e-bdc2-e1082ca0576d"
+                },
+                "transforms": [
+                  {
+                    "country": "RAS",
+                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
+                  },
+                  {
+                    "country": "RAS",
+                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
+                  }
+                ]
+              },
+              {
+                "amount": 3,
+                "material": {
+                  "id": "c5295f47-0307-48a6-8552-3705063af767"
+                },
+                "transforms": [
+                  {
+                    "id": "85b74ce2-2cbc-4d73-a5a2-5c5ffde16319"
+                  }
+                ]
+              },
+              {
+                "amount": 1,
+                "material": {
+                  "id": "20f5db04-a4c7-48ab-9903-38c65cd70be0"
+                },
+                "transforms": []
+              }
+            ]
+          },
+          "id": "1d2de15a-53d9-465d-a2cf-fa2c5f68f5e9",
+          "quantity": 2
+        },
+        {
+          "id": "71086438-51a9-4980-ac3b-f24d5baa4cd5",
+          "quantity": 1
+        }
+      ],
+      "consumptions": [
+        {
+          "amount": 12000,
+          "processId": "eec31f13-d00a-4741-a84f-85d887026f8c"
+        }
+      ],
+      "recyclable": true
+    },
+    "scope": "veli"
+  },
+  {
+    "category": "Voiture",
+    "id": "a6fb87c9-13fa-44d9-a679-d808a70e5546",
+    "name": "Voiture essence CatB, 5.5L/100km, fabrication Europe de l'Ouest",
+    "query": {
+      "assemblyCountry": "REO",
+      "components": [
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 430,
+                "material": {
+                  "country": "REO",
+                  "id": "7cd80a58-6d07-4abc-ab41-624c0d1487c7"
+                },
+                "transforms": [
+                  {
+                    "country": "REO",
+                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
+                  },
+                  {
+                    "country": "REO",
+                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
+                  }
+                ]
+              },
+              {
+                "amount": 5,
+                "material": {
+                  "country": "REO",
+                  "id": "baae8572-db4a-4cb8-8f74-e72ba5ef0116"
+                },
+                "transforms": [
+                  {
+                    "country": "REO",
+                    "id": "971df5fa-c32e-4a7e-b1aa-14ce9f240b5c"
+                  },
+                  {
+                    "country": "REO",
+                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
+                  }
+                ]
+              },
+              {
+                "amount": 5,
+                "material": {
+                  "country": "REO",
+                  "id": "baae8572-db4a-4cb8-8f74-e72ba5ef0116"
+                },
+                "transforms": [
+                  {
+                    "country": "REO",
+                    "id": "d693bd0d-88d4-4370-81ee-597956bb58f0"
+                  },
+                  {
+                    "country": "REO",
+                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
+                  }
+                ]
+              },
+              {
+                "amount": 6,
+                "material": {
+                  "country": "REO",
+                  "id": "a363f079-bc3f-424a-a2e1-06b9c76b4fc3"
+                },
+                "transforms": []
+              },
+              {
+                "amount": 17,
+                "material": {
+                  "country": "REO",
+                  "id": "42748244-0939-4da2-ad5f-206ce541d7ee"
+                },
+                "transforms": []
+              },
+              {
+                "amount": 10,
+                "material": {
+                  "country": "REO",
+                  "id": "29b1a0f9-4887-49f7-910f-e50ad9e1b572"
+                },
+                "transforms": []
+              },
+              {
+                "amount": 130,
+                "material": {
+                  "country": "REO",
+                  "id": "c5295f47-0307-48a6-8552-3705063af767"
+                },
+                "transforms": [
+                  {
+                    "country": "REO",
+                    "id": "4a08bcab-5c25-4dec-961a-0f7208f40084"
+                  }
+                ]
+              }
+            ],
+            "name": "Carosserie"
+          },
+          "quantity": 1
+        },
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 170,
+                "material": {
+                  "country": "REO",
+                  "id": "8b28671a-83f2-46e6-8c1c-e973a47dde97"
+                },
+                "transforms": []
+              }
+            ],
+            "name": "Groupe motopropulseur"
+          },
+          "quantity": 1
+        },
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 40,
+                "material": {
+                  "country": "REO",
+                  "id": "7cd80a58-6d07-4abc-ab41-624c0d1487c7"
+                },
+                "transforms": [
+                  {
+                    "country": "REO",
+                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
+                  },
+                  {
+                    "country": "REO",
+                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
+                  }
+                ]
+              },
+              {
+                "amount": 10,
+                "material": {
+                  "country": "REO",
+                  "id": "30212fbf-5912-40eb-b2ab-87837361c462"
+                },
+                "transforms": [
+                  {
+                    "country": "REO",
+                    "id": "981e74ea-ef7d-40d1-b25e-c5534446474e"
+                  },
+                  {
+                    "country": "REO",
+                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
+                  }
+                ]
+              },
+              {
+                "amount": 25,
+                "material": {
+                  "country": "REO",
+                  "id": "4b4e1204-48ac-48ac-a0e2-ee2176202a5a"
+                },
+                "transforms": [
+                  {
+                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
+                  }
+                ]
+              }
+            ],
+            "name": "Système de transmission"
+          },
+          "quantity": 1
+        },
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 200,
+                "material": {
+                  "country": "REO",
+                  "id": "7cd80a58-6d07-4abc-ab41-624c0d1487c7"
+                },
+                "transforms": [
+                  {
+                    "country": "REO",
+                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
+                  },
+                  {
+                    "country": "REO",
+                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
+                  }
+                ]
+              },
+              {
+                "amount": 15,
+                "material": {
+                  "country": "REO",
+                  "id": "30212fbf-5912-40eb-b2ab-87837361c462"
+                },
+                "transforms": [
+                  {
+                    "country": "REO",
+                    "id": "981e74ea-ef7d-40d1-b25e-c5534446474e"
+                  }
+                ]
+              },
+              {
+                "amount": 30,
+                "material": {
+                  "country": "REO",
+                  "id": "baae8572-db4a-4cb8-8f74-e72ba5ef0116"
+                },
+                "transforms": [
+                  {
+                    "country": "REO",
+                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
+                  }
+                ]
+              },
+              {
+                "amount": 10,
+                "material": {
+                  "country": "REO",
+                  "id": "baae8572-db4a-4cb8-8f74-e72ba5ef0116"
+                },
+                "transforms": [
+                  {
+                    "country": "REO",
+                    "id": "d693bd0d-88d4-4370-81ee-597956bb58f0"
+                  },
+                  {
+                    "country": "REO",
+                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
+                  }
+                ]
+              }
+            ],
+            "name": "Chassis"
+          },
+          "quantity": 1
+        },
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 20,
+                "material": {
+                  "country": "REO",
+                  "id": "f92ed520-3845-4a5a-8745-e87fd6863f03"
+                },
+                "transforms": []
+              }
+            ],
+            "name": "Batterie plomb"
+          },
+          "quantity": 1
+        },
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 8,
+                "material": {
+                  "country": "REO",
+                  "id": "5f837a69-839d-4a49-9a30-19e1501ad51e"
+                },
+                "transforms": []
+              }
+            ],
+            "name": "Pneus"
+          },
+          "quantity": 4
+        },
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 2,
+                "material": {
+                  "id": "c5295f47-0307-48a6-8552-3705063af767"
+                },
+                "transforms": [
+                  {
+                    "id": "4a08bcab-5c25-4dec-961a-0f7208f40084"
+                  }
+                ]
+              },
+              {
+                "amount": 2,
+                "material": {
+                  "id": "51956fb2-304d-4e63-a3ef-b3eed44fde38"
+                },
+                "transforms": []
+              },
+              {
+                "amount": 1,
+                "material": {
+                  "id": "30212fbf-5912-40eb-b2ab-87837361c462"
+                },
+                "transforms": [
+                  {
+                    "id": "981e74ea-ef7d-40d1-b25e-c5534446474e"
+                  },
+                  {
+                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
+                  }
+                ]
+              }
+            ],
+            "name": "Composants divers"
+          },
+          "quantity": 1
+        }
+      ],
+      "consumptions": [
+        {
+          "amount": 16500,
+          "processId": "96da7da0-19f6-46fb-b7d7-2d888e7046e0"
+        }
+      ],
+      "recyclable": true
+    },
+    "scope": "veli"
+  },
+  {
+    "category": "Vélo",
+    "id": "b616ba6d-26bf-4624-8835-f70f35cdbd17",
+    "name": "Vélo de ville, cadre aluminium, assemblage France",
+    "query": {
+      "assemblyCountry": "FR",
+      "components": [
+        {
+          "country": "CN",
+          "id": "1bd0f5c3-c368-4a2f-b404-2214a6c9b677",
+          "quantity": 1
+        },
+        {
+          "country": "CN",
+          "id": "8e38b6a5-1c95-43f6-987f-2e368fc74edc",
+          "quantity": 2
+        },
+        {
+          "country": "CN",
+          "id": "a94918a7-8915-4841-9cdc-deec0536c724",
+          "quantity": 2
+        },
+        {
+          "country": "CN",
+          "id": "6ab7bcdf-7648-43b5-beb6-b4fa11c2d5d3",
+          "quantity": 1
+        },
+        {
+          "country": "CN",
+          "id": "c4a8eb8f-b4c6-42b8-bd04-0f68e9083424",
+          "quantity": 1
+        },
+        {
+          "country": "CN",
+          "id": "892ba9b4-e6d4-408c-87b9-5eef455f5b4f",
+          "quantity": 1
+        },
+        {
+          "country": "RAS",
+          "id": "658611b7-4b76-4f1d-aed7-55ec11f299e3",
+          "quantity": 1
+        },
+        {
+          "country": "RAS",
+          "id": "347629ff-e7e9-4822-a948-d8c7757b2a9a",
+          "quantity": 1
+        },
+        {
+          "country": "RAS",
+          "id": "d2228b50-8187-4940-92a5-6dffe2a2ba85",
+          "quantity": 1
+        }
+      ]
+    },
+    "scope": "veli"
+  },
+  {
+    "category": "Veli",
+    "id": "b6791d66-3c1c-4214-9637-aa576cb1ee63",
+    "name": "Veli, 45km/h max, 5kWh/100km, Asie",
+    "query": {
+      "assemblyCountry": "RAS",
+      "components": [
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 40,
+                "material": {
+                  "country": "RAS",
+                  "id": "01d21ed5-9fc6-4d36-a0ea-cfea8035385b"
+                },
+                "transforms": [
+                  {
+                    "country": "RAS",
+                    "id": "85b74ce2-2cbc-4d73-a5a2-5c5ffde16319"
+                  }
+                ]
+              },
+              {
+                "amount": 180,
+                "material": {
+                  "country": "RAS",
+                  "id": "3e514eac-185c-449e-bdc2-e1082ca0576d"
+                },
+                "transforms": [
+                  {
+                    "country": "RAS",
+                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
+                  },
+                  {
+                    "country": "RAS",
+                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
+                  }
+                ]
+              }
+            ]
+          },
+          "id": "189674e0-737e-4d6d-aab0-3fdfc19839ed",
+          "quantity": 1
+        },
+        {
+          "id": "7cfe659e-3764-4a8c-a25b-201396cbc09f",
+          "quantity": 2
+        },
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 20,
+                "material": {
+                  "country": "RAS",
+                  "id": "97a70d45-d7d5-4ee5-86b4-ee506300cdaa"
+                },
+                "transforms": []
+              }
+            ]
+          },
+          "id": "edca4c52-b34a-4906-b2e0-4f726bfcc8f7",
+          "quantity": 1
+        },
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 8,
+                "material": {
+                  "country": "RAS",
+                  "id": "3e514eac-185c-449e-bdc2-e1082ca0576d"
+                },
+                "transforms": [
+                  {
+                    "country": "RAS",
+                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
+                  },
+                  {
+                    "country": "RAS",
+                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
+                  }
+                ]
+              }
+            ]
+          },
+          "id": "d4583813-5f80-47e0-b028-df438f59cfe2",
+          "quantity": 4
+        },
+        {
+          "id": "6b3d7f30-e87b-426c-93ed-3a1179238583",
+          "quantity": 4
+        },
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 20,
+                "material": {
+                  "country": "REO",
+                  "id": "42748244-0939-4da2-ad5f-206ce541d7ee"
+                },
+                "transforms": []
+              }
+            ]
+          },
+          "id": "d3ef64c0-3deb-4ef2-838d-015d8ece019e",
+          "quantity": 1
+        },
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 3,
+                "material": {
+                  "country": "RAS",
+                  "id": "3e514eac-185c-449e-bdc2-e1082ca0576d"
+                },
+                "transforms": [
+                  {
+                    "country": "RAS",
+                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
+                  },
+                  {
+                    "country": "RAS",
+                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
+                  }
+                ]
+              },
+              {
+                "amount": 3,
+                "material": {
+                  "id": "c5295f47-0307-48a6-8552-3705063af767"
+                },
+                "transforms": [
+                  {
+                    "id": "85b74ce2-2cbc-4d73-a5a2-5c5ffde16319"
+                  }
+                ]
+              },
+              {
+                "amount": 1,
+                "material": {
+                  "id": "20f5db04-a4c7-48ab-9903-38c65cd70be0"
+                },
+                "transforms": []
+              }
+            ]
+          },
+          "id": "1d2de15a-53d9-465d-a2cf-fa2c5f68f5e9",
+          "quantity": 2
+        },
+        {
+          "id": "71086438-51a9-4980-ac3b-f24d5baa4cd5",
+          "quantity": 1
+        }
+      ],
+      "consumptions": [
+        {
+          "amount": 5000,
+          "processId": "eec31f13-d00a-4741-a84f-85d887026f8c"
+        }
+      ],
+      "recyclable": true
+    },
+    "scope": "veli"
+  },
+  {
+    "category": "Véli",
+    "id": "cbbcf0f6-6855-4655-a164-102672d1ef89",
+    "name": "Veli actif, 45km/h max, 4kWh/100km, assemblage France",
+    "query": {
+      "assemblyCountry": "FR",
+      "components": [
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 50,
+                "material": {
+                  "country": "RAS",
+                  "id": "3e514eac-185c-449e-bdc2-e1082ca0576d"
+                },
+                "transforms": [
+                  {
+                    "country": "RAS",
+                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
+                  },
+                  {
+                    "country": "FR",
+                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
+                  }
+                ]
+              },
+              {
+                "amount": 20,
+                "material": {
+                  "country": "RAS",
+                  "id": "01d21ed5-9fc6-4d36-a0ea-cfea8035385b"
+                },
+                "transforms": [
+                  {
+                    "country": "RAS",
+                    "id": "85b74ce2-2cbc-4d73-a5a2-5c5ffde16319"
+                  }
+                ]
+              },
+              {
+                "amount": 0.002,
+                "material": {
+                  "country": "RAS",
+                  "id": "fba45d5f-64fc-44ae-ac75-9301c95c4657"
+                },
+                "transforms": [
+                  {
+                    "country": "RAS",
+                    "id": "e232270f-3a08-4536-8d8d-dcb4a2031e7b"
+                  }
+                ]
+              },
+              {
+                "amount": 20,
+                "material": {
+                  "country": "RAS",
+                  "id": "63e8a99a-d6e5-4aa5-8fe4-71c3d0ca2107"
+                },
+                "transforms": [
+                  {
+                    "country": "RAS",
+                    "id": "971df5fa-c32e-4a7e-b1aa-14ce9f240b5c"
+                  },
+                  {
+                    "country": "FR",
+                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
+                  }
+                ]
+              }
+            ],
+            "name": "Chassis-carosserie - veli actif, assemblage France"
+          },
+          "id": "f50ff677-3501-49cb-b69d-e826d4114681",
+          "quantity": 1
+        },
+        {
+          "id": "7cfe659e-3764-4a8c-a25b-201396cbc09f",
+          "quantity": 2
+        },
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 8,
+                "material": {
+                  "country": "RAS",
+                  "id": "97a70d45-d7d5-4ee5-86b4-ee506300cdaa"
+                },
+                "transforms": []
+              }
+            ],
+            "name": "Moteur électrique"
+          },
+          "id": "059f0f35-099d-4305-8a60-1666222dadb2",
+          "quantity": 1
+        },
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 0.3,
+                "material": {
+                  "country": "RAS",
+                  "id": "63e8a99a-d6e5-4aa5-8fe4-71c3d0ca2107"
+                },
+                "transforms": [
+                  {
+                    "country": "RAS",
+                    "id": "971df5fa-c32e-4a7e-b1aa-14ce9f240b5c"
+                  },
+                  {
+                    "country": "RAS",
+                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
+                  }
+                ]
+              },
+              {
+                "amount": 0.5,
+                "material": {
+                  "country": "RAS",
+                  "id": "63e8a99a-d6e5-4aa5-8fe4-71c3d0ca2107"
+                },
+                "transforms": [
+                  {
+                    "country": "RAS",
+                    "id": "d693bd0d-88d4-4370-81ee-597956bb58f0"
+                  }
+                ]
+              }
+            ]
+          },
+          "id": "9d294fb5-b42a-4a9f-adc6-ff38f6d27e65",
+          "quantity": 4
+        },
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 0.8,
+                "material": {
+                  "country": "RAS",
+                  "id": "5f837a69-839d-4a49-9a30-19e1501ad51e"
+                },
+                "transforms": []
+              },
+              {
+                "amount": 0.2,
+                "material": {
+                  "country": "RAS",
+                  "id": "9c5a7a8e-6483-4da8-9cc2-0a90a30cb93a"
+                },
+                "transforms": []
+              }
+            ]
+          },
+          "id": "8e38b6a5-1c95-43f6-987f-2e368fc74edc",
+          "quantity": 4
+        },
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 0.5,
+                "material": {
+                  "country": "RAS",
+                  "id": "c5295f47-0307-48a6-8552-3705063af767"
+                },
+                "transforms": [
+                  {
+                    "country": "RAS",
+                    "id": "85b74ce2-2cbc-4d73-a5a2-5c5ffde16319"
+                  }
+                ]
+              },
+              {
+                "amount": 2,
+                "material": {
+                  "country": "RAS",
+                  "id": "3e514eac-185c-449e-bdc2-e1082ca0576d"
+                },
+                "transforms": [
+                  {
+                    "country": "RAS",
+                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
+                  },
+                  {
+                    "country": "RAS",
+                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
+                  }
+                ]
+              },
+              {
+                "amount": 0.5,
+                "material": {
+                  "id": "20f5db04-a4c7-48ab-9903-38c65cd70be0"
+                },
+                "transforms": []
+              }
+            ]
+          },
+          "id": "ae9c83de-71bf-4f21-9030-afbfd4ad3b3a",
+          "quantity": 2
+        },
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 6,
+                "material": {
+                  "id": "30212fbf-5912-40eb-b2ab-87837361c462"
+                },
+                "transforms": [
+                  {
+                    "id": "981e74ea-ef7d-40d1-b25e-c5534446474e"
+                  },
+                  {
+                    "country": "RAS",
+                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
+                  }
+                ]
+              },
+              {
+                "amount": 5,
+                "material": {
+                  "id": "c5295f47-0307-48a6-8552-3705063af767"
+                },
+                "transforms": [
+                  {
+                    "country": "FR",
+                    "id": "85b74ce2-2cbc-4d73-a5a2-5c5ffde16319"
+                  }
+                ]
+              },
+              {
+                "amount": 1.5,
+                "material": {
+                  "country": "RAS",
+                  "id": "51956fb2-304d-4e63-a3ef-b3eed44fde38"
+                },
+                "transforms": []
+              }
+            ]
+          },
+          "id": "f134b3fd-0439-4b25-a06e-f1b8fd6e201c",
+          "quantity": 1
+        },
+        {
+          "custom": {
+            "elements": [
+              {
+                "amount": 10,
+                "material": {
+                  "country": "RAS",
+                  "id": "6445c1fa-13a6-4058-8978-bcf2be63cd56"
+                },
+                "transforms": []
+              }
+            ]
+          },
+          "id": "6cb4338a-4663-4325-90b6-f7279a498c9b",
+          "quantity": 1
+        }
+      ],
+      "consumptions": [
+        {
+          "amount": 3800,
+          "processId": "eec31f13-d00a-4741-a84f-85d887026f8c"
+        }
+      ],
+      "recyclable": true
+    },
+    "scope": "veli"
+  },
+  {
+    "category": "Vélo",
+    "id": "cefc2585-7125-4610-aadc-69970a3d67d1",
+    "name": "Vélo à assistance électrique, majorant par défaut",
+    "query": {
+      "components": [
+        {
+          "id": "49a16258-22eb-4700-88c4-5e3d1af071e7",
+          "quantity": 1
+        },
+        {
+          "id": "990f4263-3b6c-48ce-92e8-566584edf5b2",
+          "quantity": 1
+        },
+        {
+          "id": "20b35f34-166f-4da7-abc4-54d2a64de367",
+          "quantity": 1
+        },
+        {
+          "id": "1bd0f5c3-c368-4a2f-b404-2214a6c9b677",
+          "quantity": 1
+        },
+        {
+          "id": "8e38b6a5-1c95-43f6-987f-2e368fc74edc",
+          "quantity": 2
+        },
+        {
+          "id": "a94918a7-8915-4841-9cdc-deec0536c724",
+          "quantity": 2
+        },
+        {
+          "id": "6ab7bcdf-7648-43b5-beb6-b4fa11c2d5d3",
+          "quantity": 1
+        },
+        {
+          "id": "b4d552ed-6a9b-4b29-b293-50349c62e1c0",
+          "quantity": 1
+        },
+        {
+          "id": "c4a8eb8f-b4c6-42b8-bd04-0f68e9083424",
+          "quantity": 1
+        },
+        {
+          "id": "4a273102-9973-4352-8683-2503aea7bfbb",
+          "quantity": 1
+        },
+        {
+          "id": "29a80ed1-26c9-419e-9f46-9c9b77d06458",
+          "quantity": 1
+        },
+        {
+          "id": "892ba9b4-e6d4-408c-87b9-5eef455f5b4f",
+          "quantity": 1
+        }
+      ],
+      "consumptions": [
+        {
+          "amount": 150,
+          "processId": "eec31f13-d00a-4741-a84f-85d887026f8c"
+        }
+      ]
+    },
+    "scope": "veli"
+  },
+  {
+    "category": "Veli",
+    "id": "cf636ce9-e95b-4e25-9a22-625986f85ef0",
+    "name": "Minibus quadricycle à assistance électrique, 4kWh/100km, France",
+    "query": {
+      "assemblyCountry": "FR",
+      "components": [
+        {
+          "country": "FR",
+          "custom": {
+            "elements": [
+              {
+                "amount": 16,
+                "material": "01d21ed5-9fc6-4d36-a0ea-cfea8035385b",
+                "transforms": [
+                  {
+                    "country": "FR",
+                    "id": "85b74ce2-2cbc-4d73-a5a2-5c5ffde16319"
+                  }
+                ]
+              },
+              {
+                "amount": 40,
+                "material": "21a0d5b0-861e-4bed-98a9-46c61d2a0618",
+                "transforms": [
+                  {
+                    "country": "FR",
+                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
+                  },
+                  {
+                    "country": "FR",
+                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
+                  }
+                ]
+              },
+              {
+                "amount": 0.02,
+                "material": "f4a5d1ad-9362-4b18-9555-d5ab58f3b993",
+                "transforms": [
+                  {
+                    "country": "FR",
+                    "id": "e232270f-3a08-4536-8d8d-dcb4a2031e7b"
+                  }
+                ]
+              },
+              {
+                "amount": 20,
+                "material": "4b4e1204-48ac-48ac-a0e2-ee2176202a5a",
+                "transforms": [
+                  {
+                    "country": "FR",
+                    "id": "d693bd0d-88d4-4370-81ee-597956bb58f0"
+                  },
+                  {
+                    "country": "FR",
+                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
+                  }
+                ]
+              }
+            ],
+            "name": "Chassis-carosserie Minibus quadricycle"
+          },
+          "id": "189674e0-737e-4d6d-aab0-3fdfc19839ed",
+          "quantity": 1
+        },
+        {
+          "country": "DE",
+          "id": "edca4c52-b34a-4906-b2e0-4f726bfcc8f7",
+          "quantity": 1
+        },
+        {
+          "country": "RAS",
+          "id": "d4583813-5f80-47e0-b028-df438f59cfe2",
+          "quantity": 4
+        },
+        {
+          "country": "RAS",
+          "id": "6b3d7f30-e87b-426c-93ed-3a1179238583",
+          "quantity": 4
+        },
+        {
+          "country": "CN",
+          "id": "7cfe659e-3764-4a8c-a25b-201396cbc09f",
+          "quantity": 1
+        },
+        {
+          "id": "f134b3fd-0439-4b25-a06e-f1b8fd6e201c",
+          "quantity": 1
+        },
+        {
+          "id": "ae9c83de-71bf-4f21-9030-afbfd4ad3b3a",
+          "quantity": 2
+        },
+        {
+          "id": "c4a8eb8f-b4c6-42b8-bd04-0f68e9083424",
+          "quantity": 4
+        },
+        {
+          "country": "FR",
+          "id": "6cb4338a-4663-4325-90b6-f7279a498c9b",
+          "quantity": 1
+        }
+      ],
+      "consumptions": [
+        {
+          "amount": 1100,
+          "processId": "eec31f13-d00a-4741-a84f-85d887026f8c"
+        }
+      ]
     },
     "scope": "veli"
   },
@@ -1623,557 +3727,9 @@
     "scope": "veli"
   },
   {
-    "category": "Véli",
-    "id": "cbbcf0f6-6855-4655-a164-102672d1ef89",
-    "name": "Veli actif, 45km/h max, 4kWh/100km, assemblage France",
-    "query": {
-      "assemblyCountry": "FR",
-      "components": [
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 50,
-                "material": {
-                  "country": "RAS",
-                  "id": "3e514eac-185c-449e-bdc2-e1082ca0576d"
-                },
-                "transforms": [
-                  {
-                    "country": "RAS",
-                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
-                  },
-                  {
-                    "country": "FR",
-                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
-                  }
-                ]
-              },
-              {
-                "amount": 20,
-                "material": {
-                  "country": "RAS",
-                  "id": "01d21ed5-9fc6-4d36-a0ea-cfea8035385b"
-                },
-                "transforms": [
-                  {
-                    "country": "RAS",
-                    "id": "85b74ce2-2cbc-4d73-a5a2-5c5ffde16319"
-                  }
-                ]
-              },
-              {
-                "amount": 0.002,
-                "material": {
-                  "country": "RAS",
-                  "id": "fba45d5f-64fc-44ae-ac75-9301c95c4657"
-                },
-                "transforms": [
-                  {
-                    "country": "RAS",
-                    "id": "e232270f-3a08-4536-8d8d-dcb4a2031e7b"
-                  }
-                ]
-              },
-              {
-                "amount": 20,
-                "material": {
-                  "country": "RAS",
-                  "id": "63e8a99a-d6e5-4aa5-8fe4-71c3d0ca2107"
-                },
-                "transforms": [
-                  {
-                    "country": "RAS",
-                    "id": "971df5fa-c32e-4a7e-b1aa-14ce9f240b5c"
-                  },
-                  {
-                    "country": "FR",
-                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
-                  }
-                ]
-              }
-            ],
-            "name": "Chassis-carosserie - veli actif, assemblage France"
-          },
-          "id": "f50ff677-3501-49cb-b69d-e826d4114681",
-          "quantity": 1
-        },
-        {
-          "id": "7cfe659e-3764-4a8c-a25b-201396cbc09f",
-          "quantity": 2
-        },
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 8,
-                "material": {
-                  "country": "RAS",
-                  "id": "97a70d45-d7d5-4ee5-86b4-ee506300cdaa"
-                },
-                "transforms": []
-              }
-            ],
-            "name": "Moteur électrique"
-          },
-          "id": "059f0f35-099d-4305-8a60-1666222dadb2",
-          "quantity": 1
-        },
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 0.3,
-                "material": {
-                  "country": "RAS",
-                  "id": "63e8a99a-d6e5-4aa5-8fe4-71c3d0ca2107"
-                },
-                "transforms": [
-                  {
-                    "country": "RAS",
-                    "id": "971df5fa-c32e-4a7e-b1aa-14ce9f240b5c"
-                  },
-                  {
-                    "country": "RAS",
-                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
-                  }
-                ]
-              },
-              {
-                "amount": 0.5,
-                "material": {
-                  "country": "RAS",
-                  "id": "63e8a99a-d6e5-4aa5-8fe4-71c3d0ca2107"
-                },
-                "transforms": [
-                  {
-                    "country": "RAS",
-                    "id": "d693bd0d-88d4-4370-81ee-597956bb58f0"
-                  }
-                ]
-              }
-            ]
-          },
-          "id": "9d294fb5-b42a-4a9f-adc6-ff38f6d27e65",
-          "quantity": 4
-        },
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 0.8,
-                "material": {
-                  "country": "RAS",
-                  "id": "5f837a69-839d-4a49-9a30-19e1501ad51e"
-                },
-                "transforms": []
-              },
-              {
-                "amount": 0.2,
-                "material": {
-                  "country": "RAS",
-                  "id": "9c5a7a8e-6483-4da8-9cc2-0a90a30cb93a"
-                },
-                "transforms": []
-              }
-            ]
-          },
-          "id": "8e38b6a5-1c95-43f6-987f-2e368fc74edc",
-          "quantity": 4
-        },
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 0.5,
-                "material": {
-                  "country": "RAS",
-                  "id": "c5295f47-0307-48a6-8552-3705063af767"
-                },
-                "transforms": [
-                  {
-                    "country": "RAS",
-                    "id": "85b74ce2-2cbc-4d73-a5a2-5c5ffde16319"
-                  }
-                ]
-              },
-              {
-                "amount": 2,
-                "material": {
-                  "country": "RAS",
-                  "id": "3e514eac-185c-449e-bdc2-e1082ca0576d"
-                },
-                "transforms": [
-                  {
-                    "country": "RAS",
-                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
-                  },
-                  {
-                    "country": "RAS",
-                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
-                  }
-                ]
-              },
-              {
-                "amount": 0.5,
-                "material": {
-                  "id": "20f5db04-a4c7-48ab-9903-38c65cd70be0"
-                },
-                "transforms": []
-              }
-            ]
-          },
-          "id": "ae9c83de-71bf-4f21-9030-afbfd4ad3b3a",
-          "quantity": 2
-        },
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 6,
-                "material": {
-                  "id": "30212fbf-5912-40eb-b2ab-87837361c462"
-                },
-                "transforms": [
-                  {
-                    "id": "981e74ea-ef7d-40d1-b25e-c5534446474e"
-                  },
-                  {
-                    "country": "RAS",
-                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
-                  }
-                ]
-              },
-              {
-                "amount": 5,
-                "material": {
-                  "id": "c5295f47-0307-48a6-8552-3705063af767"
-                },
-                "transforms": [
-                  {
-                    "country": "FR",
-                    "id": "85b74ce2-2cbc-4d73-a5a2-5c5ffde16319"
-                  }
-                ]
-              },
-              {
-                "amount": 1.5,
-                "material": {
-                  "country": "RAS",
-                  "id": "51956fb2-304d-4e63-a3ef-b3eed44fde38"
-                },
-                "transforms": []
-              }
-            ]
-          },
-          "id": "f134b3fd-0439-4b25-a06e-f1b8fd6e201c",
-          "quantity": 1
-        },
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 10,
-                "material": {
-                  "country": "RAS",
-                  "id": "6445c1fa-13a6-4058-8978-bcf2be63cd56"
-                },
-                "transforms": []
-              }
-            ]
-          },
-          "id": "6cb4338a-4663-4325-90b6-f7279a498c9b",
-          "quantity": 1
-        }
-      ],
-      "consumptions": [
-        {
-          "amount": 3800,
-          "processId": "eec31f13-d00a-4741-a84f-85d887026f8c"
-        }
-      ],
-      "recyclable": true
-    },
-    "scope": "veli"
-  },
-  {
-    "category": "Veli",
-    "id": "8d5768cb-dd06-4dbf-a6d8-62c1429beaf7",
-    "name": "Veli actif, 45km/h max, 4kWh/100km, Asie",
-    "query": {
-      "assemblyCountry": "RAS",
-      "components": [
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 50,
-                "material": {
-                  "country": "RAS",
-                  "id": "3e514eac-185c-449e-bdc2-e1082ca0576d"
-                },
-                "transforms": [
-                  {
-                    "country": "RAS",
-                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
-                  },
-                  {
-                    "country": "RAS",
-                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
-                  }
-                ]
-              },
-              {
-                "amount": 20,
-                "material": {
-                  "country": "RAS",
-                  "id": "01d21ed5-9fc6-4d36-a0ea-cfea8035385b"
-                },
-                "transforms": [
-                  {
-                    "country": "RAS",
-                    "id": "85b74ce2-2cbc-4d73-a5a2-5c5ffde16319"
-                  }
-                ]
-              },
-              {
-                "amount": 0.002,
-                "material": {
-                  "country": "RAS",
-                  "id": "fba45d5f-64fc-44ae-ac75-9301c95c4657"
-                },
-                "transforms": [
-                  {
-                    "country": "RAS",
-                    "id": "e232270f-3a08-4536-8d8d-dcb4a2031e7b"
-                  }
-                ]
-              },
-              {
-                "amount": 20,
-                "material": {
-                  "country": "RAS",
-                  "id": "63e8a99a-d6e5-4aa5-8fe4-71c3d0ca2107"
-                },
-                "transforms": [
-                  {
-                    "country": "RAS",
-                    "id": "971df5fa-c32e-4a7e-b1aa-14ce9f240b5c"
-                  },
-                  {
-                    "country": "RAS",
-                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
-                  }
-                ]
-              }
-            ],
-            "name": "Chassis-carosserie - veli actif, Asie"
-          },
-          "id": "f50ff677-3501-49cb-b69d-e826d4114681",
-          "quantity": 1
-        },
-        {
-          "id": "7cfe659e-3764-4a8c-a25b-201396cbc09f",
-          "quantity": 2
-        },
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 8,
-                "material": {
-                  "country": "RAS",
-                  "id": "97a70d45-d7d5-4ee5-86b4-ee506300cdaa"
-                },
-                "transforms": []
-              }
-            ],
-            "name": "Moteur électrique"
-          },
-          "id": "059f0f35-099d-4305-8a60-1666222dadb2",
-          "quantity": 1
-        },
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 0.3,
-                "material": {
-                  "country": "RAS",
-                  "id": "63e8a99a-d6e5-4aa5-8fe4-71c3d0ca2107"
-                },
-                "transforms": [
-                  {
-                    "country": "RAS",
-                    "id": "971df5fa-c32e-4a7e-b1aa-14ce9f240b5c"
-                  },
-                  {
-                    "country": "RAS",
-                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
-                  }
-                ]
-              },
-              {
-                "amount": 0.5,
-                "material": {
-                  "country": "RAS",
-                  "id": "63e8a99a-d6e5-4aa5-8fe4-71c3d0ca2107"
-                },
-                "transforms": [
-                  {
-                    "country": "RAS",
-                    "id": "d693bd0d-88d4-4370-81ee-597956bb58f0"
-                  }
-                ]
-              }
-            ]
-          },
-          "id": "9d294fb5-b42a-4a9f-adc6-ff38f6d27e65",
-          "quantity": 4
-        },
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 0.8,
-                "material": {
-                  "country": "RAS",
-                  "id": "5f837a69-839d-4a49-9a30-19e1501ad51e"
-                },
-                "transforms": []
-              },
-              {
-                "amount": 0.2,
-                "material": {
-                  "country": "RAS",
-                  "id": "9c5a7a8e-6483-4da8-9cc2-0a90a30cb93a"
-                },
-                "transforms": []
-              }
-            ]
-          },
-          "id": "8e38b6a5-1c95-43f6-987f-2e368fc74edc",
-          "quantity": 4
-        },
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 0.5,
-                "material": {
-                  "country": "RAS",
-                  "id": "c5295f47-0307-48a6-8552-3705063af767"
-                },
-                "transforms": [
-                  {
-                    "country": "RAS",
-                    "id": "85b74ce2-2cbc-4d73-a5a2-5c5ffde16319"
-                  }
-                ]
-              },
-              {
-                "amount": 2,
-                "material": {
-                  "country": "RAS",
-                  "id": "3e514eac-185c-449e-bdc2-e1082ca0576d"
-                },
-                "transforms": [
-                  {
-                    "country": "RAS",
-                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
-                  },
-                  {
-                    "country": "RAS",
-                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
-                  }
-                ]
-              },
-              {
-                "amount": 0.5,
-                "material": {
-                  "id": "20f5db04-a4c7-48ab-9903-38c65cd70be0"
-                },
-                "transforms": []
-              }
-            ]
-          },
-          "id": "ae9c83de-71bf-4f21-9030-afbfd4ad3b3a",
-          "quantity": 2
-        },
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 6,
-                "material": {
-                  "id": "30212fbf-5912-40eb-b2ab-87837361c462"
-                },
-                "transforms": [
-                  {
-                    "id": "981e74ea-ef7d-40d1-b25e-c5534446474e"
-                  },
-                  {
-                    "country": "RAS",
-                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
-                  }
-                ]
-              },
-              {
-                "amount": 5,
-                "material": {
-                  "id": "c5295f47-0307-48a6-8552-3705063af767"
-                },
-                "transforms": [
-                  {
-                    "country": "FR",
-                    "id": "85b74ce2-2cbc-4d73-a5a2-5c5ffde16319"
-                  }
-                ]
-              },
-              {
-                "amount": 1.5,
-                "material": {
-                  "country": "RAS",
-                  "id": "51956fb2-304d-4e63-a3ef-b3eed44fde38"
-                },
-                "transforms": []
-              }
-            ]
-          },
-          "id": "f134b3fd-0439-4b25-a06e-f1b8fd6e201c",
-          "quantity": 1
-        },
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 10,
-                "material": {
-                  "country": "RAS",
-                  "id": "6445c1fa-13a6-4058-8978-bcf2be63cd56"
-                },
-                "transforms": []
-              }
-            ]
-          },
-          "id": "6cb4338a-4663-4325-90b6-f7279a498c9b",
-          "quantity": 1
-        }
-      ],
-      "consumptions": [
-        {
-          "amount": 3800,
-          "processId": "eec31f13-d00a-4741-a84f-85d887026f8c"
-        }
-      ],
-      "recyclable": true
-    },
-    "scope": "veli"
-  },
-  {
-    "category": "Veli",
-    "id": "cf636ce9-e95b-4e25-9a22-625986f85ef0",
-    "name": "Minibus quadricycle à assistance électrique, 4kWh/100km, France",
+    "category": "Vélo",
+    "id": "e5fc4df5-e0be-49a0-a661-10f6e15773f1",
+    "name": "Vélo de ville, cadre aluminium, fabrication France",
     "query": {
       "assemblyCountry": "FR",
       "components": [
@@ -2182,101 +3738,101 @@
           "custom": {
             "elements": [
               {
-                "amount": 16,
-                "material": "01d21ed5-9fc6-4d36-a0ea-cfea8035385b",
+                "amount": 0.5,
+                "material": "baae8572-db4a-4cb8-8f74-e72ba5ef0116",
                 "transforms": [
-                  {
-                    "country": "FR",
-                    "id": "85b74ce2-2cbc-4d73-a5a2-5c5ffde16319"
-                  }
-                ]
-              },
-              {
-                "amount": 40,
-                "material": "21a0d5b0-861e-4bed-98a9-46c61d2a0618",
-                "transforms": [
-                  {
-                    "country": "FR",
-                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
-                  },
-                  {
-                    "country": "FR",
-                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
-                  }
-                ]
-              },
-              {
-                "amount": 0.02,
-                "material": "f4a5d1ad-9362-4b18-9555-d5ab58f3b993",
-                "transforms": [
-                  {
-                    "country": "FR",
-                    "id": "e232270f-3a08-4536-8d8d-dcb4a2031e7b"
-                  }
-                ]
-              },
-              {
-                "amount": 20,
-                "material": "4b4e1204-48ac-48ac-a0e2-ee2176202a5a",
-                "transforms": [
-                  {
-                    "country": "FR",
-                    "id": "d693bd0d-88d4-4370-81ee-597956bb58f0"
-                  },
-                  {
-                    "country": "FR",
-                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
-                  }
+                  "d693bd0d-88d4-4370-81ee-597956bb58f0",
+                  "d935e937-35e7-471d-8d78-f5c6c1685adf"
                 ]
               }
-            ],
-            "name": "Chassis-carosserie Minibus quadricycle"
+            ]
           },
-          "id": "189674e0-737e-4d6d-aab0-3fdfc19839ed",
-          "quantity": 1
-        },
-        {
-          "country": "DE",
-          "id": "edca4c52-b34a-4906-b2e0-4f726bfcc8f7",
+          "id": "1bd0f5c3-c368-4a2f-b404-2214a6c9b677",
           "quantity": 1
         },
         {
           "country": "RAS",
-          "id": "d4583813-5f80-47e0-b028-df438f59cfe2",
-          "quantity": 4
+          "id": "8e38b6a5-1c95-43f6-987f-2e368fc74edc",
+          "quantity": 2
+        },
+        {
+          "country": "FR",
+          "custom": {
+            "elements": [
+              {
+                "amount": 0.6,
+                "material": "4b4e1204-48ac-48ac-a0e2-ee2176202a5a",
+                "transforms": [
+                  "d693bd0d-88d4-4370-81ee-597956bb58f0",
+                  "d935e937-35e7-471d-8d78-f5c6c1685adf"
+                ]
+              },
+              {
+                "amount": 0.5,
+                "material": "4b4e1204-48ac-48ac-a0e2-ee2176202a5a",
+                "transforms": [
+                  "d693bd0d-88d4-4370-81ee-597956bb58f0",
+                  "971df5fa-c32e-4a7e-b1aa-14ce9f240b5c"
+                ]
+              }
+            ]
+          },
+          "id": "a94918a7-8915-4841-9cdc-deec0536c724",
+          "quantity": 2
         },
         {
           "country": "RAS",
-          "id": "6b3d7f30-e87b-426c-93ed-3a1179238583",
-          "quantity": 4
+          "id": "6ab7bcdf-7648-43b5-beb6-b4fa11c2d5d3",
+          "quantity": 1
+        },
+        {
+          "country": "RAS",
+          "id": "c4a8eb8f-b4c6-42b8-bd04-0f68e9083424",
+          "quantity": 1
+        },
+        {
+          "country": "FR",
+          "custom": {
+            "elements": [
+              {
+                "amount": 0.8,
+                "material": "4b4e1204-48ac-48ac-a0e2-ee2176202a5a",
+                "transforms": [
+                  "d693bd0d-88d4-4370-81ee-597956bb58f0",
+                  "d935e937-35e7-471d-8d78-f5c6c1685adf"
+                ]
+              }
+            ]
+          },
+          "id": "892ba9b4-e6d4-408c-87b9-5eef455f5b4f",
+          "quantity": 1
         },
         {
           "country": "CN",
-          "id": "7cfe659e-3764-4a8c-a25b-201396cbc09f",
+          "custom": {
+            "elements": [
+              {
+                "amount": 2,
+                "material": "4b4e1204-48ac-48ac-a0e2-ee2176202a5a",
+                "transforms": [
+                  "d693bd0d-88d4-4370-81ee-597956bb58f0",
+                  "d935e937-35e7-471d-8d78-f5c6c1685adf"
+                ]
+              }
+            ]
+          },
+          "id": "49a16258-22eb-4700-88c4-5e3d1af071e7",
           "quantity": 1
         },
         {
-          "id": "f134b3fd-0439-4b25-a06e-f1b8fd6e201c",
+          "country": "RAS",
+          "id": "347629ff-e7e9-4822-a948-d8c7757b2a9a",
           "quantity": 1
         },
         {
-          "id": "ae9c83de-71bf-4f21-9030-afbfd4ad3b3a",
-          "quantity": 2
-        },
-        {
-          "id": "c4a8eb8f-b4c6-42b8-bd04-0f68e9083424",
-          "quantity": 4
-        },
-        {
-          "country": "FR",
-          "id": "6cb4338a-4663-4325-90b6-f7279a498c9b",
+          "country": "RAS",
+          "id": "d2228b50-8187-4940-92a5-6dffe2a2ba85",
           "quantity": 1
-        }
-      ],
-      "consumptions": [
-        {
-          "amount": 1100,
-          "processId": "eec31f13-d00a-4741-a84f-85d887026f8c"
         }
       ]
     },
@@ -2284,230 +3840,9 @@
   },
   {
     "category": "Veli",
-    "id": "78517d8b-65cb-4205-accc-3bbab581176d",
-    "name": "Veli, 45km/h max, 5kWh/100km, fabrication France",
-    "query": {
-      "assemblyCountry": "FR",
-      "components": [
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 40,
-                "material": {
-                  "country": "FR",
-                  "id": "01d21ed5-9fc6-4d36-a0ea-cfea8035385b"
-                },
-                "transforms": [
-                  {
-                    "country": "FR",
-                    "id": "85b74ce2-2cbc-4d73-a5a2-5c5ffde16319"
-                  }
-                ]
-              },
-              {
-                "amount": 180,
-                "material": {
-                  "country": "FR",
-                  "id": "21a0d5b0-861e-4bed-98a9-46c61d2a0618"
-                },
-                "transforms": [
-                  {
-                    "country": "FR",
-                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
-                  },
-                  {
-                    "country": "FR",
-                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
-                  }
-                ]
-              }
-            ]
-          },
-          "id": "189674e0-737e-4d6d-aab0-3fdfc19839ed",
-          "quantity": 1
-        },
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 3.57,
-                "material": {
-                  "country": "FR",
-                  "id": "a1f6f8a2-5398-4b32-a3d6-fc0d88ca7a28"
-                },
-                "transforms": [
-                  {
-                    "country": "FR",
-                    "id": "7f217ecc-5de8-4ce1-b2c2-b5d192c6cdb9"
-                  }
-                ]
-              },
-              {
-                "amount": 1.5,
-                "material": {
-                  "country": "FR",
-                  "id": "baae8572-db4a-4cb8-8f74-e72ba5ef0116"
-                },
-                "transforms": [
-                  {
-                    "country": "FR",
-                    "id": "971df5fa-c32e-4a7e-b1aa-14ce9f240b5c"
-                  }
-                ]
-              },
-              {
-                "amount": 0.3,
-                "material": {
-                  "country": "FR",
-                  "id": "a363f079-bc3f-424a-a2e1-06b9c76b4fc3"
-                },
-                "transforms": [
-                  {
-                    "country": "FR",
-                    "id": "d077f06e-4ae9-48b7-8019-64523e577b95"
-                  }
-                ]
-              },
-              {
-                "amount": 1.9,
-                "material": {
-                  "country": "FR",
-                  "id": "21a0d5b0-861e-4bed-98a9-46c61d2a0618"
-                },
-                "transforms": [
-                  {
-                    "country": "FR",
-                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
-                  }
-                ]
-              },
-              {
-                "amount": 0.8,
-                "material": {
-                  "country": "FR",
-                  "id": "30212fbf-5912-40eb-b2ab-87837361c462"
-                },
-                "transforms": [
-                  {
-                    "country": "FR",
-                    "id": "981e74ea-ef7d-40d1-b25e-c5534446474e"
-                  }
-                ]
-              },
-              {
-                "amount": 0.9,
-                "material": {
-                  "country": "FR",
-                  "id": "c5295f47-0307-48a6-8552-3705063af767"
-                },
-                "transforms": [
-                  {
-                    "country": "FR",
-                    "id": "85b74ce2-2cbc-4d73-a5a2-5c5ffde16319"
-                  }
-                ]
-              },
-              {
-                "amount": 0.6,
-                "material": {
-                  "country": "RAS",
-                  "id": "51956fb2-304d-4e63-a3ef-b3eed44fde38"
-                },
-                "transforms": []
-              }
-            ],
-            "name": "Batterie Li-ion 1.2kWh, NMC811, France"
-          },
-          "id": "7cfe659e-3764-4a8c-a25b-201396cbc09f",
-          "quantity": 2
-        },
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 20,
-                "material": {
-                  "country": "REO",
-                  "id": "97a70d45-d7d5-4ee5-86b4-ee506300cdaa"
-                },
-                "transforms": []
-              }
-            ]
-          },
-          "id": "edca4c52-b34a-4906-b2e0-4f726bfcc8f7",
-          "quantity": 1
-        },
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 8,
-                "material": {
-                  "country": "REO",
-                  "id": "21a0d5b0-861e-4bed-98a9-46c61d2a0618"
-                },
-                "transforms": [
-                  {
-                    "country": "REO",
-                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
-                  },
-                  {
-                    "country": "REO",
-                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
-                  }
-                ]
-              }
-            ]
-          },
-          "id": "d4583813-5f80-47e0-b028-df438f59cfe2",
-          "quantity": 4
-        },
-        {
-          "id": "6b3d7f30-e87b-426c-93ed-3a1179238583",
-          "quantity": 4
-        },
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 20,
-                "material": {
-                  "country": "FR",
-                  "id": "42748244-0939-4da2-ad5f-206ce541d7ee"
-                },
-                "transforms": []
-              }
-            ]
-          },
-          "id": "d3ef64c0-3deb-4ef2-838d-015d8ece019e",
-          "quantity": 1
-        },
-        {
-          "id": "1d2de15a-53d9-465d-a2cf-fa2c5f68f5e9",
-          "quantity": 2
-        },
-        {
-          "id": "71086438-51a9-4980-ac3b-f24d5baa4cd5",
-          "quantity": 1
-        }
-      ],
-      "consumptions": [
-        {
-          "amount": 5000,
-          "processId": "eec31f13-d00a-4741-a84f-85d887026f8c"
-        }
-      ],
-      "recyclable": true
-    },
-    "scope": "veli"
-  },
-  {
-    "category": "Veli",
     "id": "f526e36b-a4ae-41e8-be0a-f7db24f4a774",
     "name": "Veli, 45km/h max, 5kWh/100km, assemblage France",
-    "query":
-      {
+    "query": {
       "assemblyCountry": "FR",
       "components": [
         {
@@ -2665,1344 +4000,6 @@
         {
           "amount": 5000,
           "processId": "eec31f13-d00a-4741-a84f-85d887026f8c"
-        }
-      ],
-      "recyclable": true
-    },
-    "scope": "veli"
-  },
-  {
-    "category": "Veli",
-    "id": "b6791d66-3c1c-4214-9637-aa576cb1ee63",
-    "name": "Veli, 45km/h max, 5kWh/100km, Asie",
-    "query":
-      {
-      "assemblyCountry": "RAS",
-      "components": [
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 40,
-                "material": {
-                  "country": "RAS",
-                  "id": "01d21ed5-9fc6-4d36-a0ea-cfea8035385b"
-                },
-                "transforms": [
-                  {
-                    "country": "RAS",
-                    "id": "85b74ce2-2cbc-4d73-a5a2-5c5ffde16319"
-                  }
-                ]
-              },
-              {
-                "amount": 180,
-                "material": {
-                  "country": "RAS",
-                  "id": "3e514eac-185c-449e-bdc2-e1082ca0576d"
-                },
-                "transforms": [
-                  {
-                    "country": "RAS",
-                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
-                  },
-                  {
-                    "country": "RAS",
-                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
-                  }
-                ]
-              }
-            ]
-          },
-          "id": "189674e0-737e-4d6d-aab0-3fdfc19839ed",
-          "quantity": 1
-        },
-        {
-          "id": "7cfe659e-3764-4a8c-a25b-201396cbc09f",
-          "quantity": 2
-        },
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 20,
-                "material": {
-                  "country": "RAS",
-                  "id": "97a70d45-d7d5-4ee5-86b4-ee506300cdaa"
-                },
-                "transforms": []
-              }
-            ]
-          },
-          "id": "edca4c52-b34a-4906-b2e0-4f726bfcc8f7",
-          "quantity": 1
-        },
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 8,
-                "material": {
-                  "country": "RAS",
-                  "id": "3e514eac-185c-449e-bdc2-e1082ca0576d"
-                },
-                "transforms": [
-                  {
-                    "country": "RAS",
-                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
-                  },
-                  {
-                    "country": "RAS",
-                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
-                  }
-                ]
-              }
-            ]
-          },
-          "id": "d4583813-5f80-47e0-b028-df438f59cfe2",
-          "quantity": 4
-        },
-        {
-          "id": "6b3d7f30-e87b-426c-93ed-3a1179238583",
-          "quantity": 4
-        },
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 20,
-                "material": {
-                  "country": "REO",
-                  "id": "42748244-0939-4da2-ad5f-206ce541d7ee"
-                },
-                "transforms": []
-              }
-            ]
-          },
-          "id": "d3ef64c0-3deb-4ef2-838d-015d8ece019e",
-          "quantity": 1
-        },
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 3,
-                "material": {
-                  "country": "RAS",
-                  "id": "3e514eac-185c-449e-bdc2-e1082ca0576d"
-                },
-                "transforms": [
-                  {
-                    "country": "RAS",
-                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
-                  },
-                  {
-                    "country": "RAS",
-                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
-                  }
-                ]
-              },
-              {
-                "amount": 3,
-                "material": {
-                  "id": "c5295f47-0307-48a6-8552-3705063af767"
-                },
-                "transforms": [
-                  {
-                    "id": "85b74ce2-2cbc-4d73-a5a2-5c5ffde16319"
-                  }
-                ]
-              },
-              {
-                "amount": 1,
-                "material": {
-                  "id": "20f5db04-a4c7-48ab-9903-38c65cd70be0"
-                },
-                "transforms": []
-              }
-            ]
-          },
-          "id": "1d2de15a-53d9-465d-a2cf-fa2c5f68f5e9",
-          "quantity": 2
-        },
-        {
-          "id": "71086438-51a9-4980-ac3b-f24d5baa4cd5",
-          "quantity": 1
-        }
-      ],
-      "consumptions": [
-        {
-          "amount": 5000,
-          "processId": "eec31f13-d00a-4741-a84f-85d887026f8c"
-        }
-      ],
-      "recyclable": true
-    },
-    "scope": "veli"
-  },
-  {
-    "category": "Veli",
-    "id": "48545a07-026b-46ca-8440-4bfaa036cce6",
-    "name": "Veli, 90km/h max, 6kWh/100km, fabrication France",
-    "query": {
-      "assemblyCountry": "FR",
-      "components": [
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 40,
-                "material": {
-                  "country": "FR",
-                  "id": "01d21ed5-9fc6-4d36-a0ea-cfea8035385b"
-                },
-                "transforms": [
-                  {
-                    "country": "FR",
-                    "id": "85b74ce2-2cbc-4d73-a5a2-5c5ffde16319"
-                  }
-                ]
-              },
-              {
-                "amount": 180,
-                "material": {
-                  "country": "FR",
-                  "id": "21a0d5b0-861e-4bed-98a9-46c61d2a0618"
-                },
-                "transforms": [
-                  {
-                    "country": "FR",
-                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
-                  },
-                  {
-                    "country": "FR",
-                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
-                  }
-                ]
-              }
-            ]
-          },
-          "id": "189674e0-737e-4d6d-aab0-3fdfc19839ed",
-          "quantity": 1
-        },
-        {
-          "id": "3b15918f-d21c-4251-96a8-548ac8444a04",
-          "quantity": 1
-        },
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 50,
-                "material": {
-                  "country": "REO",
-                  "id": "97a70d45-d7d5-4ee5-86b4-ee506300cdaa"
-                },
-                "transforms": []
-              }
-            ]
-          },
-          "id": "da06c70f-5b61-4de7-bb51-5761818aa0dd",
-          "quantity": 1
-        },
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 8,
-                "material": {
-                  "country": "FR",
-                  "id": "21a0d5b0-861e-4bed-98a9-46c61d2a0618"
-                },
-                "transforms": [
-                  {
-                    "country": "FR",
-                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
-                  },
-                  {
-                    "country": "FR",
-                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
-                  }
-                ]
-              }
-            ]
-          },
-          "id": "d4583813-5f80-47e0-b028-df438f59cfe2",
-          "quantity": 4
-        },
-        {
-          
-          "custom": {
-            "elements": [
-              {
-                "amount": 6,
-                "material": {
-                  "country": "FR",
-                  "id": "5f837a69-839d-4a49-9a30-19e1501ad51e"
-                },
-                "transforms": []
-              }
-            ]
-          },
-          "id": "6b3d7f30-e87b-426c-93ed-3a1179238583",
-          "quantity": 4
-        },
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 20,
-                "material": {
-                  "country": "FR",
-                  "id": "42748244-0939-4da2-ad5f-206ce541d7ee"
-                },
-                "transforms": []
-              }
-            ]
-          },
-          "id": "d3ef64c0-3deb-4ef2-838d-015d8ece019e",
-          "quantity": 1
-        },
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 3,
-                "material": {
-                  "country": "FR",
-                  "id": "21a0d5b0-861e-4bed-98a9-46c61d2a0618"
-                },
-                "transforms": [
-                  {
-                    "country": "FR",
-                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
-                  },
-                  {
-                    "country": "FR",
-                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
-                  }
-                ]
-              },
-              {
-                "amount": 3,
-                "material": {
-                  "country": "FR",
-                  "id": "c5295f47-0307-48a6-8552-3705063af767"
-                },
-                "transforms": [
-                  {
-                    "country": "FR",
-                    "id": "85b74ce2-2cbc-4d73-a5a2-5c5ffde16319"
-                  }
-                ]
-              },
-              {
-                "amount": 1,
-                "material": {
-                  "country": "FR",
-                  "id": "20f5db04-a4c7-48ab-9903-38c65cd70be0"
-                },
-                "transforms": []
-              }
-            ]
-          },
-          "id": "1d2de15a-53d9-465d-a2cf-fa2c5f68f5e9",
-          "quantity": 2
-        },
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 16,
-                "material": {
-                  "country": "RAS",
-                  "id": "30212fbf-5912-40eb-b2ab-87837361c462"
-                },
-                "transforms": [
-                  {
-                    "country": "RAS",
-                    "id": "981e74ea-ef7d-40d1-b25e-c5534446474e"
-                  },
-                  {
-                    "country": "RAS",
-                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
-                  }
-                ]
-              },
-              {
-                "amount": 16,
-                "material": {
-                  "country": "RAS",
-                  "id": "c5295f47-0307-48a6-8552-3705063af767"
-                },
-                "transforms": [
-                  {
-                    "country": "RAS",
-                    "id": "85b74ce2-2cbc-4d73-a5a2-5c5ffde16319"
-                  }
-                ]
-              },
-              {
-                "amount": 4,
-                "material": {
-                  "country": "RAS",
-                  "id": "51956fb2-304d-4e63-a3ef-b3eed44fde38"
-                },
-                "transforms": []
-              }
-            ]
-          },
-          "id": "71086438-51a9-4980-ac3b-f24d5baa4cd5",
-          "quantity": 1
-        }
-      ],
-      "consumptions": [
-        {
-          "amount": 12000,
-          "processId": "eec31f13-d00a-4741-a84f-85d887026f8c"
-        }
-      ],
-      "recyclable": true
-    },
-    "scope": "veli"
-  },
-  {
-    "category": "Veli",
-    "id": "351a0340-2be5-49e1-a7e2-4d843e860fc5",
-    "name": "Veli, 90km/h max, 6kWh/100km, assemblage France",
-    "query": {
-      "assemblyCountry": "FR",
-      "components": [
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 40,
-                "material": {
-                  "country": "RAS",
-                  "id": "01d21ed5-9fc6-4d36-a0ea-cfea8035385b"
-                },
-                "transforms": [
-                  {
-                    "country": "RAS",
-                    "id": "85b74ce2-2cbc-4d73-a5a2-5c5ffde16319"
-                  }
-                ]
-              },
-              {
-                "amount": 180,
-                "material": {
-                  "country": "RAS",
-                  "id": "3e514eac-185c-449e-bdc2-e1082ca0576d"
-                },
-                "transforms": [
-                  {
-                    "country": "RAS",
-                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
-                  },
-                  {
-                    "country": "FR",
-                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
-                  }
-                ]
-              }
-            ]
-          },
-          "id": "189674e0-737e-4d6d-aab0-3fdfc19839ed",
-          "quantity": 1
-        },
-        {
-          "id": "57df64a3-278e-4e93-b836-9ba44b880fb5",
-          "quantity": 1
-        },
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 50,
-                "material": {
-                  "country": "RAS",
-                  "id": "97a70d45-d7d5-4ee5-86b4-ee506300cdaa"
-                },
-                "transforms": []
-              }
-            ]
-          },
-          "id": "da06c70f-5b61-4de7-bb51-5761818aa0dd",
-          "quantity": 1
-        },
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 8,
-                "material": {
-                  "country": "RAS",
-                  "id": "3e514eac-185c-449e-bdc2-e1082ca0576d"
-                },
-                "transforms": [
-                  {
-                    "country": "RAS",
-                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
-                  },
-                  {
-                    "country": "RAS",
-                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
-                  }
-                ]
-              }
-            ]
-          },
-          "id": "d4583813-5f80-47e0-b028-df438f59cfe2",
-          "quantity": 4
-        },
-        {
-          "id": "6b3d7f30-e87b-426c-93ed-3a1179238583",
-          "quantity": 4
-        },
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 20,
-                "material": {
-                  "country": "REO",
-                  "id": "42748244-0939-4da2-ad5f-206ce541d7ee"
-                },
-                "transforms": []
-              }
-            ]
-          },
-          "id": "d3ef64c0-3deb-4ef2-838d-015d8ece019e",
-          "quantity": 1
-        },
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 3,
-                "material": {
-                  "country": "RAS",
-                  "id": "3e514eac-185c-449e-bdc2-e1082ca0576d"
-                },
-                "transforms": [
-                  {
-                    "country": "RAS",
-                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
-                  },
-                  {
-                    "country": "RAS",
-                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
-                  }
-                ]
-              },
-              {
-                "amount": 3,
-                "material": {
-                  "id": "c5295f47-0307-48a6-8552-3705063af767"
-                },
-                "transforms": [
-                  {
-                    "id": "85b74ce2-2cbc-4d73-a5a2-5c5ffde16319"
-                  }
-                ]
-              },
-              {
-                "amount": 1,
-                "material": {
-                  "id": "20f5db04-a4c7-48ab-9903-38c65cd70be0"
-                },
-                "transforms": []
-              }
-            ]
-          },
-          "id": "1d2de15a-53d9-465d-a2cf-fa2c5f68f5e9",
-          "quantity": 2
-        },
-        {
-          "id": "71086438-51a9-4980-ac3b-f24d5baa4cd5",
-          "quantity": 1
-        }
-      ],
-      "consumptions": [
-        {
-          "amount": 12000,
-          "processId": "eec31f13-d00a-4741-a84f-85d887026f8c"
-        }
-      ],
-      "recyclable": true
-    },
-    "scope": "veli"
-  },
-  {
-    "category": "Veli",
-    "id": "a6a45e4e-c92c-4382-98b4-76ae7f95d1c5",
-    "name": "Veli, 90km/h max, 6kWh/100km, Asie",
-    "query": {
-      "assemblyCountry": "RAS",
-      "components": [
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 40,
-                "material": {
-                  "country": "RAS",
-                  "id": "01d21ed5-9fc6-4d36-a0ea-cfea8035385b"
-                },
-                "transforms": [
-                  {
-                    "country": "RAS",
-                    "id": "85b74ce2-2cbc-4d73-a5a2-5c5ffde16319"
-                  }
-                ]
-              },
-              {
-                "amount": 180,
-                "material": {
-                  "country": "RAS",
-                  "id": "3e514eac-185c-449e-bdc2-e1082ca0576d"
-                },
-                "transforms": [
-                  {
-                    "country": "RAS",
-                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
-                  },
-                  {
-                    "country": "RAS",
-                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
-                  }
-                ]
-              }
-            ]
-          },
-          "id": "189674e0-737e-4d6d-aab0-3fdfc19839ed",
-          "quantity": 1
-        },
-        {
-          "id": "57df64a3-278e-4e93-b836-9ba44b880fb5",
-          "quantity": 1
-        },
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 50,
-                "material": {
-                  "country": "RAS",
-                  "id": "97a70d45-d7d5-4ee5-86b4-ee506300cdaa"
-                },
-                "transforms": []
-              }
-            ]
-          },
-          "id": "da06c70f-5b61-4de7-bb51-5761818aa0dd",
-          "quantity": 1
-        },
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 8,
-                "material": {
-                  "country": "RAS",
-                  "id": "3e514eac-185c-449e-bdc2-e1082ca0576d"
-                },
-                "transforms": [
-                  {
-                    "country": "RAS",
-                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
-                  },
-                  {
-                    "country": "RAS",
-                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
-                  }
-                ]
-              }
-            ]
-          },
-          "id": "d4583813-5f80-47e0-b028-df438f59cfe2",
-          "quantity": 4
-        },
-        {
-          "id": "6b3d7f30-e87b-426c-93ed-3a1179238583",
-          "quantity": 4
-        },
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 20,
-                "material": {
-                  "country": "REO",
-                  "id": "42748244-0939-4da2-ad5f-206ce541d7ee"
-                },
-                "transforms": []
-              }
-            ]
-          },
-          "id": "d3ef64c0-3deb-4ef2-838d-015d8ece019e",
-          "quantity": 1
-        },
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 3,
-                "material": {
-                  "country": "RAS",
-                  "id": "3e514eac-185c-449e-bdc2-e1082ca0576d"
-                },
-                "transforms": [
-                  {
-                    "country": "RAS",
-                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
-                  },
-                  {
-                    "country": "RAS",
-                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
-                  }
-                ]
-              },
-              {
-                "amount": 3,
-                "material": {
-                  "id": "c5295f47-0307-48a6-8552-3705063af767"
-                },
-                "transforms": [
-                  {
-                    "id": "85b74ce2-2cbc-4d73-a5a2-5c5ffde16319"
-                  }
-                ]
-              },
-              {
-                "amount": 1,
-                "material": {
-                  "id": "20f5db04-a4c7-48ab-9903-38c65cd70be0"
-                },
-                "transforms": []
-              }
-            ]
-          },
-          "id": "1d2de15a-53d9-465d-a2cf-fa2c5f68f5e9",
-          "quantity": 2
-        },
-        {
-          "id": "71086438-51a9-4980-ac3b-f24d5baa4cd5",
-          "quantity": 1
-        }
-      ],
-      "consumptions": [
-        {
-          "amount": 12000,
-          "processId": "eec31f13-d00a-4741-a84f-85d887026f8c"
-        }
-      ],
-      "recyclable": true
-    },
-    "scope": "veli"
-  },
-  {
-    "category": "Voiture",
-    "id": "4582eb3a-e6fd-40e2-9c0c-fd65ac222ea8",
-    "name": "Voiture électrique CatB, 15kWh/100km, fabrication Europe de l'Ouest",
-    "query": {
-      "assemblyCountry": "REO",
-      "components": [
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 400,
-                "material": {
-                  "country": "REO",
-                  "id": "7cd80a58-6d07-4abc-ab41-624c0d1487c7"
-                },
-                "transforms": [
-                  {
-                    "country": "REO",
-                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
-                  },
-                  {
-                    "country": "REO",
-                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
-                  }
-                ]
-              },
-              {
-                "amount": 20,
-                "material": {
-                  "country": "REO",
-                  "id": "baae8572-db4a-4cb8-8f74-e72ba5ef0116"
-                },
-                "transforms": [
-                  {
-                    "country": "REO",
-                    "id": "971df5fa-c32e-4a7e-b1aa-14ce9f240b5c"
-                  },
-                  {
-                    "country": "REO",
-                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
-                  }
-                ]
-              },
-              {
-                "amount": 10,
-                "material": {
-                  "country": "REO",
-                  "id": "baae8572-db4a-4cb8-8f74-e72ba5ef0116"
-                },
-                "transforms": [
-                  {
-                    "country": "REO",
-                    "id": "d693bd0d-88d4-4370-81ee-597956bb58f0"
-                  },
-                  {
-                    "country": "REO",
-                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
-                  }
-                ]
-              },
-              {
-                "amount": 10,
-                "material": {
-                  "country": "REO",
-                  "id": "a363f079-bc3f-424a-a2e1-06b9c76b4fc3"
-                },
-                "transforms": []
-              },
-              {
-                "amount": 20,
-                "material": {
-                  "country": "REO",
-                  "id": "42748244-0939-4da2-ad5f-206ce541d7ee"
-                },
-                "transforms": []
-              },
-              {
-                "amount": 10,
-                "material": {
-                  "country": "REO",
-                  "id": "29b1a0f9-4887-49f7-910f-e50ad9e1b572"
-                },
-                "transforms": []
-              },
-              {
-                "amount": 220,
-                "material": {
-                  "country": "REO",
-                  "id": "c5295f47-0307-48a6-8552-3705063af767"
-                },
-                "transforms": [
-                  {
-                    "country": "REO",
-                    "id": "4a08bcab-5c25-4dec-961a-0f7208f40084"
-                  }
-                ]
-              }
-            ],
-            "name": "Carosserie"
-          },
-          "quantity": 1
-        },
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 80,
-                "material": {
-                  "country": "REO",
-                  "id": "97a70d45-d7d5-4ee5-86b4-ee506300cdaa"
-                },
-                "transforms": []
-              }
-            ],
-            "name": "Moteur"
-          },
-          "quantity": 1
-        },
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 10,
-                "material": {
-                  "country": "REO",
-                  "id": "7cd80a58-6d07-4abc-ab41-624c0d1487c7"
-                },
-                "transforms": [
-                  {
-                    "country": "REO",
-                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
-                  },
-                  {
-                    "country": "REO",
-                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
-                  }
-                ]
-              }
-            ],
-            "name": "Système de transmission"
-          },
-          "quantity": 1
-        },
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 220,
-                "material": {
-                  "country": "REO",
-                  "id": "7cd80a58-6d07-4abc-ab41-624c0d1487c7"
-                },
-                "transforms": [
-                  {
-                    "country": "REO",
-                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
-                  },
-                  {
-                    "country": "REO",
-                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
-                  }
-                ]
-              },
-              {
-                "amount": 15,
-                "material": {
-                  "country": "REO",
-                  "id": "30212fbf-5912-40eb-b2ab-87837361c462"
-                },
-                "transforms": [
-                  {
-                    "country": "REO",
-                    "id": "981e74ea-ef7d-40d1-b25e-c5534446474e"
-                  }
-                ]
-              },
-              {
-                "amount": 70,
-                "material": {
-                  "country": "REO",
-                  "id": "baae8572-db4a-4cb8-8f74-e72ba5ef0116"
-                },
-                "transforms": [
-                  {
-                    "country": "REO",
-                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
-                  }
-                ]
-              },
-              {
-                "amount": 15,
-                "material": {
-                  "country": "REO",
-                  "id": "baae8572-db4a-4cb8-8f74-e72ba5ef0116"
-                },
-                "transforms": [
-                  {
-                    "country": "REO",
-                    "id": "d693bd0d-88d4-4370-81ee-597956bb58f0"
-                  },
-                  {
-                    "country": "REO",
-                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
-                  }
-                ]
-              }
-            ],
-            "name": "Chassis"
-          },
-          "quantity": 1
-        },
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 8,
-                "material": {
-                  "country": "REO",
-                  "id": "5f837a69-839d-4a49-9a30-19e1501ad51e"
-                },
-                "transforms": []
-              }
-            ],
-            "name": "Pneus"
-          },
-          "quantity": 4
-        },
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 10,
-                "material": {
-                  "id": "c5295f47-0307-48a6-8552-3705063af767"
-                },
-                "transforms": [
-                  {
-                    "id": "4a08bcab-5c25-4dec-961a-0f7208f40084"
-                  }
-                ]
-              },
-              {
-                "amount": 10,
-                "material": {
-                  "id": "51956fb2-304d-4e63-a3ef-b3eed44fde38"
-                },
-                "transforms": []
-              },
-              {
-                "amount": 1,
-                "material": {
-                  "id": "30212fbf-5912-40eb-b2ab-87837361c462"
-                },
-                "transforms": [
-                  {
-                    "id": "981e74ea-ef7d-40d1-b25e-c5534446474e"
-                  },
-                  {
-                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
-                  }
-                ]
-              }
-            ],
-            "name": "Composants divers"
-          },
-          "quantity": 1
-        },
-        {
-          "id": "52e25580-d83a-4de6-9632-da4303d5211d",
-          "quantity": 1
-        }
-      ],
-      "consumptions": [
-        {
-          "amount": 45000,
-          "processId": "eec31f13-d00a-4741-a84f-85d887026f8c"
-        }
-      ],
-      "recyclable": true
-    },
-    "scope": "veli"
-  },
-  {
-    "category": "Voiture",
-    "id": "a6fb87c9-13fa-44d9-a679-d808a70e5546",
-    "name": "Voiture essence CatB, 5.5L/100km, fabrication Europe de l'Ouest",
-    "query": {
-      "assemblyCountry": "REO",
-      "components": [
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 430,
-                "material": {
-                  "country": "REO",
-                  "id": "7cd80a58-6d07-4abc-ab41-624c0d1487c7"
-                },
-                "transforms": [
-                  {
-                    "country": "REO",
-                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
-                  },
-                  {
-                    "country": "REO",
-                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
-                  }
-                ]
-              },
-              {
-                "amount": 5,
-                "material": {
-                  "country": "REO",
-                  "id": "baae8572-db4a-4cb8-8f74-e72ba5ef0116"
-                },
-                "transforms": [
-                  {
-                    "country": "REO",
-                    "id": "971df5fa-c32e-4a7e-b1aa-14ce9f240b5c"
-                  },
-                  {
-                    "country": "REO",
-                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
-                  }
-                ]
-              },
-              {
-                "amount": 5,
-                "material": {
-                  "country": "REO",
-                  "id": "baae8572-db4a-4cb8-8f74-e72ba5ef0116"
-                },
-                "transforms": [
-                  {
-                    "country": "REO",
-                    "id": "d693bd0d-88d4-4370-81ee-597956bb58f0"
-                  },
-                  {
-                    "country": "REO",
-                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
-                  }
-                ]
-              },
-              {
-                "amount": 6,
-                "material": {
-                  "country": "REO",
-                  "id": "a363f079-bc3f-424a-a2e1-06b9c76b4fc3"
-                },
-                "transforms": []
-              },
-              {
-                "amount": 17,
-                "material": {
-                  "country": "REO",
-                  "id": "42748244-0939-4da2-ad5f-206ce541d7ee"
-                },
-                "transforms": []
-              },
-              {
-                "amount": 10,
-                "material": {
-                  "country": "REO",
-                  "id": "29b1a0f9-4887-49f7-910f-e50ad9e1b572"
-                },
-                "transforms": []
-              },
-              {
-                "amount": 130,
-                "material": {
-                  "country": "REO",
-                  "id": "c5295f47-0307-48a6-8552-3705063af767"
-                },
-                "transforms": [
-                  {
-                    "country": "REO",
-                    "id": "4a08bcab-5c25-4dec-961a-0f7208f40084"
-                  }
-                ]
-              }
-            ],
-            "name": "Carosserie"
-          },
-          "quantity": 1
-        },
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 170,
-                "material": {
-                  "country": "REO",
-                  "id": "8b28671a-83f2-46e6-8c1c-e973a47dde97"
-                },
-                "transforms": []
-              }
-            ],
-            "name": "Groupe motopropulseur"
-          },
-          "quantity": 1
-        },
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 40,
-                "material": {
-                  "country": "REO",
-                  "id": "7cd80a58-6d07-4abc-ab41-624c0d1487c7"
-                },
-                "transforms": [
-                  {
-                    "country": "REO",
-                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
-                  },
-                  {
-                    "country": "REO",
-                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
-                  }
-                ]
-              },
-              {
-                "amount": 10,
-                "material": {
-                  "country": "REO",
-                  "id": "30212fbf-5912-40eb-b2ab-87837361c462"
-                },
-                "transforms": [
-                  {
-                    "country": "REO",
-                    "id": "981e74ea-ef7d-40d1-b25e-c5534446474e"
-                  },
-                  {
-                    "country": "REO",
-                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
-                  }
-                ]
-              },
-              {
-                "amount": 25,
-                "material": {
-                  "country": "REO",
-                  "id": "4b4e1204-48ac-48ac-a0e2-ee2176202a5a"
-                },
-                "transforms": [
-                  {
-                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
-                  }
-                ]
-              }
-            ],
-            "name": "Système de transmission"
-          },
-          "quantity": 1
-        },
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 200,
-                "material": {
-                  "country": "REO",
-                  "id": "7cd80a58-6d07-4abc-ab41-624c0d1487c7"
-                },
-                "transforms": [
-                  {
-                    "country": "REO",
-                    "id": "ea284007-49a8-4be1-95fc-452ea180285a"
-                  },
-                  {
-                    "country": "REO",
-                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
-                  }
-                ]
-              },
-              {
-                "amount": 15,
-                "material": {
-                  "country": "REO",
-                  "id": "30212fbf-5912-40eb-b2ab-87837361c462"
-                },
-                "transforms": [
-                  {
-                    "country": "REO",
-                    "id": "981e74ea-ef7d-40d1-b25e-c5534446474e"
-                  }
-                ]
-              },
-              {
-                "amount": 30,
-                "material": {
-                  "country": "REO",
-                  "id": "baae8572-db4a-4cb8-8f74-e72ba5ef0116"
-                },
-                "transforms": [
-                  {
-                    "country": "REO",
-                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
-                  }
-                ]
-              },
-              {
-                "amount": 10,
-                "material": {
-                  "country": "REO",
-                  "id": "baae8572-db4a-4cb8-8f74-e72ba5ef0116"
-                },
-                "transforms": [
-                  {
-                    "country": "REO",
-                    "id": "d693bd0d-88d4-4370-81ee-597956bb58f0"
-                  },
-                  {
-                    "country": "REO",
-                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
-                  }
-                ]
-              }
-            ],
-            "name": "Chassis"
-          },
-          "quantity": 1
-        },
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 20,
-                "material": {
-                  "country": "REO",
-                  "id": "f92ed520-3845-4a5a-8745-e87fd6863f03"
-                },
-                "transforms": []
-              }
-            ],
-            "name": "Batterie plomb"
-          },
-          "quantity": 1
-        },
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 8,
-                "material": {
-                  "country": "REO",
-                  "id": "5f837a69-839d-4a49-9a30-19e1501ad51e"
-                },
-                "transforms": []
-              }
-            ],
-            "name": "Pneus"
-          },
-          "quantity": 4
-        },
-        {
-          "custom": {
-            "elements": [
-              {
-                "amount": 2,
-                "material": {
-                  "id": "c5295f47-0307-48a6-8552-3705063af767"
-                },
-                "transforms": [
-                  {
-                    "id": "4a08bcab-5c25-4dec-961a-0f7208f40084"
-                  }
-                ]
-              },
-              {
-                "amount": 2,
-                "material": {
-                  "id": "51956fb2-304d-4e63-a3ef-b3eed44fde38"
-                },
-                "transforms": []
-              },
-              {
-                "amount": 1,
-                "material": {
-                  "id": "30212fbf-5912-40eb-b2ab-87837361c462"
-                },
-                "transforms": [
-                  {
-                    "id": "981e74ea-ef7d-40d1-b25e-c5534446474e"
-                  },
-                  {
-                    "id": "7319ac9c-5796-412f-a1eb-58e01afa7708"
-                  }
-                ]
-              }
-            ],
-            "name": "Composants divers"
-          },
-          "quantity": 1
-        }
-      ],
-      "consumptions": [
-        {
-          "amount": 16500,
-          "processId": "96da7da0-19f6-46fb-b7d7-2d888e7046e0"
         }
       ],
       "recyclable": true

--- a/tests/backend/integration/test_contrib.py
+++ b/tests/backend/integration/test_contrib.py
@@ -7,7 +7,10 @@ from app.domain.contrib.schemas import (
     ExampleContribResponse,
     GenericScope,
 )
-from app.domain.contrib.services import format_example_contrib_pr
+from app.domain.contrib.services import (
+    format_example_contrib_pr,
+    insert_example_sorted,
+)
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import joinedload
@@ -64,6 +67,12 @@ async def test_example_contrib_create_pull_request(
         "branchName": "contrib/veli/test-contrib",
         "pullRequestUrl": "https://github.com/MTES-MCT/ecobalyse/pull/123",
     }
+
+
+async def test_insert_example_sorted_orders_by_id() -> None:
+    result = insert_example_sorted([{"id": "b"}, {"id": "d"}], {"id": "c"})
+
+    assert [example["id"] for example in result] == ["b", "c", "d"]
 
 
 async def test_example_contrib_service_helpers_include_user_identity(

--- a/tests/server.spec.js
+++ b/tests/server.spec.js
@@ -12,6 +12,19 @@ describe("Env", () => {
   });
 });
 
+describe("Examples data", () => {
+  const exampleFiles = ["food2/examples.json", "object/examples.json", "veli/examples.json"];
+
+  for (const exampleFile of exampleFiles) {
+    it(`${exampleFile} should be sorted by ascending id`, () => {
+      const examples = require(`${__dirname}/../public/data/${exampleFile}`);
+      const ids = examples.map(({ id }) => id);
+
+      expect(ids).toEqual([...ids].sort());
+    });
+  }
+});
+
 describe("Web", () => {
   it("should render the homepage", async () => {
     const response = await request(app).get("/");


### PR DESCRIPTION
## :wrench: Problem

Fixes #2564

## :cake: Solution

Ce patch permet d'assurer un ordonnancement constant et prévisible des fichiers d'exemples génériques (food2, object, veli), et ce afin de faciliter les contributions parallèles via git et github.

## :rotating_light:  Points to watch/comments

- J'ai ajouté un script `bin/sort_generic_examples.py` qui devra être lancé une fois que TOUTES les PR de contributions auront été landées dans master. Le résultat devra alors être poussé sur cette branche, qui pourra lander à son tour. La raison est qu'il faudra partir d'une copie propre et ordonnancée pour éviter de multiples conflits inutilement complexes à résoudre sur les PR de contribution existantes, si on landait ces modifications immédiatement.
- Du fait du point précédent, les données existantes ne sont pas triées sur le patch, attendant que toutes les contributions soient landées sur master d'abord: en conséquence, le test que j'ai ajouté pour vérifier ce tri est en échec dans la CI, et c'est attendu pour le moment.
- Je susi toujours une quiche en Python :/

## 📋 TODO

- [x] technical validation by either @vjousse or @cedricr
- [x] All contribs by @nicolaspkandeel are landed onto master, none opened remaining
- [x] All contribs by @albanfournier are landed onto master, none opened remaining
- [x] All contribs by @GLestra15 are landed onto master, none opened remaining
- [x] Once all three checkboxes above are checked, run the sorting script onto this branch, rebased on top of latest master:
  ```
  uv run python bin/sort_generic_examples.py
  ```
- [x] Commit and push the results to this branch, build should turn green
