### PR TITLE
feat(generic,ux): localize new transforms with sensible defaults

### DIFF
--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -442,15 +442,15 @@ addElement targetItem material items =
             |> Ok
 
 
-addElementTransform : TargetElement -> Process -> List Item -> Result String (List Item)
-addElementTransform targetElement transform items =
+addElementTransform : TargetElement -> Maybe CountryCode.Code -> Process -> List Item -> Result String (List Item)
+addElementTransform targetElement maybeCountry transform items =
     if not <| List.member Category.Transform transform.categories then
         Err "Seuls les procédés de catégorie `transformation` sont mobilisables comme procédés de transformation"
 
     else
         items
             |> updateElement targetElement
-                (\el -> { el | transforms = el.transforms ++ [ nonLocalizedProcess transform.id ] })
+                (\el -> { el | transforms = el.transforms ++ [ { country = maybeCountry, id = transform.id } ] })
             |> Ok
 
 
@@ -469,7 +469,11 @@ addOrSetProcess db category targetItem maybeElementIndex process items =
             items |> addElement targetItem process
 
         ( Category.Transform, Just elementIndex ) ->
-            items |> addElementTransform ( targetItem, elementIndex ) process
+            let
+                maybeCountry =
+                    items |> getTransformDefaultCountry targetItem maybeElementIndex
+            in
+            items |> addElementTransform ( targetItem, elementIndex ) maybeCountry process
 
         ( Category.Transform, Nothing ) ->
             Err "Un procédé de transformation ne peut être ajouté qu'à un élément existant"
@@ -2022,6 +2026,32 @@ getTotalTransportImpacts transports =
         [ transports.toAssembly.impacts
         , transports.toDistribution.impacts
         ]
+
+
+{-| Find the country a new transform should default to either:
+
+  - the one of the step it will follow, that is the last existing transform of the target element
+  - or its material when no transforms are present yet
+
+-}
+getTransformDefaultCountry : TargetItem -> Maybe Index -> List Item -> Maybe CountryCode.Code
+getTransformDefaultCountry targetItem maybeElementIndex items =
+    maybeElementIndex
+        |> Maybe.andThen
+            (\elementIndex ->
+                items
+                    |> itemElements targetItem
+                    |> LE.getAt elementIndex
+            )
+        |> Maybe.andThen
+            (\{ material, transforms } ->
+                case LE.last transforms of
+                    Just lastTransform ->
+                        lastTransform.country
+
+                    Nothing ->
+                        material.country
+            )
 
 
 idFromString : String -> Result String Id

