### PR TITLE
feat(data): import bafu from a simapro csv export

### DIFF
--- a/data/import_bafu.py
+++ b/data/import_bafu.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+
+import bw2data
+from bw2io.strategies import (
+    change_electricity_unit_mj_to_kwh,
+    normalize_units,
+)
+
+from common import brightway_patch as brightway_patch
+from common.import_ import (
+    import_simapro_csv,
+    setup_project,
+)
+from config import settings
+from ecobalyse_data.bw.strategy import (
+    extract_simapro_metadata,
+    extract_tags,
+)
+from ecobalyse_data.logging import logger
+from import_ecoinvent import STRATEGIES
+
+# BAFU is a SimaPro CSV export of the Swiss KBOB ecoSpold project. It reuses the ecoinvent
+# normalization chain (STRATEGIES). Two ecoinvent-only strategies are intentionally left out:
+# - `extract_name_location_product`: its regex expects the ecoinvent-v3 SimaPro naming
+#   `product {CC}| activity`; BAFU uses the older UVEK/v2 convention (`name, at ... {CH} U`),
+#   with no product/activity split. `split_simapro_name_geo` + `assign_only_product_as_production`
+#   (both in STRATEGIES) already set location and reference product.
+# - the `remove_*` drop strategies: they would silently discard BAFU flows. Any later
+#   adjustment is driven by the flow diagnostic and the VoLCA cross-check, not by dropping data.
+BAFU_STRATEGIES = [
+    extract_simapro_metadata,
+    extract_tags,
+]
+
+
+def main():
+    setup_project()
+
+    if (db := settings.bw.BAFU) not in bw2data.databases:
+        import_simapro_csv(
+            settings.dbfiles.BAFU,
+            settings.dbfiles.BAFU_MD5,
+            db,
+            # A handful of BAFU electricity products are defined in MJ. The shared chain
+            # converts electricity MJ->kWh only after set_code_by_activity_hash, which desyncs
+            # the dataset unit from its production exchange and breaks the production self-link.
+            # Prepend normalize_units + the conversion so assign_only_product_as_production and
+            # set_code_by_activity_hash already see consistent kWh (both steps are idempotent).
+            strategies=[normalize_units, change_electricity_unit_mj_to_kwh]
+            + STRATEGIES
+            + BAFU_STRATEGIES,
+        )
+    else:
+        logger.info(f"{db} already imported")
+
+
+if __name__ == "__main__":
+    main()

--- a/data/justfile
+++ b/data/justfile
@@ -15,13 +15,16 @@ default:
 ################################################################################
 ### Imports
 
-import-all: import-food import-ecoinvent import-method create-activities sync-datapackages
+import-all: import-food import-ecoinvent import-bafu import-method create-activities sync-datapackages
 
 import-food:
   {{uv}} run python import_food.py
 
 import-ecoinvent:
   {{uv}} run python import_ecoinvent.py
+
+import-bafu:
+  {{uv}} run python import_bafu.py
 
 import-method:
   {{uv}} run python import_method.py

