### PR TITLE
feat(generic,ux): conditional component/element add buttons

### DIFF
--- a/src/Page/Object.elm
+++ b/src/Page/Object.elm
@@ -1117,6 +1117,12 @@ view session model =
 
 modalView : Session -> Model -> Modal -> Html Msg
 modalView session ({ modals } as model) modal =
+    let
+        labelsConfig =
+            { context = ComponentView.GenericContext
+            , scope = model.scope
+            }
+    in
     case modal of
         AddComponentModal autocompleteState ->
             AutocompleteSelectorView.view
@@ -1126,8 +1132,8 @@ modalView session ({ modals } as model) modal =
                 , noOp = NoOp
                 , onAutocomplete = OnAutocompleteAddComponent
                 , onAutocompleteSelect = OnAutocompleteSelectComponent
-                , placeholderText = ComponentView.scopeLabels ComponentView.GenericContext model.scope |> .search
-                , title = ComponentView.scopeLabels ComponentView.GenericContext model.scope |> .select
+                , placeholderText = ComponentView.scopeLabels labelsConfig |> .search
+                , title = ComponentView.scopeLabels labelsConfig |> .select
                 , toLabel = .name
                 , toCategory = \_ -> ""
                 }
@@ -1221,8 +1227,8 @@ modalView session ({ modals } as model) modal =
                 ( placeholderText, title ) =
                     case category of
                         Category.Material ->
-                            ( ComponentView.scopeLabels ComponentView.GenericContext model.scope |> .search
-                            , ComponentView.scopeLabels ComponentView.GenericContext model.scope |> .selectRaw
+                            ( ComponentView.scopeLabels labelsConfig |> .search
+                            , ComponentView.scopeLabels labelsConfig |> .selectRaw
                             )
 
                         Category.Transform ->

--- a/src/Page/Object.elm
+++ b/src/Page/Object.elm
@@ -1126,8 +1126,8 @@ modalView session ({ modals } as model) modal =
                 , noOp = NoOp
                 , onAutocomplete = OnAutocompleteAddComponent
                 , onAutocompleteSelect = OnAutocompleteSelectComponent
-                , placeholderText = ComponentView.scopeLabels ComponentView.GenericContext model.scope |> .searchComponent
-                , title = ComponentView.scopeLabels ComponentView.GenericContext model.scope |> .selectComponent
+                , placeholderText = ComponentView.scopeLabels ComponentView.GenericContext model.scope |> .search
+                , title = ComponentView.scopeLabels ComponentView.GenericContext model.scope |> .select
                 , toLabel = .name
                 , toCategory = \_ -> ""
                 }
@@ -1221,8 +1221,8 @@ modalView session ({ modals } as model) modal =
                 ( placeholderText, title ) =
                     case category of
                         Category.Material ->
-                            ( ComponentView.scopeLabels ComponentView.GenericContext model.scope |> .searchRawElement
-                            , ComponentView.scopeLabels ComponentView.GenericContext model.scope |> .selectRawElement
+                            ( ComponentView.scopeLabels ComponentView.GenericContext model.scope |> .search
+                            , ComponentView.scopeLabels ComponentView.GenericContext model.scope |> .selectRaw
                             )
 
                         Category.Transform ->

--- a/src/Page/Object.elm
+++ b/src/Page/Object.elm
@@ -1126,8 +1126,8 @@ modalView session ({ modals } as model) modal =
                 , noOp = NoOp
                 , onAutocomplete = OnAutocompleteAddComponent
                 , onAutocompleteSelect = OnAutocompleteSelectComponent
-                , placeholderText = "tapez ici le nom du composant pour le rechercher"
-                , title = "Sélectionnez un composant"
+                , placeholderText = ComponentView.scopeLabels ComponentView.GenericContext model.scope |> .searchComponent
+                , title = ComponentView.scopeLabels ComponentView.GenericContext model.scope |> .selectComponent
                 , toLabel = .name
                 , toCategory = \_ -> ""
                 }
@@ -1221,8 +1221,8 @@ modalView session ({ modals } as model) modal =
                 ( placeholderText, title ) =
                     case category of
                         Category.Material ->
