### PR TITLE
feat(generic,ui): implement scoped labels

### DIFF
--- a/e2e/object-simulator.spec.js
+++ b/e2e/object-simulator.spec.js
@@ -4,11 +4,11 @@ test("object simulator", async ({ page }) => {
   await page.goto("/");
   await page.getByLabel("Menu principal").getByRole("link", { name: "Objets" }).click();
 
-  await page.getByRole("button", { name: "Ajouter un composant" }).click();
+  await page.getByRole("button", { name: "Ajouter un matériau" }).click();
   await page.getByRole("option", { name: "Pied chaise acier" }).click();
-  await page.getByRole("button", { name: "Ajouter un composant" }).click();
+  await page.getByRole("button", { name: "Ajouter un matériau" }).click();
   await page.getByRole("option", { name: "Structure acier (canapé 3p)" }).click();
-  await page.getByRole("button", { name: "Ajouter un composant" }).click();
+  await page.getByRole("button", { name: "Ajouter un matériau" }).click();
   await page.getByRole("option", { name: "Mousse polyurethane (canapé 3p)" }).click();
 
   await page.getByRole("row", { name: "▶ Pied chaise acier" }).getByRole("spinbutton").fill("2");

--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -436,6 +436,7 @@ addElement targetItem material items =
                                      , transforms = []
                                      }
                                    ]
+                        , name = material.displayName
                     }
                 )
             |> Ok

