### PR TITLE
feat(ui,api): provide authenticated api commands

### DIFF
--- a/src/Data/Food/Query.elm
+++ b/src/Data/Food/Query.elm
@@ -35,6 +35,7 @@ import Data.Food.Ingredient as Ingredient
 import Data.Food.Preparation as Preparation
 import Data.Food.Retail as Retail
 import Data.Process as Process exposing (Process)
+import Data.Text as Text
 import Json.Decode as Decode exposing (Decoder)
 import Json.Decode.Pipeline as Pipe
 import Json.Encode as Encode
@@ -123,15 +124,10 @@ addPackaging packaging query =
     }
 
 
-buildApiQuery : String -> Query -> String
-buildApiQuery clientUrl query =
-    """curl -sS -X POST %apiUrl% \\
-  -H "accept: application/json" \\
-  -H "content-type: application/json" \\
-  -d '%json%'
-"""
-        |> String.replace "%apiUrl%" (clientUrl ++ "/api/food")
-        |> String.replace "%json%" (encode query |> Encode.encode 0)
+buildApiQuery : Maybe String -> String -> Query -> String
+buildApiQuery maybeToken clientUrl query =
+    (clientUrl ++ "/api/food")
+        |> Text.buildCurlCommand maybeToken (encode query |> Encode.encode 0)
 
 
 decode : Decoder Query

--- a/src/Data/Session.elm
+++ b/src/Data/Session.elm
@@ -10,6 +10,7 @@ module Data.Session exposing
     , decodeRawStore
     , defaultStore
     , deleteBookmark
+    , getAccessToken
     , getAuth
     , hasAccessToDetailedImpacts
     , isAuthenticated
@@ -327,6 +328,12 @@ encodeAuth auth =
         [ ( "accessTokenData", User.encodeAccessTokenData auth.accessTokenData )
         , ( "user", User.encodeUser auth.user )
         ]
+
+
+getAccessToken : Session -> Maybe String
+getAccessToken { store } =
+    store.auth
+        |> Maybe.map (.accessTokenData >> .accessToken)
 
 
 getAuth : Session -> Maybe Auth

--- a/src/Data/Text.elm
+++ b/src/Data/Text.elm
@@ -1,5 +1,6 @@
 module Data.Text exposing
-    ( search
+    ( buildCurlCommand
+    , search
     , sortI18nStrings
     , toWords
     , yesNo
@@ -14,6 +15,20 @@ type alias SearchConfig element =
     , query : String
     , toSearchableWords : element -> List String
     }
+
+
+buildCurlCommand : Maybe String -> String -> String -> String
+buildCurlCommand maybeToken json apiUrl =
+    [ Just "curl -sS -X POST %apiUrl%"
+    , Just "  -H \"accept: application/json\""
+    , Just "  -H \"content-type: application/json\""
+    , maybeToken |> Maybe.map (\token -> "  -H \"Authorization: Bearer " ++ token ++ "\"")
+    , Just "  -d '%json%'"
+    ]
+        |> List.filterMap identity
+        |> String.join " \\\n"
+        |> String.replace "%apiUrl%" apiUrl
+        |> String.replace "%json%" json
 
 
 {-| Filter a list of stringifyable items against provided search terms:

--- a/src/Data/Textile/Query.elm
+++ b/src/Data/Textile/Query.elm
@@ -28,6 +28,7 @@ import Data.Common.EncodeUtils as EU
 import Data.Component as Component exposing (Item)
 import Data.Country.Code as CountryCode
 import Data.Split as Split exposing (Split)
+import Data.Text as Text
 import Data.Textile.Dyeing as Dyeing exposing (ProcessType)
 import Data.Textile.Economics as Economics
 import Data.Textile.Fabric as Fabric exposing (Fabric)
@@ -131,15 +132,10 @@ updateTrims products fn query =
             { query | trims = Nothing }
 
 
-buildApiQuery : String -> Query -> String
-buildApiQuery clientUrl query =
-    """curl -sS -X POST %apiUrl% \\
-  -H "accept: application/json" \\
-  -H "content-type: application/json" \\
-  -d '%json%'
-"""
-        |> String.replace "%apiUrl%" (clientUrl ++ "/api/textile/simulator")
-        |> String.replace "%json%" (encode query |> Encode.encode 0)
+buildApiQuery : Maybe String -> String -> Query -> String
+buildApiQuery maybeToken clientUrl query =
+    (clientUrl ++ "/api/textile/simulator")
+        |> Text.buildCurlCommand maybeToken (encode query |> Encode.encode 0)
 
 
 decode : Decoder Query

--- a/src/Views/Bookmark.elm
+++ b/src/Views/Bookmark.elm
@@ -12,6 +12,7 @@ import Data.Food.Query as FoodQuery
 import Data.Impact.Definition exposing (Definition)
 import Data.Scope as Scope exposing (Scope)
 import Data.Session as Session exposing (Session)
+import Data.Text as Text
 import Data.Textile.Query as TextileQuery
 import Html exposing (..)
 import Html.Attributes exposing (..)
@@ -95,17 +96,13 @@ view cfg =
         }
 
 
-buildObjectApiQuery : Scope -> String -> Component.Query -> String
-buildObjectApiQuery scope clientUrl query =
-    -- FIXME: the Object/Veli API doesn't exist just yet, but we already expose what
+buildObjectApiQuery : Scope -> Maybe String -> String -> Component.Query -> String
+buildObjectApiQuery scope maybeToken clientUrl query =
+    -- FIXME: the Food2/Object/Veli API doesn't exist just yet, but we already expose what
     -- could be used when it's live
-    """curl -sS -X POST %apiUrl% \\
-  -H "accept: application/json" \\
-  -H "content-type: application/json" \\
-  -d '%json%'
-"""
-        |> String.replace "%apiUrl%" (clientUrl ++ "/api/" ++ Scope.toString scope ++ "/simulator")
-        |> String.replace "%json%" (Component.encodeQuery query |> Encode.encode 0)
+    (clientUrl ++ "/api/" ++ Scope.toString scope ++ "/simulator")
+        |> Text.buildCurlCommand maybeToken
+            (query |> Component.encodeQuery |> Encode.encode 0)
 
 
 shareTabView : ManagerConfig msg -> Html msg
@@ -123,7 +120,8 @@ shareTabView { copyToClipBoard, impact, scope, session } =
                         |> Route.toString
                         |> (++) "/"
                         |> (++) session.clientUrl
-                    , FoodQuery.buildApiQuery session.clientUrl query
+                    , query
+                        |> FoodQuery.buildApiQuery (Session.getAccessToken session) session.clientUrl
                     , FoodQuery.encode query
                         |> Encode.encode 2
                     )