--- a/data/schemas/lci-schema.json
+++ b/data/schemas/lci-schema.json
@@ -192,7 +192,7 @@
     "source": {
       "enum": [
         "Agribalyse 3.2",
-        "BAFU 2026v1",
+        "BAFU 2025v2",
         "Ecobalyse_manual_lcia",
         "Ecobalyse_custom_lci",
         "Ecoinvent 3.9.1",

--- a/data/schemas/lci-schema.json
+++ b/data/schemas/lci-schema.json
@@ -192,6 +192,7 @@
     "source": {
       "enum": [
         "Agribalyse 3.2",
+        "BAFU 2026v1",
         "Ecobalyse_manual_lcia",
         "Ecobalyse_custom_lci",
         "Ecoinvent 3.9.1",

--- a/data/settings.toml
+++ b/data/settings.toml
@@ -37,6 +37,10 @@ EI311_MD5 = "98e7681cc57a729c952f48af7be9b164"
 WOOL = "wool.2.CSV.zip"
 WOOL_MD5 = "246b8ec57389086829bce58a689e7904"
 
+# BAFU
+BAFU = "BAFU2026v1.CSV.zip"
+BAFU_MD5 = "cdcf7c5828407e61972ebcf3162996c4"
+
 # Food
 AGRIBALYSE = "AGB32_final.CSV.zip"                           # Agribalyse 3.2
 AGRIBALYSE_MD5 = "044fdeb632e6e38711ef05a0ae596c55"
@@ -52,6 +56,7 @@ WFLDB_MD5 = "f619341f47c971b0d53ad28bd985fade"
 [default.bw]
 METHOD = "Environmental Footprint 3.1 (adapted)"
 AGRIBALYSE = "Agribalyse 3.2"
+BAFU = "BAFU 2026v1"
 BIOSPHERE = "biosphere3"
 ECOINVENT = "Ecoinvent 3.9.1"
 PROJECT = "ecobalyse"

--- a/data/settings.toml
+++ b/data/settings.toml
@@ -39,7 +39,7 @@ WOOL_MD5 = "246b8ec57389086829bce58a689e7904"
 
 # BAFU
 BAFU = "bafu-2025-2.csv.zip"
-BAFU_MD5 = "4031fa2f2c0a6378038fc48ee4a6e9a7"
+BAFU_MD5 = "b5d178b8e063ee618606c934862cacd3"
 
 # Food
 AGRIBALYSE = "AGB32_final.CSV.zip"                           # Agribalyse 3.2

--- a/data/settings.toml
+++ b/data/settings.toml
@@ -38,7 +38,7 @@ WOOL = "wool.2.CSV.zip"
 WOOL_MD5 = "246b8ec57389086829bce58a689e7904"
 
 # BAFU
-BAFU = "BAFU2025v2.CSV.zip"
+BAFU = "bafu-2025-2.csv.zip"
 BAFU_MD5 = "4031fa2f2c0a6378038fc48ee4a6e9a7"
 
 # Food

--- a/data/settings.toml
+++ b/data/settings.toml
@@ -38,8 +38,8 @@ WOOL = "wool.2.CSV.zip"
 WOOL_MD5 = "246b8ec57389086829bce58a689e7904"
 
 # BAFU
-BAFU = "BAFU2026v1.CSV.zip"
-BAFU_MD5 = "cdcf7c5828407e61972ebcf3162996c4"
+BAFU = "BAFU2025v2.CSV.zip"
+BAFU_MD5 = "4031fa2f2c0a6378038fc48ee4a6e9a7"
 
 # Food
 AGRIBALYSE = "AGB32_final.CSV.zip"                           # Agribalyse 3.2
@@ -56,7 +56,7 @@ WFLDB_MD5 = "f619341f47c971b0d53ad28bd985fade"
 [default.bw]
 METHOD = "Environmental Footprint 3.1 (adapted)"
 AGRIBALYSE = "Agribalyse 3.2"
-BAFU = "BAFU 2026v1"
+BAFU = "BAFU 2025v2"
 BIOSPHERE = "biosphere3"
 ECOINVENT = "Ecoinvent 3.9.1"
 PROJECT = "ecobalyse"


### PR DESCRIPTION
## :wrench: Problem

BAFU is out and we need to be able to start using it

Maybe fixes #2517 ?

## :cake: Solution

Exported a SimaPro CSV from the original BAFU simapro database and exported to CSV.

## :rotating_light:  Points to watch/comments

- Just a few things to dig after merge for another PR : https://htmlpreview.github.io/?https://github.com/MTES-MCT/ecobalyse-method-tooling/blob/main/bafu/brightway_vs_volca/etat_egalise.html
- Also need to update to 2026v1 as soon as we have it in simapro format.

## :desert_island: How to test

`just import-all` check you get BAFU in the brightway database list of the `ecobalyse`project.