--- a/src/Page/Admin/Component.elm
+++ b/src/Page/Admin/Component.elm
@@ -636,8 +636,7 @@ modalView { componentConfig, db } modals index modal =
                     { title = "Modifier le composant"
                     , content =
                         [ ComponentView.editorView
-                            { addLabel = ""
-                            , componentConfig = componentConfig
+                            { componentConfig = componentConfig
                             , context = ComponentView.AdminContext
                             , db = db
                             , debug = False
@@ -676,7 +675,6 @@ modalView { componentConfig, db } modals index modal =
                             , removeItem = \_ -> NoOp
                             , scope = component.scope
                             , setDetailed = \_ -> NoOp
-                            , title = ""
                             , toggleTransportByAir = \_ -> NoOp
                             , toggleTransportCooling = \_ -> NoOp
                             , updateAssemblyCountry = \_ -> NoOp

--- a/src/Page/Object.elm
+++ b/src/Page/Object.elm
@@ -745,7 +745,7 @@ createComponent query ({ model, session } as pageUpdate) =
             Component.createItem Nothing
 
         newItem =
-            { baseItem | custom = Just { name = Just "Nouveau composant", elements = [], scope = Nothing } }
+            { baseItem | custom = Just { name = Nothing, elements = [], scope = Nothing } }
     in
     pageUpdate
         -- add new item to query

--- a/src/Page/Object.elm
+++ b/src/Page/Object.elm
@@ -895,8 +895,7 @@ selectProcess category targetItem maybeElementIndex autocompleteState query ({ m
 
 editorConfig : Session -> Model -> ComponentView.Config Db Msg
 editorConfig session ({ scope } as model) =
-    { addLabel = "Ajouter un composant existant"
-    , componentConfig = session.componentConfig
+    { componentConfig = session.componentConfig
     , context = ComponentView.GenericContext
     , db = session.db
     , debug = True
@@ -920,7 +919,6 @@ editorConfig session ({ scope } as model) =
     , lifeCycle = model.lifeCycle
     , scope = scope
     , setDetailed = SetDetailedComponents
-    , title = "Production des composants"
     , toggleTransportByAir = ToggleTransportByAir
     , toggleTransportCooling = ToggleTransportCooling
     , updateAssemblyCountry = UpdateAssemblyCountry

--- a/src/Page/Textile.elm
+++ b/src/Page/Textile.elm
@@ -987,8 +987,7 @@ simulatorFormView session model ({ inputs } as simulator) =
             ]
         ]
     , ComponentView.editorView
-        { addLabel = "Ajouter un accessoire"
-        , componentConfig = session.componentConfig
+        { componentConfig = session.componentConfig
         , context = ComponentView.TextileTrimsContext
         , db = session.db
         , debug = False
@@ -1019,7 +1018,6 @@ simulatorFormView session model ({ inputs } as simulator) =
         , removeItem = RemoveTrim
         , scope = Scope.Textile
         , setDetailed = \_ -> NoOp
-        , title = "Accessoires"
         , toggleTransportByAir = \_ -> NoOp
         , toggleTransportCooling = \_ -> NoOp
         , updateAssemblyCountry = \_ -> NoOp

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -59,8 +59,7 @@ import Views.Transport as TransportView
 
 
 type alias Config db msg =
-    { addLabel : String
-    , componentConfig : Component.Config
+    { componentConfig : Component.Config
     , context : Context
     , db : Component.DataContainer db
     , debug : Bool
@@ -84,7 +83,6 @@ type alias Config db msg =
     , removePackaging : Index -> msg
     , scope : Scope
     , setDetailed : List Index -> msg
-    , title : String
     , toggleTransportByAir : Split -> msg
     , toggleTransportCooling : Bool -> msg
     , updateAssemblyCountry : Maybe CountryCode.Code -> msg
@@ -120,7 +118,7 @@ requirementsFromConfig config =
 
 
 addComponentButton : Config db msg -> Html msg
-addComponentButton { addLabel, db, openSelectComponentModal, scope } =
+addComponentButton { context, db, openSelectComponentModal, scope } =
     let
         availableComponents =
             db.components
@@ -139,8 +137,47 @@ addComponentButton { addLabel, db, openSelectComponentModal, scope } =
         , onClick <| openSelectComponentModal autocompleteState
         ]
         [ Icon.plus
-        , text addLabel
+        , scopeLabels context scope
+            |> .add
+            |> text
         ]
+
+
+type alias Labels =
+    { add : String
+    , create : String
+    , heading : String
+    }
+
+
+{-| Scoped label. TODO: we might eventually want to make these configurable.
+-}
+scopeLabels : Context -> Scope -> Labels
+scopeLabels context scope =
+    case ( context, scope ) of
+        ( GenericContext, Scope.Generic Scope.Food2 ) ->
+            { add = "Ajouter un ingrédient"
+            , create = "Créer un nouvel ingrédient"
+            , heading = "Recette"
+            }
+
+        ( GenericContext, _ ) ->
+            { add = "Ajouter un matériau"
+            , create = "Créer un nouveau matériau"
+            , heading = "Production des matériaux"
+            }
+
+        ( TextileTrimsContext, Scope.Textile ) ->
+            { add = "Ajouter un accessoire"
+            , create = "Créer un nouvel accessoire"
+            , heading = "Accessoires"
+            }
+
+        _ ->
+            { add = "Ajouter un composant"
+            , create = "Créer un nouveau composant"
+            , heading = "Production des composants"
+            }
 
 
 createComponentButton : Config db msg -> Html msg
@@ -156,7 +193,9 @@ createComponentButton config =
             |> disabled
         ]
         [ Icon.plus
-        , text "Créer un nouveau composant"
+        , scopeLabels config.context config.scope
+            |> .create
+            |> text
         ]
 
 
@@ -432,12 +471,14 @@ simpleError title message =
 
 
 lifeCycleView : Config db msg -> LifeCycle -> Html msg
-lifeCycleView ({ db, docsUrl, explorerRoute, impact, query, scope, title } as config) lifeCycle =
+lifeCycleView ({ db, docsUrl, explorerRoute, impact, query, scope } as config) lifeCycle =
     div [ class "d-flex flex-column" ]
         [ div [ class "card shadow-sm" ]
             [ div [ class "card-header d-flex align-items-center justify-content-between gap-2" ]
                 [ h2 [ class "h5 mb-0" ]
-                    [ text title
+                    [ scopeLabels config.context scope
+                        |> .heading
+                        |> text
                     , case explorerRoute of
                         Just route ->
                             Link.smallPillExternal

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -147,6 +147,7 @@ type alias Labels =
     { add : String
     , create : String
     , heading : String
+    , name : String
     }
 
 
@@ -159,24 +160,28 @@ scopeLabels context scope =
             { add = "Ajouter un ingrédient"
             , create = "Créer un nouvel ingrédient"
             , heading = "Recette"
+            , name = "Nom de l'ingrédient"
             }
 
         ( GenericContext, _ ) ->
             { add = "Ajouter un matériau"
             , create = "Créer un nouveau matériau"
             , heading = "Production des matériaux"
+            , name = "Nom du matériau"
             }
 
         ( TextileTrimsContext, Scope.Textile ) ->
             { add = "Ajouter un accessoire"
             , create = "Créer un nouvel accessoire"
             , heading = "Accessoires"
+            , name = "Nom de l'accessoire"
             }
 
         _ ->
             { add = "Ajouter un composant"
             , create = "Créer un nouveau composant"
             , heading = "Production des composants"
+            , name = "Nom du composant"
             }
 
 
@@ -308,7 +313,12 @@ componentView config itemIndex ({ component, elements, quantity } as expandedIte
                         [ th [] []
                         , th [ class "pb-0 fs-8 fw-normal text-muted" ] [ text "Quantité" ]
                         , th [ class "pb-0 fs-8 fw-normal text-muted", colspan 2 ]
-                            [ span [] [ text "Nom du composant" ] ]
+                            [ span []
+                                [ scopeLabels config.context config.scope
+                                    |> .name
+                                    |> text
+                                ]
+                            ]
                         , th [ colspan 3 ] []
                         ]
 
@@ -349,7 +359,11 @@ componentView config itemIndex ({ component, elements, quantity } as expandedIte
                                         [ type_ "text"
                                         , class "form-control"
                                         , onInput (config.updateItemName ( component, itemIndex ))
-                                        , placeholder "Nom du composant"
+
+                                        -- TODO: use element material label if available, otherwide fallback to default
+                                        , scopeLabels config.context config.scope
+                                            |> .name
+                                            |> placeholder
                                         , value component.name
                                         ]
                                         []


### PR DESCRIPTION
## :wrench: Problem

Fixes #2569

## :cake: Solution

- Use domain-specific ui labels ("ingredient" for food2, "matériau" for other generic scopes, "accessoires" for textile components)
- also use default material display name when "adding/creating" an ingredient/matériau to the production list

## :desert_island: How to test

- Inspect generic simulators UI: food2 should use "ingrédient", others should use "matériau"
- Check that adding an ingredient makes the resulting component using the first element label (eg. I create "Ail bio", the resulting added component name should be "Ail bio"