@@ -138,7 +136,8 @@ shareTabView { copyToClipBoard, impact, scope, session } =
                         |> Route.toString
                         |> (++) "/"
                         |> (++) session.clientUrl
-                    , buildObjectApiQuery scope session.clientUrl query
+                    , query
+                        |> buildObjectApiQuery scope (Session.getAccessToken session) session.clientUrl
                     , Component.encodeQuery query
                         |> Encode.encode 2
                     )
@@ -153,7 +152,8 @@ shareTabView { copyToClipBoard, impact, scope, session } =
                         |> Route.toString
                         |> (++) "/"
                         |> (++) session.clientUrl
-                    , buildObjectApiQuery scope session.clientUrl query
+                    , query
+                        |> buildObjectApiQuery scope (Session.getAccessToken session) session.clientUrl
                     , Component.encodeQuery query
                         |> Encode.encode 2
                     )
@@ -168,7 +168,8 @@ shareTabView { copyToClipBoard, impact, scope, session } =
                         |> Route.toString
                         |> (++) "/"
                         |> (++) session.clientUrl
-                    , buildObjectApiQuery scope session.clientUrl query
+                    , query
+                        |> buildObjectApiQuery scope (Session.getAccessToken session) session.clientUrl
                     , Component.encodeQuery query
                         |> Encode.encode 2
                     )
@@ -183,7 +184,8 @@ shareTabView { copyToClipBoard, impact, scope, session } =
                         |> Route.toString
                         |> (++) "/"
                         |> (++) session.clientUrl
-                    , TextileQuery.buildApiQuery session.clientUrl query
+                    , query
+                        |> TextileQuery.buildApiQuery (Session.getAccessToken session) session.clientUrl
                     , TextileQuery.encode query
                         |> Encode.encode 2
                     )


### PR DESCRIPTION
## :wrench: Problem

When we recently made the food1 api requiring authentication to be accessed, we didn't update the generated sample commands in the "Share/Partager > API" section of the sidebar.

Even authenticated on the web app, copying and using the provided command would always fail with this message:

```
$ curl -sS -X POST https://ecobalyse.beta.gouv.fr/api/food \
  -H "accept: application/json" \
  -H "content-type: application/json" \
  -d '{"ingredients":[{"id":"f55d6582-d0c6-5987-8171-c6d3a9e448b3","mass":100}]}'
{"error":{"authorization":"Un token valide est requis pour utiliser l’API"},"documentation":"https://ecobalyse.beta.gouv.fr/#/api"}%
```

Frustrating, to say the least.

## :cake: Solution

Update all the provided API sample curl commands in the UI to use auth token when users when they're signed in. That way, commands they copy will work in their tooling.

### Before

<img width="818" height="398" alt="image" src="https://github.com/user-attachments/assets/3d759fc5-cd6a-4327-b3f3-2a434abfdb8f" />

### After

Note the added `Authorization` header:

<img width="820" height="449" alt="image" src="https://github.com/user-attachments/assets/1216fa58-df21-44cc-bf00-d31c222b0090" />

## :rotating_light:  Points to watch/comments

I pondered if that could increase risks of leaking the token, but quickly realized a token can already be sent by email or over chat, so… I don't think this patch adds much to the existing risk (which is very low)

## :desert_island: How to test

Check and test copyable API curl commands in all scopes, in anon and authenticated modes.