### PR TITLE
fix(food1): fix scoring total score computation

### DIFF
--- a/src/Data/Scoring.elm
+++ b/src/Data/Scoring.elm
@@ -33,7 +33,9 @@ compute definitions totalComplementsImpactPerKg perKgWithoutComplements =
                 |> Impact.toProtectionAreas definitions
     in
     { all =
-        -- Reminder: complements are stored as negative values, so a negative
+        -- Reminder: complements are stored using the same convention as impacts and therefore must be **added** not substracted
+        -- `value < 0` -> decreased environmental impact 
+        -- `value > 0` -> increased environmental impact
         -- complement is a bonus and must be *added* to lower the score
         Quantity.plus ecsPerKgWithoutComplements totalComplementsImpactPerKg
     , allWithoutComplements = ecsPerKgWithoutComplements

--- a/src/Data/Scoring.elm
+++ b/src/Data/Scoring.elm
@@ -34,9 +34,8 @@ compute definitions totalComplementsImpactPerKg perKgWithoutComplements =
     in
     { all =
         -- Reminder: complements are stored using the same convention as impacts and therefore must be **added** not substracted
-        -- `value < 0` -> decreased environmental impact 
+        -- `value < 0` -> decreased environmental impact
         -- `value > 0` -> increased environmental impact
-        -- complement is a bonus and must be *added* to lower the score
         Quantity.plus ecsPerKgWithoutComplements totalComplementsImpactPerKg
     , allWithoutComplements = ecsPerKgWithoutComplements
     , biodiversity = subScores.biodiversity

--- a/src/Data/Scoring.elm
+++ b/src/Data/Scoring.elm
@@ -32,7 +32,10 @@ compute definitions totalComplementsImpactPerKg perKgWithoutComplements =
             perKgWithoutComplements
                 |> Impact.toProtectionAreas definitions
     in
-    { all = Quantity.difference ecsPerKgWithoutComplements totalComplementsImpactPerKg
+    { all =
+        -- Reminder: complements are stored as negative values, so a negative
+        -- complement is a bonus and must be *added* to lower the score
+        Quantity.plus ecsPerKgWithoutComplements totalComplementsImpactPerKg
     , allWithoutComplements = ecsPerKgWithoutComplements
     , biodiversity = subScores.biodiversity
     , climate = subScores.climate

--- a/tests/Data/Food/RecipeTest.elm
+++ b/tests/Data/Food/RecipeTest.elm
@@ -15,7 +15,7 @@ import Expect
 import Length
 import Mass
 import Test exposing (..)
-import TestUtils exposing (asTest, suiteWithDb)
+import TestUtils exposing (asTest, itFromResult, suiteWithDb)
 
 
 expectImpactEqual : Unit.Impact -> Maybe Unit.Impact -> Expect.Expectation
@@ -191,16 +191,14 @@ suite =
                                             |> asTest "should properly score impact on resources protected area"
                                         ]
                                 )
-                             , asTest "should compute a total scoring value consistent with the per-kg ecs impact" <|
-                                case royalPizzaResults |> Result.map Tuple.second of
-                                    Err err ->
-                                        Expect.fail err
-
-                                    Ok results ->
-                                        results.perKg
-                                            |> Impact.getImpact Definition.Ecs
-                                            |> Unit.impactToFloat
-                                            |> Expect.within (Expect.Absolute 0.01) (Unit.impactToFloat results.scoring.all)
+                             , itFromResult "should compute a total scoring value consistent with the per-kg ecs impact"
+                                (royalPizzaResults |> Result.map Tuple.second)
+                                (\{ perKg, scoring } ->
+                                    perKg
+                                        |> Impact.getImpact Definition.Ecs
+                                        |> Unit.impactToFloat
+                                        |> Expect.within (Expect.Absolute 0.01) (Unit.impactToFloat scoring.all)
+                                )
                              ]
                             )
                         , describe "raw-to-cooked checks"

--- a/tests/Data/Food/RecipeTest.elm
+++ b/tests/Data/Food/RecipeTest.elm
@@ -166,7 +166,7 @@ suite =
 
                                     Ok scoring ->
                                         [ Unit.impactToFloat scoring.all
-                                            |> Expect.within (Expect.Absolute 0.01) 457.32
+                                            |> Expect.within (Expect.Absolute 0.01) 455.04
                                             |> asTest "should properly score total impact"
                                         , Unit.impactToFloat scoring.allWithoutComplements
                                             |> Expect.within (Expect.Absolute 0.01) 456.18
@@ -174,7 +174,7 @@ suite =
                                         , Unit.impactToFloat scoring.complements
                                             |> Expect.within (Expect.Absolute 0.01) -1.136
                                             |> asTest "should properly score complement impact"
-                                        , (Unit.impactToFloat scoring.allWithoutComplements - Unit.impactToFloat scoring.complements)
+                                        , (Unit.impactToFloat scoring.allWithoutComplements + Unit.impactToFloat scoring.complements)
                                             |> Expect.within (Expect.Absolute 0.0001) (Unit.impactToFloat scoring.all)
                                             |> asTest "should expose coherent scoring"
                                         , Unit.impactToFloat scoring.biodiversity
@@ -191,6 +191,16 @@ suite =
                                             |> asTest "should properly score impact on resources protected area"
                                         ]
                                 )
+                             , asTest "should compute a total scoring value consistent with the per-kg ecs impact" <|
+                                case royalPizzaResults |> Result.map Tuple.second of
+                                    Err err ->
+                                        Expect.fail err
+
+                                    Ok results ->
+                                        results.perKg
+                                            |> Impact.getImpact Definition.Ecs
+                                            |> Unit.impactToFloat
+                                            |> Expect.within (Expect.Absolute 0.01) (Unit.impactToFloat results.scoring.all)
                              ]
                             )
                         , describe "raw-to-cooked checks"


### PR DESCRIPTION
## :wrench: Problem

L'API food1 renvoie dans ses réponses un scoring total (`scoring.all`) qui ajoute au lieu de retrabncher les compléments bénéfiques du bio.

## :cake: Solution

Ce patch corrige le souci et ajoute les test adhoc.

## :desert_island: How to test

Le test ajouté garantit la bonne application du signe, mais cela peut se vérifier en requêtant l'API sur un produit bio comme l'abricot, qui doit avoir la valeur de `scoring.all` égale à celle de `results.perKg.ecs`.