--- a/tests/Data/ComponentTest.elm
+++ b/tests/Data/ComponentTest.elm
@@ -105,7 +105,7 @@ suite =
                         (\testComponent validTransformProcess invalidTransformProcess ->
                             [ itFromResult "should add a valid transformation process to a component element"
                                 (chair
-                                    |> Result.andThen (Component.addElementTransform ( ( testComponent, 1 ), 0 ) validTransformProcess)
+                                    |> Result.andThen (Component.addElementTransform ( ( testComponent, 1 ), 0 ) Nothing validTransformProcess)
                                     |> Result.map
                                         (\items ->
                                             items
@@ -122,7 +122,7 @@ suite =
                                 (Expect.equal (Just [ Component.nonLocalizedProcess validTransformProcess.id ]))
                             , it "should reject an invalid transformation process"
                                 (chair
-                                    |> Result.andThen (Component.addElementTransform ( ( testComponent, 1 ), 0 ) invalidTransformProcess)
+                                    |> Result.andThen (Component.addElementTransform ( ( testComponent, 1 ), 0 ) Nothing invalidTransformProcess)
                                     |> expectResultErrorContains "Seuls les procédés de catégorie `transformation` sont mobilisables comme procédés de transformation"
                                 )
                             ]
@@ -1534,7 +1534,7 @@ suite =
                         (\testComponent testProcess ->
                             [ itFromResult "should remove an element transform"
                                 (chair
-                                    |> Result.andThen (Component.addElementTransform ( ( testComponent, 1 ), 0 ) testProcess)
+                                    |> Result.andThen (Component.addElementTransform ( ( testComponent, 1 ), 0 ) Nothing testProcess)
                                     |> Result.map (Component.removeElementTransform ( ( testComponent, 1 ), 0 ) 0)
                                     |> Result.map (LE.getAt 1)
                                 )

--- a/tests/Data/ComponentTest.elm
+++ b/tests/Data/ComponentTest.elm
@@ -127,6 +127,43 @@ suite =
                                 )
                             ]
                         )
+                    , suiteFromResult3 "addOrSetProcess transform default country"
+                        chairBack
+                        injectionMoulding
+                        sawing
+                        (\testComponent firstTransform secondTransform ->
+                            let
+                                targetItem =
+                                    ( testComponent, 0 )
+
+                                itemsWithMaterialCountry =
+                                    decodeJson (Decode.list Component.decodeItem) <|
+                                        """ [ { "quantity": 1, "custom": { "name": "Test", "elements": [
+                                            { "amount": 1, "material": { "id": "6527710e-2434-5347-9bef-2205e0aa4f66", "country": "FR" }, "transforms": [] }
+                                        ] } } ] """
+
+                                itemsWithExistingTransform =
+                                    decodeJson (Decode.list Component.decodeItem) <|
+                                        """ [ { "quantity": 1, "custom": { "name": "Test", "elements": [
+                                            { "amount": 1, "material": { "id": "6527710e-2434-5347-9bef-2205e0aa4f66", "country": "FR" }, "transforms": [
+                                                { "id": "111539de-deea-588a-9581-6f6ceaa2dfa9", "country": "DE" }
+                                            ] }
+                                        ] } } ] """
+                            in
+                            [ itFromResult "should default a new transform country to the element material country"
+                                (itemsWithMaterialCountry
+                                    |> Result.andThen (Component.addOrSetProcess requirements.db Category.Transform targetItem (Just 0) firstTransform)
+                                    |> Result.map (elementTransformCountryAt 0 0 0)
+                                )
+                                (Expect.equal (Just (CountryCode.fromString "FR")))
+                            , itFromResult "should default a new transform country to the last transform country"
+                                (itemsWithExistingTransform
+                                    |> Result.andThen (Component.addOrSetProcess requirements.db Category.Transform targetItem (Just 0) secondTransform)
+                                    |> Result.map (elementTransformCountryAt 0 0 1)
+                                )
+                                (Expect.equal (Just (CountryCode.fromString "DE")))
+                            ]
+                        )
                     , suiteFromResult "addItem"
                         chairBack
                         (\testComponent ->
@@ -2095,6 +2132,16 @@ decodeJsonThen : Decoder a -> (a -> Result String b) -> String -> Result String 
 decodeJsonThen decoder fn =
     decodeJson decoder
         >> Result.andThen fn
+
+
+elementTransformCountryAt : Int -> Int -> Int -> List Item -> Maybe CountryCode.Code
+elementTransformCountryAt itemIndex elementIndex transformIndex items =
+    items
+        |> LE.getAt itemIndex
+        |> Maybe.andThen .custom
+        |> Maybe.andThen (.elements >> LE.getAt elementIndex)
+        |> Maybe.andThen (.transforms >> LE.getAt transformIndex)
+        |> Maybe.andThen .country
 
 
 resetProcessElecAndHeat : Process -> Process


### PR DESCRIPTION
## :wrench: Problem

⚠️ there's no matching issue/card, this is an UX-oriented initiative from me

In the simulator UI, adding a new transformation process doesn't localize it as the material or previous transform step country; from a UX perspective, this slows down the process of creating simulations.

## :cake: Solution

When picking a transform process, automatically apply the country from either the material or the previous transform one, eg.:

1. I pick `Ail bio`, which has a default origin `France`
2. I add a transform and select `Cuisson des fruits et légumes`
3. The added transform is automatically localized in `France` by default

## :desert_island: How to test

On a generic calculator (food2/object/veli):

Scenario 1:

- Add a component (=ingrédient/matériau)
- edit its first element
- either leave the default origin country if any, or pick one
- add a transform: the transform should be localized as the material

Scenario 2:

- Add a component (=ingrédient/matériau)
- edit its first element
- either leave the default origin country if any, or pick one
- add a transform, ensure it's localized
- add a new transform: the added transform should be localized the same as previous one