### PR TITLE
chore: move e2e test suite to a scheduled job

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,7 +3,7 @@ name: End-to-end tests
 on:
   schedule:
     # Every hour
-    - cron: "0 * * * *"
+    - cron: "40 * * * *"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,7 +29,7 @@ jobs:
     services:
       postgres:
         # Same as Scalingo
-        image: postgres:14
+        image: postgres:17.9
         env:
           POSTGRES_DB: ecobalyse_test
           POSTGRES_USER: ecobalyse

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,7 +1,14 @@
-# This workflow will do a clean install of node dependencies, cache/restore them, build the source code and run tests across different versions of node
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+name: End-to-end tests
 
-name: Node.js CI
+on:
+  schedule:
+    # Every hour
+    - cron: "0 * * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
 
 env:
   NODE_ENV: test
@@ -13,12 +20,6 @@ env:
   EMAIL_SERVER_HOST: localhost
   EMAIL_SERVER_PORT: 1025
   EMAIL_SERVER_USE_TLS: false
-on:
-  push:
-    branches: [ master, staging ]
-  pull_request:
-    branches: [ master, staging ]
-  workflow_dispatch:
 
 jobs:
   build:
@@ -80,14 +81,6 @@ jobs:
     - name: Install Node dependencies
       run: npm ci --prefer-offline --no-audit --ignore-scripts
 
-    - name: Check JSON db formating
-      run: npm run db:validate
-
-    - name: Install Ubuntu dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y gettext
-
     - name: Install the latest version of uv
       uses: astral-sh/setup-uv@v4
       with:
@@ -97,17 +90,17 @@ jobs:
     - name: Build app
       run: npm run build --if-present
 
-    - name: Run prettier, openapi & ruff formatting check
-      run: npm run lint:all
+    # e2e tests
+    - name: Install Playwright Browsers
+      run: npx playwright install chromium --with-deps
 
-    - name: Run elm-review
-      run: npm run test:review
+    - name: Run Playwright tests
+      run: NODE_ENV=test npm run test:e2e
 
-    - name: Run client tests
-      run: npm run test:client
-
-    - name: Run js lib tests
-      run: npm run test:jslib
-
-    - name: Run server tests
-      run: npm run test:server && npm run test:backend
+    - name: Upload Playwright test artifacts
+      uses: actions/upload-artifact@v4
+      if: ${{ !cancelled() }}
+      with:
+        name: playwright-report
+        path: playwright-report/
+        retention-days: 3

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -28,7 +28,7 @@ jobs:
     services:
       postgres:
         # Same as Scalingo
-        image: postgres:14
+        image: postgres:17.9
         env:
           POSTGRES_DB: ecobalyse_test
           POSTGRES_USER: ecobalyse

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   db:
     container_name: ecobalyse_dev_db
     # Use the same version than Scalingo in production
-    image: postgres:14
+    image: postgres:17.9
     environment:
       POSTGRES_DB: ecobalyse_dev
       POSTGRES_USER: ecobalyse


### PR DESCRIPTION
## :wrench: Problem

CI runs & builds are very long, and it's inconvenient. Most of the CI build time is spent running the e2e test suite.

## :cake: Solution

Move the e2e test suite to a scheduled CI job, like we do for score history, so that CI builds on PRs are faster.

## :desert_island: How to test

I don't have a clear idea how we could test the whole thing before landing… hints?