### PR TITLE
feat: update road/sea transport ratios

### DIFF
--- a/src/Data/Split.elm
+++ b/src/Data/Split.elm
@@ -16,7 +16,6 @@ module Data.Split exposing
     , fromPercent
     , full
     , half
-    , quarter
     , sixty
     , tenth
     , third
@@ -71,11 +70,6 @@ fifteen =
 twenty : Split
 twenty =
     Split 0.2
-
-
-quarter : Split
-quarter =
-    Split 0.25
 
 
 thirty : Split

--- a/src/Data/Transport.elm
+++ b/src/Data/Transport.elm
@@ -198,35 +198,21 @@ totalKm { air, road, sea } =
         |> Length.inKilometers
 
 
-{-| Determine road/sea transport ratio, so road transport is priviledged
-for shorter distances. A few notes:
+{-| Determine road/sea transport ratio: below a 3000km road-distance threshold,
+transport is fully done by road; otherwise it's fully done by sea.
 
-  - When road distance is 0, we fully take sea distance
-  - When sea distance is 0, we fully take road distance
-  - Otherwise we can apply specific ratios
+  - When road distance is greater than 0 and lower than 3000km, we fully take road distance
+  - When sea distance is 0, fall back to using full road distance
+  - Otherwise we fully take sea distance
 
 -}
 roadSeaTransportRatio : Transport -> Split
 roadSeaTransportRatio { road, sea } =
-    if Length.inKilometers road == 0 then
-        Split.zero
+    if Length.inKilometers road > 0 && Length.inKilometers road < 3000 then
+        Split.full
 
     else if Length.inKilometers sea == 0 then
         Split.full
-
-    else if Length.inKilometers road <= 500 then
-        Split.full
-
-    else if Length.inKilometers road < 1000 then
-        -- 0.9
-        Split.tenth
-            |> Split.complement
-
-    else if Length.inKilometers road < 2000 then
-        Split.half
-
-    else if Length.inKilometers road < 3000 then
-        Split.quarter
 
     else
         Split.zero

--- a/tests/Data/ComponentTest.elm
+++ b/tests/Data/ComponentTest.elm
@@ -1120,7 +1120,7 @@ suite =
                                             , Length.inKilometers sea > 0
                                             )
                                         )
-                                    |> Expect.equal (Ok ( False, True, True ))
+                                    |> Expect.equal (Ok ( False, True, False ))
                                 )
                             , it "should compute distance between two countries accounting transport to hubs"
                                 (Component.computeTransportDistance requirements

--- a/tests/Data/Food/RecipeTest.elm
+++ b/tests/Data/Food/RecipeTest.elm
@@ -458,7 +458,7 @@ suite =
                           }
                             |> Recipe.compute db
                             |> Result.map (firstIngredientDistance .roadCooled)
-                            |> Expect.equal (Ok (Just 1320))
+                            |> Expect.equal (Ok (Just 1980))
                             |> asTest "should have the computed road transport for Europe and Maghreb ('REM')"
                         ]
                     ]

--- a/tests/Data/TransportTest.elm
+++ b/tests/Data/TransportTest.elm
@@ -53,35 +53,25 @@ suite =
                             |> testTransportRatio Split.zero
                             |> Expect.equal ( 0, 0, 0 )
                         )
-                    , it "should handle ratio for road < 500km"
-                        ({ road = 400, sea = 200, air = 0 }
-                            |> testTransportRatio Split.zero
-                            |> Expect.equal ( 400, 0, 0 )
-                        )
-                    , it "should handle ratio for road < 1000km"
-                        ({ road = 900, sea = 1000, air = 0 }
-                            |> testTransportRatio Split.zero
-                            |> Expect.equal ( 810, 100, 0 )
-                        )
-                    , it "should handle ratio for road < 2000km"
-                        ({ road = 1800, sea = 1000, air = 0 }
-                            |> testTransportRatio Split.zero
-                            |> Expect.equal ( 900, 500, 0 )
-                        )
-                    , it "should handle ratio for road < 3000km"
+                    , it "should take 100% road distance below the 3000km threshold"
                         ({ road = 2800, sea = 4000, air = 0 }
                             |> testTransportRatio Split.zero
-                            |> Expect.equal ( 700, 3000, 0 )
+                            |> Expect.equal ( 2800, 0, 0 )
                         )
-                    , it "should handle ratio for road > 3000km"
+                    , it "should take 100% sea distance at or above the 3000km threshold"
                         ({ road = 5000, sea = 10000, air = 0 }
                             |> testTransportRatio Split.zero
                             |> Expect.equal ( 0, 10000, 0 )
                         )
-                    , it "should handle case where road=0km"
+                    , it "should take 100% sea distance when no road distance"
                         ({ road = 0, sea = 11310, air = 7300 }
                             |> testTransportRatio Split.zero
                             |> Expect.equal ( 0, 11310, 0 )
+                        )
+                    , it "should fall back to road past the threshold and no sea transport"
+                        ({ road = 5000, sea = 0, air = 0 }
+                            |> testTransportRatio Split.zero
+                            |> Expect.equal ( 5000, 0, 0 )
                         )
                     ]
                 , describe "with air transport"
@@ -91,7 +81,7 @@ suite =
                       in
                       Split.fromFloat 0.5
                         |> Result.map (\split -> testTransportRatio split transport)
-                        |> Expect.equal (Ok ( 250, 1250, 2500 ))
+                        |> Expect.equal (Ok ( 500, 0, 2500 ))
                         |> asTest "should handle air transport ratio"
                     ]
                 ]


### PR DESCRIPTION
## :wrench: Problem

Fixes #2145

## :cake: Solution

- Updated ratios
- Fallback to 100% road transport applied when sea transport is `null` or `0` (does not happen with current datasets, but may in the future)


## :rotating_light:  Points to watch/comments

Scores are changed in every scope

## :desert_island: How to test

Inspect ratios applied to distances