### PR TITLE
chore: move score_history to GH cron

### DIFF
--- a/.github/workflows/score_history.yml
+++ b/.github/workflows/score_history.yml
@@ -6,6 +6,11 @@ on:
     - cron: "0 * * * *"
   workflow_dispatch:
 
+# prevent overlapping runs
+# see https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
 
 env:
   NODE_ENV: test

--- a/.github/workflows/score_history.yml
+++ b/.github/workflows/score_history.yml
@@ -1,9 +1,9 @@
 name: Score History
 
 on:
-  push:
-    branches:
-      - '*'
+  schedule:
+    # Every hour
+    - cron: "0 * * * *"
   workflow_dispatch:
 
 


### PR DESCRIPTION
## :wrench: Problem

Deploys are blocked by the failing score history action that takes too long.

## :cake: Solution

As a first step, remove score history from the required checks and run it every hour or on demand.

## :desert_island: How to test

Merge and it should fix deploys