-                            ( "tapez ici le nom d'une matière pour la rechercher"
-                            , "Sélectionnez une matière première"
+                            ( ComponentView.scopeLabels ComponentView.GenericContext model.scope |> .searchRawElement
+                            , ComponentView.scopeLabels ComponentView.GenericContext model.scope |> .selectRawElement
                             )
 
                         Category.Transform ->

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -117,6 +117,48 @@ requirementsFromConfig config =
     }
 
 
+type alias Labels =
+    { addComponent : String
+    , addRawElement : String
+    , heading : String
+    , name : String
+    }
+
+
+{-| Scoped label. TODO: we might eventually want to make these configurable.
+-}
+scopeLabels : Context -> Scope -> Labels
+scopeLabels context scope =
+    case ( context, scope ) of
+        ( GenericContext, Scope.Generic Scope.Food2 ) ->
+            { addComponent = "Ajouter un ingrédient complexe"
+            , addRawElement = "Ajouter un ingrédient brut"
+            , heading = "Recette"
+            , name = "Nom de l'ingrédient"
+            }
+
+        ( GenericContext, _ ) ->
+            { addComponent = "Ajouter un matériau complexe"
+            , addRawElement = "Ajouter un matériau brut"
+            , heading = "Production des matériaux"
+            , name = "Nom du matériau"
+            }
+
+        ( TextileTrimsContext, Scope.Textile ) ->
+            { addComponent = "Ajouter un accessoire"
+            , addRawElement = "Ajouter un accessoire brut"
+            , heading = "Accessoires"
+            , name = "Nom de l'accessoire"
+            }
+
+        _ ->
+            { addComponent = "Ajouter un composant"
+            , addRawElement = "Ajouter un élément brut"
+            , heading = "Production des composants"
+            , name = "Nom du composant"
+            }
+
+
 addComponentButton : Config db msg -> Html msg
 addComponentButton { context, db, openSelectComponentModal, scope } =
     let
@@ -138,55 +180,13 @@ addComponentButton { context, db, openSelectComponentModal, scope } =
         ]
         [ Icon.plus
         , scopeLabels context scope
-            |> .add
+            |> .addComponent
             |> text
         ]
 
 
-type alias Labels =
-    { add : String
-    , create : String
-    , heading : String
-    , name : String
-    }
-
-
-{-| Scoped label. TODO: we might eventually want to make these configurable.
--}
-scopeLabels : Context -> Scope -> Labels
-scopeLabels context scope =
-    case ( context, scope ) of
-        ( GenericContext, Scope.Generic Scope.Food2 ) ->
-            { add = "Ajouter un ingrédient"
-            , create = "Créer un nouvel ingrédient"
-            , heading = "Recette"
-            , name = "Nom de l'ingrédient"
-            }
-
-        ( GenericContext, _ ) ->
-            { add = "Ajouter un matériau"
-            , create = "Créer un nouveau matériau"
-            , heading = "Production des matériaux"
-            , name = "Nom du matériau"
-            }
-
-        ( TextileTrimsContext, Scope.Textile ) ->
-            { add = "Ajouter un accessoire"
-            , create = "Créer un nouvel accessoire"
-            , heading = "Accessoires"
-            , name = "Nom de l'accessoire"
-            }
-
-        _ ->
-            { add = "Ajouter un composant"
-            , create = "Créer un nouveau composant"
-            , heading = "Production des composants"
-            , name = "Nom du composant"
-            }
-
-
-createComponentButton : Config db msg -> Html msg
-createComponentButton config =
+addRawElementButton : Config db msg -> Html msg
+addRawElementButton config =
     button
         [ type_ "button"
         , class "btn btn-outline-primary w-100"
@@ -199,7 +199,7 @@ createComponentButton config =
         ]
         [ Icon.plus
         , scopeLabels config.context config.scope
-            |> .create
+            |> .addRawElement
             |> text
         ]
 
@@ -556,18 +556,7 @@ lifeCycleView ({ db, docsUrl, explorerRoute, impact, query, scope } as config) l
                                         )
                                 )
                             ]
