### PR TITLE
fix: reload config after detailed processes received

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -467,6 +467,19 @@ update rawMsg ({ state } as model) =
                     in
                     ( { model | tray = newTray }, Cmd.map (AppMsg << App.ToastMsg) newToastMsg )
 
+                -- Component config (reloaded after detailed processes are received): refresh the session
+                -- config and re-init the current route so cached page results are recomputed with detailed impacts
+                ( ComponentConfigReceived _ _ (RemoteData.Success componentConfig), currentPage ) ->
+                    setRoute model.url
+                        ( { model | state = Loaded { session | componentConfig = componentConfig } currentPage }
+                        , Cmd.none
+                        )
+
+                ( ComponentConfigReceived _ _ (RemoteData.Failure error), _ ) ->
+                    notifyError model "Erreur" <|
+                        "Impossible de recharger la configuration des composants\u{00A0}: "
+                            ++ RequestCommon.errorToString error
+
                 -- Detailed processes
                 ( DetailedProcessesReceived sessionConfig (RemoteData.Success rawDetailedProcessesJson), currentPage ) ->
                     let


### PR DESCRIPTION
## :wrench: Problem

Fixes #2621

When detailed processes were loaded or reloaded, the config was fetched and updated in the Session, but the current simulator page state wasn't fully recomputed using all new data available, so the scores were computed without detailed impacts issued from processes attached to the config: the config still had references to the previous processes data, which were with all detailed impacts set to zero, hence the empty resulting impacts. (yes, in case you're wondering, this was a nightmare to debug)

## :cake: Solution

Force setting the route whenever we receive a config (which is always requested upon detailed processes received), triggering a full page recomputation using updated data.

## :desert_island: How to test

Check that issues raised in #2621 are solved by the patch.