### PR TITLE
feat(data,veli): Fix Euro norm in diesel example

### DIFF
--- a/public/data/veli/examples.json
+++ b/public/data/veli/examples.json
@@ -3105,7 +3105,7 @@
         },
         {
           "amount": 1,
-          "processId": "cb471c73-27fd-42db-9450-a52b2d479d68"
+          "processId": "9c894465-b599-41cd-a39e-a69f1699c024"
         }
       ],
       "recyclable": true


### PR DESCRIPTION
## :wrench: Problem

"Camionette diesel" in modeled with EuroIV emission norm, whereas new vehicles now comply with EuroVI norm.
It has a significant impact.
No linked issue.

## :cake: Solution

fix the use process attached to this example :
9c894465-b599-41cd-a39e-a69f1699c024 (Diesel, Emissions EuroVId - kilométrage de 200 000 km) instead of cb471c73-27fd-42db-9450-a52b2d479d68 (Diesel, Emissions EuroIV - kilométrage de 200 000 km).


## :rotating_light:  Points to watch/comments

> _If there is anything unusual or some clarifications needed for the reviewer to better understand the PR, discuss it here._

## :desert_island: How to test

> _What someone else than you should do to validate that the solution you implemented is working as expected. Don't hesitate to be too verbose and to explain in details, using bullet points for example, the steps to follow to test the expected behavior._