-            , case config.context of
-                AdminContext ->
-                    createComponentButton config
-
-                GenericContext ->
-                    div [ class "d-flex gap-1" ]
-                        [ addComponentButton config
-                        , createComponentButton config
-                        ]
-
-                TextileTrimsContext ->
-                    addComponentButton config
+            , productionButtonsView config
             ]
         , if Scope.isGeneric scope && not (List.isEmpty query.items) then
             div []
@@ -597,6 +586,27 @@ lifeCycleView ({ db, docsUrl, explorerRoute, impact, query, scope } as config) l
           else
             text ""
         ]
+
+
+productionButtonsView : Config db msg -> Html msg
+productionButtonsView ({ db, scope } as config) =
+    case config.context of
+        AdminContext ->
+            addRawElementButton config
+
+        GenericContext ->
+            div [ class "d-flex gap-1" ] <|
+                -- when no components are available for the current scope, only show the button to add raw elements
+                if db.components |> List.all (\component -> component.scope /= scope || Component.isEmpty component) then
+                    [ addRawElementButton config ]
+
+                else
+                    [ addComponentButton config
+                    , addRawElementButton config
+                    ]
+
+        TextileTrimsContext ->
+            addComponentButton config
 
 
 documentationLink : Config db msg -> String -> Html msg

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -133,8 +133,8 @@ type alias Labels =
 
 {-| Scoped label. TODO: we might eventually want to make these configurable.
 -}
-scopeLabels : Context -> Scope -> Labels
-scopeLabels context scope =
+scopeLabels : { config | context : Context, scope : Scope } -> Labels
+scopeLabels { context, scope } =
     case ( context, scope ) of
         ( GenericContext, Scope.Generic Scope.Food2 ) ->
             { add = "Ajouter un ingrédient transformé"
@@ -187,12 +187,12 @@ scopeLabels context scope =
 
 
 addComponentButton : Config db msg -> Html msg
-addComponentButton { context, db, openSelectComponentModal, scope } =
+addComponentButton ({ db, openSelectComponentModal } as config) =
     let
         availableComponents =
             db.components
                 |> List.filter (not << Component.isEmpty)
-                |> List.filter (.scope >> (==) scope)
+                |> List.filter (.scope >> (==) config.scope)
 
         autocompleteState =
             AutocompleteSelector.init .name availableComponents
@@ -206,9 +206,7 @@ addComponentButton { context, db, openSelectComponentModal, scope } =
         , onClick <| openSelectComponentModal autocompleteState
         ]
         [ Icon.plus
-        , scopeLabels context scope
-            |> .add
-            |> text
+        , scopeLabels config |> .add |> text
         ]
 
 
@@ -225,9 +223,7 @@ addRawElementButton config =
             |> disabled
         ]
         [ Icon.plus
-        , scopeLabels config.context config.scope
-            |> .addRaw
-            |> text
+        , scopeLabels config |> .addRaw |> text
         ]
 
 
@@ -340,12 +336,7 @@ componentView config itemIndex ({ component, elements, quantity } as expandedIte
                         [ th [] []
                         , th [ class "pb-0 fs-8 fw-normal text-muted" ] [ text "Quantité" ]
                         , th [ class "pb-0 fs-8 fw-normal text-muted", colspan 2 ]
-                            [ span []
-                                [ scopeLabels config.context config.scope
-                                    |> .label
-                                    |> text
-                                ]
-                            ]
+                            [ span [] [ scopeLabels config |> .label |> text ] ]
                         , th [ colspan 3 ] []
                         ]
 
@@ -386,9 +377,7 @@ componentView config itemIndex ({ component, elements, quantity } as expandedIte
                                         [ type_ "text"
                                         , class "form-control"
                                         , onInput (config.updateItemName ( component, itemIndex ))
-                                        , scopeLabels config.context config.scope
-                                            |> .label
-                                            |> placeholder
+                                        , scopeLabels config |> .label |> placeholder
                                         , value component.name
                                         ]
                                         []
@@ -517,9 +506,7 @@ lifeCycleView ({ db, docsUrl, explorerRoute, impact, query, scope } as config) l
         [ div [ class "card shadow-sm" ]
             [ div [ class "card-header d-flex align-items-center justify-content-between gap-2" ]
                 [ h2 [ class "h5 mb-0" ]
-                    [ scopeLabels config.context scope
-                        |> .heading
-                        |> text
+                    [ scopeLabels config |> .heading |> text
                     , case explorerRoute of
                         Just route ->
                             Link.smallPillExternal
@@ -551,9 +538,7 @@ lifeCycleView ({ db, docsUrl, explorerRoute, impact, query, scope } as config) l
                 ]
             , if List.isEmpty query.items then
                 div [ class "card-body" ]
-                    [ scopeLabels config.context config.scope
-                        |> .empty
-                        |> text
+                    [ scopeLabels config |> .empty |> text
                     ]
 
               else
@@ -570,9 +555,7 @@ lifeCycleView ({ db, docsUrl, explorerRoute, impact, query, scope } as config) l
                                             [ th [] []
                                             , th [ class "ps-0", Attr.scope "col" ] [ text "Quantité" ]
                                             , th [ Attr.scope "col", colspan 2 ]
-                                                [ scopeLabels config.context config.scope
-                                                    |> .name
-                                                    |> text
+                                                [ scopeLabels config |> .name |> text
                                                 ]
                                             , th [ Attr.scope "col" ] [ text "Masse" ]
                                             , th [ Attr.scope "col" ] [ text "Impact" ]

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -4,6 +4,7 @@ module Views.Component exposing
     , createElementMaterialAutocomplete
     , editorView
     , elementEditModalView
+    , scopeLabels
     )
 
 import Autocomplete exposing (Autocomplete)
@@ -122,6 +123,10 @@ type alias Labels =
     , addRawElement : String
     , heading : String
     , name : String
+    , searchComponent : String
+    , searchRawElement : String
+    , selectComponent : String
+    , selectRawElement : String
     }
 
 
@@ -131,31 +136,48 @@ scopeLabels : Context -> Scope -> Labels
 scopeLabels context scope =
     case ( context, scope ) of
         ( GenericContext, Scope.Generic Scope.Food2 ) ->
-            { addComponent = "Ajouter un ingrédient complexe"
+            { addComponent = "Ajouter un ingrédient transformé"
             , addRawElement = "Ajouter un ingrédient brut"
             , heading = "Recette"
             , name = "Nom de l'ingrédient"
+            , searchComponent = "tapez ici le nom de l’ingrédient pour le rechercher"
+            , searchRawElement = "tapez ici le nom de l’ingrédient brut pour le rechercher"
+            , selectComponent = "Sélectionnez un ingrédient transformé"
+            , selectRawElement = "Sélectionnez un ingrédient brut"
             }
 
         ( GenericContext, _ ) ->
-            { addComponent = "Ajouter un matériau complexe"
+            { addComponent = "Ajouter un matériau transformé"
             , addRawElement = "Ajouter un matériau brut"
             , heading = "Production des matériaux"
             , name = "Nom du matériau"
+            , searchComponent = "tapez ici le nom du matériau pour le rechercher"
+            , searchRawElement = "tapez ici le nom du matériau brut pour le rechercher"
+            , selectComponent = "Sélectionnez un matériau transformé"
+            , selectRawElement = "Sélectionnez un matériau brut"
             }
 
         ( TextileTrimsContext, Scope.Textile ) ->
+            -- Note: in Textile context, raw element handling is not available
             { addComponent = "Ajouter un accessoire"
-            , addRawElement = "Ajouter un accessoire brut"
+            , addRawElement = "Ajouter un accessoire"
             , heading = "Accessoires"
             , name = "Nom de l'accessoire"
+            , searchComponent = "tapez ici le nom de l’accessoire pour le rechercher"
+            , searchRawElement = "tapez ici le nom de l’accessoire pour le rechercher"
+            , selectComponent = "Sélectionnez un accessoire"
+            , selectRawElement = "Sélectionnez un accessoire"
             }
 
         _ ->
             { addComponent = "Ajouter un composant"
-            , addRawElement = "Ajouter un élément brut"
+            , addRawElement = "Créer un composant"
             , heading = "Production des composants"
             , name = "Nom du composant"
+            , searchComponent = "tapez ici le nom du composant pour le rechercher"
+            , searchRawElement = "tapez ici le nom d'un procédé matière pour le rechercher"
+            , selectComponent = "Sélectionnez un composant"
+            , selectRawElement = "Sélectionnez un procédé matière"
             }
 
 
@@ -359,8 +381,6 @@ componentView config itemIndex ({ component, elements, quantity } as expandedIte
                                         [ type_ "text"
                                         , class "form-control"
                                         , onInput (config.updateItemName ( component, itemIndex ))
-
-                                        -- TODO: use element material label if available, otherwide fallback to default
                                         , scopeLabels config.context config.scope
                                             |> .name
                                             |> placeholder

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -121,6 +121,7 @@ requirementsFromConfig config =
 type alias Labels =
     { add : String
     , addRaw : String
+    , empty : String
     , heading : String
     , name : String
     , search : String
@@ -137,6 +138,7 @@ scopeLabels context scope =
         ( GenericContext, Scope.Generic Scope.Food2 ) ->
             { add = "Ajouter un ingrédient transformé"
             , addRaw = "Ajouter un ingrédient brut"
+            , empty = "Aucun ingrédient"
             , heading = "Recette"
             , name = "Nom de l'ingrédient"
             , search = "tapez ici le nom de l’ingrédient pour le rechercher"
@@ -147,6 +149,7 @@ scopeLabels context scope =
         ( GenericContext, _ ) ->
             { add = "Ajouter un matériau transformé"
             , addRaw = "Ajouter un matériau brut"
+            , empty = "Aucun matériau"
             , heading = "Production des matériaux"
             , name = "Nom du matériau"
             , search = "tapez ici le nom du matériau pour le rechercher"
@@ -158,6 +161,7 @@ scopeLabels context scope =
             -- Note: in Textile context, raw element handling is not available
             { add = "Ajouter un accessoire"
             , addRaw = "Ajouter un accessoire"
+            , empty = "Aucun accessoire"
             , heading = "Accessoires"
             , name = "Nom de l'accessoire"
             , search = "tapez ici le nom de l’accessoire pour le rechercher"
@@ -168,6 +172,7 @@ scopeLabels context scope =
         _ ->
             { add = "Ajouter un composant"
             , addRaw = "Créer un composant"
+            , empty = "Aucun composant"
             , heading = "Production des composants"
             , name = "Nom du composant"
             , search = "tapez ici le nom du composant pour le rechercher"
@@ -430,7 +435,9 @@ componentDetailedView config elements itemIndex expandedItem itemResults =
         , if List.isEmpty elements then
             [ tr []
                 [ th [] []
-                , td [] [ text "Aucun élément" ]
+                , td []
+                    [ text "Aucun élément"
+                    ]
                 ]
             ]
 
@@ -538,7 +545,11 @@ lifeCycleView ({ db, docsUrl, explorerRoute, impact, query, scope } as config) l
                 , documentationLink config "production"
                 ]
             , if List.isEmpty query.items then
-                div [ class "card-body" ] [ text "Aucun élément." ]
+                div [ class "card-body" ]
+                    [ scopeLabels config.context config.scope
+                        |> .empty
+                        |> text
+                    ]
 
               else
                 case Component.expandItems db query.items of

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -119,14 +119,13 @@ requirementsFromConfig config =
 
 
 type alias Labels =
-    { addComponent : String
-    , addRawElement : String
+    { add : String
+    , addRaw : String
     , heading : String
     , name : String
-    , searchComponent : String
-    , searchRawElement : String
-    , selectComponent : String
-    , selectRawElement : String
+    , search : String
+    , select : String
+    , selectRaw : String
     }
 
 
@@ -136,48 +135,44 @@ scopeLabels : Context -> Scope -> Labels
 scopeLabels context scope =
     case ( context, scope ) of
         ( GenericContext, Scope.Generic Scope.Food2 ) ->
-            { addComponent = "Ajouter un ingrédient transformé"
-            , addRawElement = "Ajouter un ingrédient brut"
+            { add = "Ajouter un ingrédient transformé"
+            , addRaw = "Ajouter un ingrédient brut"
             , heading = "Recette"
             , name = "Nom de l'ingrédient"
-            , searchComponent = "tapez ici le nom de l’ingrédient pour le rechercher"
-            , searchRawElement = "tapez ici le nom de l’ingrédient brut pour le rechercher"
-            , selectComponent = "Sélectionnez un ingrédient transformé"
-            , selectRawElement = "Sélectionnez un ingrédient brut"
+            , search = "tapez ici le nom de l’ingrédient pour le rechercher"
+            , select = "Sélectionnez un ingrédient transformé"
+            , selectRaw = "Sélectionnez un ingrédient brut"
             }
 
         ( GenericContext, _ ) ->
-            { addComponent = "Ajouter un matériau transformé"
-            , addRawElement = "Ajouter un matériau brut"
+            { add = "Ajouter un matériau transformé"
+            , addRaw = "Ajouter un matériau brut"
             , heading = "Production des matériaux"
             , name = "Nom du matériau"
-            , searchComponent = "tapez ici le nom du matériau pour le rechercher"
-            , searchRawElement = "tapez ici le nom du matériau brut pour le rechercher"
-            , selectComponent = "Sélectionnez un matériau transformé"
-            , selectRawElement = "Sélectionnez un matériau brut"
+            , search = "tapez ici le nom du matériau pour le rechercher"
+            , select = "Sélectionnez un matériau transformé"
+            , selectRaw = "Sélectionnez un matériau brut"
             }
 
         ( TextileTrimsContext, Scope.Textile ) ->
             -- Note: in Textile context, raw element handling is not available
-            { addComponent = "Ajouter un accessoire"
-            , addRawElement = "Ajouter un accessoire"
+            { add = "Ajouter un accessoire"
+            , addRaw = "Ajouter un accessoire"
             , heading = "Accessoires"
             , name = "Nom de l'accessoire"
-            , searchComponent = "tapez ici le nom de l’accessoire pour le rechercher"
-            , searchRawElement = "tapez ici le nom de l’accessoire pour le rechercher"
-            , selectComponent = "Sélectionnez un accessoire"
-            , selectRawElement = "Sélectionnez un accessoire"
+            , search = "tapez ici le nom de l’accessoire pour le rechercher"
+            , select = "Sélectionnez un accessoire"
+            , selectRaw = "Sélectionnez un accessoire"
             }
 
         _ ->
-            { addComponent = "Ajouter un composant"
-            , addRawElement = "Créer un composant"
+            { add = "Ajouter un composant"
+            , addRaw = "Créer un composant"
             , heading = "Production des composants"
             , name = "Nom du composant"
-            , searchComponent = "tapez ici le nom du composant pour le rechercher"
-            , searchRawElement = "tapez ici le nom d'un procédé matière pour le rechercher"
-            , selectComponent = "Sélectionnez un composant"
-            , selectRawElement = "Sélectionnez un procédé matière"
+            , search = "tapez ici le nom du composant pour le rechercher"
+            , select = "Sélectionnez un composant"
+            , selectRaw = "Sélectionnez un procédé matière"
             }
 
 
@@ -202,7 +197,7 @@ addComponentButton { context, db, openSelectComponentModal, scope } =
         ]
         [ Icon.plus
         , scopeLabels context scope
-            |> .addComponent
+            |> .add
             |> text
         ]
 
@@ -221,7 +216,7 @@ addRawElementButton config =
         ]
         [ Icon.plus
         , scopeLabels config.context config.scope
-            |> .addRawElement
+            |> .addRaw
             |> text
         ]
 

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -123,6 +123,7 @@ type alias Labels =
     , addRaw : String
     , empty : String
     , heading : String
+    , label : String
     , name : String
     , search : String
     , select : String
@@ -140,7 +141,8 @@ scopeLabels context scope =
             , addRaw = "Ajouter un ingrédient brut"
             , empty = "Aucun ingrédient"
             , heading = "Recette"
-            , name = "Nom de l'ingrédient"
+            , label = "Nom de l'ingrédient"
+            , name = "Ingrédient"
             , search = "tapez ici le nom de l’ingrédient pour le rechercher"
             , select = "Sélectionnez un ingrédient transformé"
             , selectRaw = "Sélectionnez un ingrédient brut"
@@ -151,7 +153,8 @@ scopeLabels context scope =
             , addRaw = "Ajouter un matériau brut"
             , empty = "Aucun matériau"
             , heading = "Production des matériaux"
-            , name = "Nom du matériau"
+            , label = "Nom du matériau"
+            , name = "Matériau"
             , search = "tapez ici le nom du matériau pour le rechercher"
             , select = "Sélectionnez un matériau transformé"
             , selectRaw = "Sélectionnez un matériau brut"
@@ -163,7 +166,8 @@ scopeLabels context scope =
             , addRaw = "Ajouter un accessoire"
             , empty = "Aucun accessoire"
             , heading = "Accessoires"
-            , name = "Nom de l'accessoire"
+            , label = "Nom de l'accessoire"
+            , name = "Accessoire"
             , search = "tapez ici le nom de l’accessoire pour le rechercher"
             , select = "Sélectionnez un accessoire"
             , selectRaw = "Sélectionnez un accessoire"
@@ -174,7 +178,8 @@ scopeLabels context scope =
             , addRaw = "Créer un composant"
             , empty = "Aucun composant"
             , heading = "Production des composants"
-            , name = "Nom du composant"
+            , label = "Nom du composant"
+            , name = "Composant"
             , search = "tapez ici le nom du composant pour le rechercher"
             , select = "Sélectionnez un composant"
             , selectRaw = "Sélectionnez un procédé matière"
@@ -337,7 +342,7 @@ componentView config itemIndex ({ component, elements, quantity } as expandedIte
                         , th [ class "pb-0 fs-8 fw-normal text-muted", colspan 2 ]
                             [ span []
                                 [ scopeLabels config.context config.scope
-                                    |> .name
+                                    |> .label
                                     |> text
                                 ]
                             ]
@@ -382,7 +387,7 @@ componentView config itemIndex ({ component, elements, quantity } as expandedIte
                                         , class "form-control"
                                         , onInput (config.updateItemName ( component, itemIndex ))
                                         , scopeLabels config.context config.scope
-                                            |> .name
+                                            |> .label
                                             |> placeholder
                                         , value component.name
                                         ]
@@ -564,7 +569,11 @@ lifeCycleView ({ db, docsUrl, explorerRoute, impact, query, scope } as config) l
                                         [ tr [ class "fs-7 text-muted" ]
                                             [ th [] []
                                             , th [ class "ps-0", Attr.scope "col" ] [ text "Quantité" ]
-                                            , th [ Attr.scope "col", colspan 2 ] [ text "Composant" ]
+                                            , th [ Attr.scope "col", colspan 2 ]
+                                                [ scopeLabels config.context config.scope
+                                                    |> .name
+                                                    |> text
+                                                ]
                                             , th [ Attr.scope "col" ] [ text "Masse" ]
                                             , th [ Attr.scope "col" ] [ text "Impact" ]
                                             , th [ Attr.scope "col" ] []


### PR DESCRIPTION
Ce patch est une tentative de résolution simple de #2571 par des modifications d'ordre UI/UX, comme évoqué dans [le commentaire sur le ticket initial](https://github.com/MTES-MCT/ecobalyse/issues/2571#issuecomment-4965686280):

> Si j'introduis une règle UI qui stipule que :
>
>>**SI** aucun composant n'existe pour une verticale
>>**ET** que des procédés matériau bruts existent pour cette verticale,
>>**ALORS** on affiche un seul bouton "Ajouter un {ingrédient/matériau}" qui pointe vers la liste des procédés matière brute disponibles pour sélection et ajout
>>**SINON** on affiche les deux boutons
>
>Est-ce que tu penses que c'est une approche raisonnable ? Elle est beaucoup moins complexe et coûteuse à implémenter que la fusion des listes composants/procédés, pour un résultat opérationnel qui me semblerait satisfaire le besoin initial exprimé

Ce qui nous donne, côté food2:

<img width="1759" height="427" alt="image" src="https://github.com/user-attachments/assets/bce08e17-ff33-4cfa-a3f3-f41d6b08be82" />

Et côté Objet:

<img width="1761" height="669" alt="image" src="https://github.com/user-attachments/assets/078582bb-868d-499f-b74f-3b7cdd8d1589" />

## EDIT

The initial requirement of having a single add button is proposed for testing in #2664

