### PR TITLE
feat(generic,ux): single production item add button

### DIFF
--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -15,6 +15,7 @@ module Data.Component exposing
     , Item
     , LifeCycle
     , Packaging
+    , ProductionItem(..)
     , Quantity
     , Query
     , Requirements
@@ -95,6 +96,7 @@ module Data.Component exposing
     , packaging
     , parseBase64Query
     , parseConfig
+    , productionItemToLabel
     , quantityFromInt
     , quantityToInt
     , removeConsumption
@@ -291,6 +293,14 @@ type alias ExpandedLocalizedProcess =
     { country : Maybe Country
     , process : Process
     }
+
+
+{-| The type of item to add at the production stage of the life cycle: either an existing Component
+or a raw material Process (which is turned into a custom component).
+-}
+type ProductionItem
+    = ComponentItem Component
+    | MaterialItem Process
 
 
 {-| Packaging process id and a quantity of its unit
@@ -2186,6 +2196,16 @@ parseBase64Query =
 parseConfig : DataContainer db -> String -> Result String Config
 parseConfig =
     Config.parse
+
+
+productionItemToLabel : ProductionItem -> String
+productionItemToLabel productionItem =
+    case productionItem of
+        ComponentItem { name } ->
+            name
+
+        MaterialItem process ->
+            Process.getDisplayName process
 
 
 quantityFromInt : Int -> Quantity

--- a/src/Page/Admin/Component.elm
+++ b/src/Page/Admin/Component.elm
@@ -653,14 +653,13 @@ modalView { componentConfig, db } modals index modal =
                                         , scope = component.scope
                                         }
                             , noOp = NoOp
-                            , openCreateComponentModal = NoOp
-                            , openSelectComponentModal = \_ -> NoOp
+                            , openEditElementModal = \_ _ -> NoOp
                             , openSelectConsumptionModal = \_ -> NoOp
                             , openSelectPackagingModal = \_ -> NoOp
-                            , openEditElementModal = \_ _ -> NoOp
                             , openSelectProcessModal =
                                 \p ti ei s ->
                                     SetModals (SelectProcessModal p ti ei s :: modals)
+                            , openSelectProductionItem = \_ -> NoOp
 
                             -- Note: we don't handle assembly country in the admin
                             , query = Component.emptyQuery |> Component.setQueryItems [ item ]

--- a/src/Page/Admin/Component.elm
+++ b/src/Page/Admin/Component.elm
@@ -644,7 +644,7 @@ modalView { componentConfig, db } modals index modal =
                             , docsUrl = Nothing
                             , explorerRoute = Nothing
                             , impact = db.definitions |> Definition.get Definition.Ecs
-                            , labels = ComponentView.scopeLabels { context = ComponentView.AdminContext, scope = component.scope }
+                            , labels = ComponentView.scopeLabels ComponentView.AdminContext component.scope
                             , lifeCycle =
                                 Component.emptyQuery
                                     |> Component.setQueryItems [ item ]

--- a/src/Page/Admin/Component.elm
+++ b/src/Page/Admin/Component.elm
@@ -644,6 +644,7 @@ modalView { componentConfig, db } modals index modal =
                             , docsUrl = Nothing
                             , explorerRoute = Nothing
                             , impact = db.definitions |> Definition.get Definition.Ecs
+                            , labels = ComponentView.scopeLabels { context = ComponentView.AdminContext, scope = component.scope }
                             , lifeCycle =
                                 Component.emptyQuery
                                     |> Component.setQueryItems [ item ]

--- a/src/Page/Object.elm
+++ b/src/Page/Object.elm
@@ -1117,6 +1117,12 @@ view session model =
 
 modalView : Session -> Model -> Modal -> Html Msg
 modalView session ({ modals } as model) modal =
+    let
+        labelsConfig =
+            { context = ComponentView.GenericContext
+            , scope = model.scope
+            }
+    in
     case modal of
         AddComponentModal autocompleteState ->
             AutocompleteSelectorView.view
@@ -1126,8 +1132,8 @@ modalView session ({ modals } as model) modal =
                 , noOp = NoOp
                 , onAutocomplete = OnAutocompleteAddComponent
                 , onAutocompleteSelect = OnAutocompleteSelectComponent
-                , placeholderText = ComponentView.scopeLabels ComponentView.GenericContext model.scope |> .search
-                , title = ComponentView.scopeLabels ComponentView.GenericContext model.scope |> .select
+                , placeholderText = ComponentView.scopeLabels labelsConfig |> .search
+                , title = ComponentView.scopeLabels labelsConfig |> .select
                 , toLabel = .name
                 , toCategory = \_ -> ""
                 }
@@ -1221,8 +1227,8 @@ modalView session ({ modals } as model) modal =
                 ( placeholderText, title ) =
                     case category of
                         Category.Material ->
-                            ( ComponentView.scopeLabels ComponentView.GenericContext model.scope |> .search
-                            , ComponentView.scopeLabels ComponentView.GenericContext model.scope |> .selectRaw
+                            ( ComponentView.scopeLabels labelsConfig |> .search
+                            , ComponentView.scopeLabels labelsConfig |> .selectRaw
                             )
 
                         Category.Transform ->

--- a/src/Page/Object.elm
+++ b/src/Page/Object.elm
@@ -1126,8 +1126,8 @@ modalView session ({ modals } as model) modal =
                 , noOp = NoOp
                 , onAutocomplete = OnAutocompleteAddComponent
                 , onAutocompleteSelect = OnAutocompleteSelectComponent
-                , placeholderText = ComponentView.scopeLabels ComponentView.GenericContext model.scope |> .searchComponent
-                , title = ComponentView.scopeLabels ComponentView.GenericContext model.scope |> .selectComponent
+                , placeholderText = ComponentView.scopeLabels ComponentView.GenericContext model.scope |> .search
+                , title = ComponentView.scopeLabels ComponentView.GenericContext model.scope |> .select
                 , toLabel = .name
                 , toCategory = \_ -> ""
                 }
@@ -1221,8 +1221,8 @@ modalView session ({ modals } as model) modal =
                 ( placeholderText, title ) =
                     case category of
                         Category.Material ->
-                            ( ComponentView.scopeLabels ComponentView.GenericContext model.scope |> .searchRawElement
-                            , ComponentView.scopeLabels ComponentView.GenericContext model.scope |> .selectRawElement
+                            ( ComponentView.scopeLabels ComponentView.GenericContext model.scope |> .search
+                            , ComponentView.scopeLabels ComponentView.GenericContext model.scope |> .selectRaw
                             )
 
                         Category.Transform ->

--- a/src/Page/Object.elm
+++ b/src/Page/Object.elm
@@ -790,12 +790,16 @@ selectExample autocompleteState ({ model } as pageUpdate) =
 
 selectComponentOrMaterial : Component.Query -> Autocomplete Component.ProductionItem -> PageUpdate Model Msg -> PageUpdate Model Msg
 selectComponentOrMaterial query autocompleteState ({ model, session } as pageUpdate) =
+    let
+        plausibleCommand =
+            Plausible.send pageUpdate.session <| Plausible.ComponentAdded model.scope
+    in
     case Autocomplete.selectedValue autocompleteState of
         Just (Component.ComponentItem component) ->
             pageUpdate
                 |> updateQuery (query |> Component.mapItems (Component.addItem component.id))
                 |> App.apply update (SetModals [])
-                |> App.withCmds [ Plausible.send pageUpdate.session <| Plausible.ComponentAdded model.scope ]
+                |> App.withCmds [ plausibleCommand ]
 
         Just (Component.MaterialItem process) ->
             let
@@ -824,7 +828,7 @@ selectComponentOrMaterial query autocompleteState ({ model, session } as pageUpd
                         |> updateQuery validQuery
                         |> App.apply update (SetModals [])
                         |> App.apply update (SetDetailedComponents (LE.unique (newItemIndex :: model.detailedComponents)))
-                        |> App.withCmds [ Plausible.send pageUpdate.session <| Plausible.ComponentAdded model.scope ]
+                        |> App.withCmds [ plausibleCommand ]
 
         Nothing ->
             pageUpdate |> App.notifyWarning "Aucun composant sélectionné"

--- a/src/Page/Object.elm
+++ b/src/Page/Object.elm
@@ -1120,16 +1120,6 @@ view session model =
     )
 
 
-productionItemCategoryName : Component.ProductionItem -> String
-productionItemCategoryName productionItem =
-    case productionItem of
-        Component.ComponentItem _ ->
-            "multi-procédés"
-
-        Component.MaterialItem _ ->
-            "mono-procédé"
-
-
 modalView : Session -> Model -> Modal -> Html Msg
 modalView session ({ modals } as model) modal =
     let
@@ -1151,7 +1141,7 @@ modalView session ({ modals } as model) modal =
                 , placeholderText = scopeLabels.search
                 , title = scopeLabels.select
                 , toLabel = Component.productionItemToLabel
-                , toCategory = productionItemCategoryName
+                , toCategory = always ""
                 }
 
         ComparatorModal ->

--- a/src/Page/Object.elm
+++ b/src/Page/Object.elm
@@ -1116,9 +1116,9 @@ view session model =
 
 
 productionItemCategoryName : Component.ProductionItem -> String
-productionItemCategoryName materialOrComponent =
+productionItemCategoryName productionItem =
     -- TODO: ensure everybody is onboard with these "controversial" labels
-    case materialOrComponent of
+    case productionItem of
         Component.ComponentItem _ ->
             "Composant"
 
@@ -1239,7 +1239,7 @@ modalView session ({ modals } as model) modal =
                     case category of
                         Category.Material ->
                             ( ComponentView.scopeLabels labelsConfig |> .search
-                            , ComponentView.scopeLabels labelsConfig |> .selectRaw
+                            , ComponentView.scopeLabels labelsConfig |> .select
                             )
 
                         Category.Transform ->

--- a/src/Page/Object.elm
+++ b/src/Page/Object.elm
@@ -1119,17 +1119,6 @@ view session model =
     )
 
 
-productionItemCategoryName : Component.ProductionItem -> String
-productionItemCategoryName productionItem =
-    -- TODO: ensure everybody is onboard with these "controversial" labels
-    case productionItem of
-        Component.ComponentItem _ ->
-            "Composant"
-
-        Component.MaterialItem _ ->
-            "Matière"
-
-
 modalView : Session -> Model -> Modal -> Html Msg
 modalView session ({ modals } as model) modal =
     let
@@ -1150,7 +1139,7 @@ modalView session ({ modals } as model) modal =
                 , placeholderText = ComponentView.scopeLabels labelsConfig |> .search
                 , title = ComponentView.scopeLabels labelsConfig |> .select
                 , toLabel = Component.productionItemToLabel
-                , toCategory = productionItemCategoryName
+                , toCategory = always ""
                 }
 
         ComparatorModal ->

--- a/src/Page/Object.elm
+++ b/src/Page/Object.elm
@@ -1126,8 +1126,8 @@ modalView session ({ modals } as model) modal =
                 , noOp = NoOp
                 , onAutocomplete = OnAutocompleteAddComponent
                 , onAutocompleteSelect = OnAutocompleteSelectComponent
-                , placeholderText = "tapez ici le nom du composant pour le rechercher"
-                , title = "Sélectionnez un composant"
+                , placeholderText = ComponentView.scopeLabels ComponentView.GenericContext model.scope |> .searchComponent
+                , title = ComponentView.scopeLabels ComponentView.GenericContext model.scope |> .selectComponent
                 , toLabel = .name
                 , toCategory = \_ -> ""
                 }
@@ -1221,8 +1221,8 @@ modalView session ({ modals } as model) modal =
                 ( placeholderText, title ) =
                     case category of
                         Category.Material ->
-                            ( "tapez ici le nom d'une matière pour la rechercher"
-                            , "Sélectionnez une matière première"
+                            ( ComponentView.scopeLabels ComponentView.GenericContext model.scope |> .searchRawElement
+                            , ComponentView.scopeLabels ComponentView.GenericContext model.scope |> .selectRawElement
                             )
 
                         Category.Transform ->

--- a/src/Page/Object.elm
+++ b/src/Page/Object.elm
@@ -80,7 +80,7 @@ type alias Model =
 
 
 type Modal
-    = AddComponentModal (Autocomplete Component)
+    = AddProductionItemModal (Autocomplete Component.ProductionItem)
     | ComparatorModal
     | EditElementModal Component TargetElement
     | SelectConsumptionModal (Autocomplete Process)
@@ -92,23 +92,22 @@ type Modal
 type Msg
     = AppendModal Modal
     | CopyToClipBoard String
-    | CreateComponent
     | CreateExampleContrib
     | DeleteBookmark Bookmark
     | ExampleContribCreated (WebData Contrib.ExampleContribResponse)
     | ExportBookmarks
     | ImportBookmarks
     | NoOp
-    | OnAutocompleteAddComponent (Autocomplete.Msg Component)
     | OnAutocompleteAddConsumption (Autocomplete.Msg Process)
     | OnAutocompleteAddProcess Category TargetItem (Maybe Index) (Autocomplete.Msg Process)
+    | OnAutocompleteAddProductionItem (Autocomplete.Msg Component.ProductionItem)
     | OnAutocompleteExample (Autocomplete.Msg Component.Query)
     | OnAutocompletePackaging (Autocomplete.Msg Process)
-    | OnAutocompleteSelectComponent
     | OnAutocompleteSelectConsumption
     | OnAutocompleteSelectExample
     | OnAutocompleteSelectPackaging
     | OnAutocompleteSelectProcess Category TargetItem (Maybe Index)
+    | OnAutocompleteSelectProductionItem
     | OnDragLeaveBookmark
     | OnDragOverBookmark Bookmark
     | OnDragStartBookmark Bookmark
@@ -313,10 +312,6 @@ update ({ navKey } as session) msg model =
             createPageUpdate session model
                 |> App.withCmds [ Ports.copyToClipboard shareableLink ]
 
-        ( CreateComponent, _ ) ->
-            createPageUpdate session model
-                |> createComponent query
-
         ( CreateExampleContrib, _ ) ->
             case ( Session.isAuthenticated session, createExampleContribData model ) of
                 ( True, Ok contribData ) ->
@@ -367,16 +362,16 @@ update ({ navKey } as session) msg model =
         ( NoOp, _ ) ->
             createPageUpdate session model
 
-        ( OnAutocompleteAddComponent autocompleteMsg, (AddComponentModal autocompleteState) :: otherModals ) ->
+        ( OnAutocompleteAddProductionItem autocompleteMsg, (AddProductionItemModal autocompleteState) :: otherModals ) ->
             let
                 ( newAutocompleteState, autoCompleteCmd ) =
                     Autocomplete.update autocompleteMsg autocompleteState
             in
-            { model | modals = AddComponentModal newAutocompleteState :: otherModals }
+            { model | modals = AddProductionItemModal newAutocompleteState :: otherModals }
                 |> createPageUpdate session
-                |> App.withCmds [ Cmd.map OnAutocompleteAddComponent autoCompleteCmd ]
+                |> App.withCmds [ Cmd.map OnAutocompleteAddProductionItem autoCompleteCmd ]
 
-        ( OnAutocompleteAddComponent _, _ ) ->
+        ( OnAutocompleteAddProductionItem _, _ ) ->
             createPageUpdate session model
 
         ( OnAutocompleteAddConsumption autocompleteMsg, (SelectConsumptionModal autocompleteState) :: otherModals ) ->
@@ -427,11 +422,11 @@ update ({ navKey } as session) msg model =
         ( OnAutocompletePackaging _, _ ) ->
             createPageUpdate session model
 
-        ( OnAutocompleteSelectComponent, (AddComponentModal autocompleteState) :: _ ) ->
+        ( OnAutocompleteSelectProductionItem, (AddProductionItemModal autocompleteState) :: _ ) ->
             createPageUpdate session model
-                |> selectComponent query autocompleteState
+                |> selectComponentOrMaterial query autocompleteState
 
-        ( OnAutocompleteSelectComponent, _ ) ->
+        ( OnAutocompleteSelectProductionItem, _ ) ->
             createPageUpdate session model
 
         ( OnAutocompleteSelectConsumption, (SelectConsumptionModal autocompleteState) :: _ ) ->
@@ -738,29 +733,6 @@ createPageUpdate session model =
             ]
 
 
-createComponent : Component.Query -> PageUpdate Model Msg -> PageUpdate Model Msg
-createComponent query ({ model, session } as pageUpdate) =
-    let
-        baseItem =
-            Component.createItem Nothing
-
-        newItem =
-            { baseItem | custom = Just { name = Nothing, elements = [], scope = Nothing } }
-    in
-    pageUpdate
-        -- add new item to query
-        |> updateQuery { query | items = query.items ++ [ newItem ] }
-        -- open material process selection modal
-        |> App.apply update
-            (ComponentView.createElementMaterialAutocomplete session.db model.scope
-                |> SelectProcessModal Category.Material ( Component.emptyComponent, List.length query.items ) Nothing
-                |> List.singleton
-                |> SetModals
-            )
-        -- expand item row
-        |> App.apply update (SetDetailedComponents (LE.unique (List.length query.items :: model.detailedComponents)))
-
-
 createExampleContribData : Model -> Result (List String) Contrib.ExampleContribData
 createExampleContribData model =
     let
@@ -787,7 +759,7 @@ createExampleContribData model =
 isAutocompleteModal : Modal -> Bool
 isAutocompleteModal modal =
     case modal of
-        AddComponentModal _ ->
+        AddProductionItemModal _ ->
             True
 
         SelectConsumptionModal _ ->
@@ -816,14 +788,43 @@ selectExample autocompleteState ({ model } as pageUpdate) =
         |> App.withCmds [ Plausible.send pageUpdate.session <| Plausible.ExampleSelected model.scope ]
 
 
-selectComponent : Component.Query -> Autocomplete Component -> PageUpdate Model Msg -> PageUpdate Model Msg
-selectComponent query autocompleteState ({ model } as pageUpdate) =
+selectComponentOrMaterial : Component.Query -> Autocomplete Component.ProductionItem -> PageUpdate Model Msg -> PageUpdate Model Msg
+selectComponentOrMaterial query autocompleteState ({ model, session } as pageUpdate) =
     case Autocomplete.selectedValue autocompleteState of
-        Just component ->
+        Just (Component.ComponentItem component) ->
             pageUpdate
                 |> updateQuery (query |> Component.mapItems (Component.addItem component.id))
                 |> App.apply update (SetModals [])
                 |> App.withCmds [ Plausible.send pageUpdate.session <| Plausible.ComponentAdded model.scope ]
+
+        Just (Component.MaterialItem process) ->
+            let
+                newItemIndex =
+                    List.length query.items
+
+                baseItem =
+                    Component.createItem Nothing
+
+                newItem =
+                    { baseItem | custom = Just { name = Nothing, elements = [], scope = Nothing } }
+
+                targetItem =
+                    ( Component.emptyComponent, newItemIndex )
+            in
+            case
+                { query | items = query.items ++ [ newItem ] }
+                    |> Component.tryMapItems
+                        (Component.addOrSetProcess session.db Category.Material targetItem Nothing process)
+            of
+                Err error ->
+                    pageUpdate |> App.notifyError "Erreur" error
+
+                Ok validQuery ->
+                    pageUpdate
+                        |> updateQuery validQuery
+                        |> App.apply update (SetModals [])
+                        |> App.apply update (SetDetailedComponents (LE.unique (newItemIndex :: model.detailedComponents)))
+                        |> App.withCmds [ Plausible.send pageUpdate.session <| Plausible.ComponentAdded model.scope ]
 
         Nothing ->
             pageUpdate |> App.notifyWarning "Aucun composant sélectionné"
@@ -904,12 +905,11 @@ editorConfig session ({ scope } as model) =
     , explorerRoute = Just (Route.Explore scope (Dataset.Components scope Nothing))
     , impact = model.impact
     , noOp = NoOp
-    , openCreateComponentModal = CreateComponent
-    , openSelectComponentModal = AddComponentModal >> List.singleton >> SetModals
     , openEditElementModal = \c ti -> AppendModal (EditElementModal c ti)
+    , openSelectConsumptionModal = SelectConsumptionModal >> List.singleton >> SetModals
     , openSelectPackagingModal = SelectPackagingModal >> List.singleton >> SetModals
     , openSelectProcessModal = \c ti mi ac -> AppendModal (SelectProcessModal c ti mi ac)
-    , openSelectConsumptionModal = SelectConsumptionModal >> List.singleton >> SetModals
+    , openSelectProductionItem = AddProductionItemModal >> List.singleton >> SetModals
     , query = session |> Session.objectQueryFromScope model.scope
     , removeConsumption = RemoveConsumption
     , removeElement = RemoveElement
@@ -1115,6 +1115,17 @@ view session model =
     )
 
 
+productionItemCategoryName : Component.ProductionItem -> String
+productionItemCategoryName materialOrComponent =
+    -- TODO: ensure everybody is onboard with these "controversial" labels
+    case materialOrComponent of
+        Component.ComponentItem _ ->
+            "Composant"
+
+        Component.MaterialItem _ ->
+            "Matière"
+
+
 modalView : Session -> Model -> Modal -> Html Msg
 modalView session ({ modals } as model) modal =
     let
@@ -1124,18 +1135,18 @@ modalView session ({ modals } as model) modal =
             }
     in
     case modal of
-        AddComponentModal autocompleteState ->
+        AddProductionItemModal autocompleteState ->
             AutocompleteSelectorView.view
                 { autocompleteState = autocompleteState
                 , closeModal = SetModals (List.drop 1 modals)
                 , footer = []
                 , noOp = NoOp
-                , onAutocomplete = OnAutocompleteAddComponent
-                , onAutocompleteSelect = OnAutocompleteSelectComponent
+                , onAutocomplete = OnAutocompleteAddProductionItem
+                , onAutocompleteSelect = OnAutocompleteSelectProductionItem
                 , placeholderText = ComponentView.scopeLabels labelsConfig |> .search
                 , title = ComponentView.scopeLabels labelsConfig |> .select
-                , toLabel = .name
-                , toCategory = \_ -> ""
+                , toLabel = Component.productionItemToLabel
+                , toCategory = productionItemCategoryName
                 }
 
         ComparatorModal ->

--- a/src/Page/Object.elm
+++ b/src/Page/Object.elm
@@ -908,6 +908,7 @@ editorConfig session ({ scope } as model) =
     , docsUrl = Nothing
     , explorerRoute = Just (Route.Explore scope (Dataset.Components scope Nothing))
     , impact = model.impact
+    , labels = ComponentView.scopeLabels { context = ComponentView.GenericContext, scope = scope }
     , noOp = NoOp
     , openEditElementModal = \c ti -> AppendModal (EditElementModal c ti)
     , openSelectConsumptionModal = SelectConsumptionModal >> List.singleton >> SetModals
@@ -1132,10 +1133,11 @@ productionItemCategoryName productionItem =
 modalView : Session -> Model -> Modal -> Html Msg
 modalView session ({ modals } as model) modal =
     let
-        labelsConfig =
-            { context = ComponentView.GenericContext
-            , scope = model.scope
-            }
+        scopeLabels =
+            ComponentView.scopeLabels
+                { context = ComponentView.GenericContext
+                , scope = model.scope
+                }
     in
     case modal of
         AddProductionItemModal autocompleteState ->
@@ -1146,8 +1148,8 @@ modalView session ({ modals } as model) modal =
                 , noOp = NoOp
                 , onAutocomplete = OnAutocompleteAddProductionItem
                 , onAutocompleteSelect = OnAutocompleteSelectProductionItem
-                , placeholderText = ComponentView.scopeLabels labelsConfig |> .search
-                , title = ComponentView.scopeLabels labelsConfig |> .select
+                , placeholderText = scopeLabels.search
+                , title = scopeLabels.select
                 , toLabel = Component.productionItemToLabel
                 , toCategory = productionItemCategoryName
                 }
@@ -1241,8 +1243,8 @@ modalView session ({ modals } as model) modal =
                 ( placeholderText, title ) =
                     case category of
                         Category.Material ->
-                            ( ComponentView.scopeLabels labelsConfig |> .search
-                            , ComponentView.scopeLabels labelsConfig |> .select
+                            ( scopeLabels.search
+                            , scopeLabels.select
                             )
 
                         Category.Transform ->

--- a/src/Page/Object.elm
+++ b/src/Page/Object.elm
@@ -1119,6 +1119,16 @@ view session model =
     )
 
 
+productionItemCategoryName : Component.ProductionItem -> String
+productionItemCategoryName productionItem =
+    case productionItem of
+        Component.ComponentItem _ ->
+            "multi-procédés"
+
+        Component.MaterialItem _ ->
+            "mono-procédé"
+
+
 modalView : Session -> Model -> Modal -> Html Msg
 modalView session ({ modals } as model) modal =
     let
@@ -1139,7 +1149,7 @@ modalView session ({ modals } as model) modal =
                 , placeholderText = ComponentView.scopeLabels labelsConfig |> .search
                 , title = ComponentView.scopeLabels labelsConfig |> .select
                 , toLabel = Component.productionItemToLabel
-                , toCategory = always ""
+                , toCategory = productionItemCategoryName
                 }
 
         ComparatorModal ->

--- a/src/Page/Object.elm
+++ b/src/Page/Object.elm
@@ -424,7 +424,7 @@ update ({ navKey } as session) msg model =
 
         ( OnAutocompleteSelectProductionItem, (AddProductionItemModal autocompleteState) :: _ ) ->
             createPageUpdate session model
-                |> selectComponentOrMaterial query autocompleteState
+                |> selectProductionItem query autocompleteState
 
         ( OnAutocompleteSelectProductionItem, _ ) ->
             createPageUpdate session model
@@ -788,8 +788,8 @@ selectExample autocompleteState ({ model } as pageUpdate) =
         |> App.withCmds [ Plausible.send pageUpdate.session <| Plausible.ExampleSelected model.scope ]
 
 
-selectComponentOrMaterial : Component.Query -> Autocomplete Component.ProductionItem -> PageUpdate Model Msg -> PageUpdate Model Msg
-selectComponentOrMaterial query autocompleteState ({ model, session } as pageUpdate) =
+selectProductionItem : Component.Query -> Autocomplete Component.ProductionItem -> PageUpdate Model Msg -> PageUpdate Model Msg
+selectProductionItem query autocompleteState ({ model, session } as pageUpdate) =
     let
         plausibleCommand =
             Plausible.send pageUpdate.session <| Plausible.ComponentAdded model.scope
@@ -806,11 +806,11 @@ selectComponentOrMaterial query autocompleteState ({ model, session } as pageUpd
                 newItemIndex =
                     List.length query.items
 
-                baseItem =
-                    Component.createItem Nothing
-
                 newItem =
-                    { baseItem | custom = Just { name = Nothing, elements = [], scope = Nothing } }
+                    { custom = Nothing
+                    , id = Nothing
+                    , quantity = Component.quantityFromInt 1
+                    }
 
                 targetItem =
                     ( Component.emptyComponent, newItemIndex )

--- a/src/Page/Object.elm
+++ b/src/Page/Object.elm
@@ -908,7 +908,7 @@ editorConfig session ({ scope } as model) =
     , docsUrl = Nothing
     , explorerRoute = Just (Route.Explore scope (Dataset.Components scope Nothing))
     , impact = model.impact
-    , labels = ComponentView.scopeLabels { context = ComponentView.GenericContext, scope = scope }
+    , labels = ComponentView.scopeLabels ComponentView.GenericContext scope
     , noOp = NoOp
     , openEditElementModal = \c ti -> AppendModal (EditElementModal c ti)
     , openSelectConsumptionModal = SelectConsumptionModal >> List.singleton >> SetModals
@@ -1124,10 +1124,7 @@ modalView : Session -> Model -> Modal -> Html Msg
 modalView session ({ modals } as model) modal =
     let
         scopeLabels =
-            ComponentView.scopeLabels
-                { context = ComponentView.GenericContext
-                , scope = model.scope
-                }
+            ComponentView.scopeLabels ComponentView.GenericContext model.scope
     in
     case modal of
         AddProductionItemModal autocompleteState ->

--- a/src/Page/Textile.elm
+++ b/src/Page/Textile.elm
@@ -1000,7 +1000,7 @@ simulatorFormView session model ({ inputs } as simulator) =
         , docsUrl = Just <| Gitbook.publicUrlFromPath Gitbook.TextileTrims
         , explorerRoute = Just (Route.Explore Scope.Textile (Dataset.Components Scope.Textile Nothing))
         , impact = model.impact
-        , labels = ComponentView.scopeLabels { context = ComponentView.TextileTrimsContext, scope = Scope.Textile }
+        , labels = ComponentView.scopeLabels ComponentView.TextileTrimsContext Scope.Textile
         , lifeCycle =
             Component.emptyQuery
                 |> Component.setQueryItems inputs.trims

--- a/src/Page/Textile.elm
+++ b/src/Page/Textile.elm
@@ -1000,6 +1000,7 @@ simulatorFormView session model ({ inputs } as simulator) =
         , docsUrl = Just <| Gitbook.publicUrlFromPath Gitbook.TextileTrims
         , explorerRoute = Just (Route.Explore Scope.Textile (Dataset.Components Scope.Textile Nothing))
         , impact = model.impact
+        , labels = ComponentView.scopeLabels { context = ComponentView.TextileTrimsContext, scope = Scope.Textile }
         , lifeCycle =
             Component.emptyQuery
                 |> Component.setQueryItems inputs.trims

--- a/src/Page/Textile.elm
+++ b/src/Page/Textile.elm
@@ -15,7 +15,7 @@ import Browser.Events
 import Browser.Navigation as Navigation
 import Data.AutocompleteSelector as AutocompleteSelector
 import Data.Bookmark as Bookmark exposing (Bookmark)
-import Data.Component as Component exposing (Component, Index)
+import Data.Component as Component exposing (Index)
 import Data.Country.Code as CountryCode
 import Data.Dataset as Dataset
 import Data.Db exposing (Db)
@@ -93,7 +93,7 @@ type alias Model =
 
 type Modal
     = AddMaterialModal (Maybe Inputs.MaterialInput) (Autocomplete Material)
-    | AddTrimModal (Autocomplete Component)
+    | AddTrimModal (Autocomplete Component.ProductionItem)
     | ComparatorModal
     | ConfirmSwitchToRegulatoryModal
     | ExplorerDetailsTab Material
@@ -118,7 +118,7 @@ type Msg
     | OnAutocompleteMaterial (Autocomplete.Msg Material)
     | OnAutocompleteProduct (Autocomplete.Msg Product)
     | OnAutocompleteSelect
-    | OnAutocompleteTrim (Autocomplete.Msg Component)
+    | OnAutocompleteTrim (Autocomplete.Msg Component.ProductionItem)
     | OnDragLeaveBookmark
     | OnDragOverBookmark Bookmark
     | OnDragStartBookmark Bookmark
@@ -730,16 +730,21 @@ selectExample autocompleteState { model, session } =
         |> App.withCmds [ Plausible.send session <| Plausible.ExampleSelected Scope.Textile ]
 
 
-selectTrim : Autocomplete Component -> PageUpdate Model Msg -> PageUpdate Model Msg
+selectTrim : Autocomplete Component.ProductionItem -> PageUpdate Model Msg -> PageUpdate Model Msg
 selectTrim autocompleteState ({ session } as pageUpdate) =
     case Autocomplete.selectedValue autocompleteState of
-        Just trim ->
+        Just (Component.ComponentItem trim) ->
             pageUpdate
                 |> App.apply update (SetModal NoModal)
                 |> updateQuery
                     (session.queries.textile
                         |> Query.updateTrims session.db.textile.products (Component.addItem trim.id)
                     )
+
+        -- Note: raw materials are not offered in the Textile trims context, so
+        -- only components are selectable here.
+        Just (Component.MaterialItem _) ->
+            pageUpdate |> App.notifyError "Erreur" "Un matériau brut ne peut pas être ajouté comme accessoire"
 
         Nothing ->
             pageUpdate |> App.notifyError "Erreur" "Aucun accessoire sélectionné"
@@ -1004,12 +1009,11 @@ simulatorFormView session model ({ inputs } as simulator) =
                     , scope = Scope.Textile
                     }
         , noOp = NoOp
-        , openCreateComponentModal = NoOp
-        , openSelectComponentModal = AddTrimModal >> SetModal
-        , openSelectPackagingModal = \_ -> NoOp
         , openEditElementModal = \_ _ -> NoOp
-        , openSelectProcessModal = \_ _ _ _ -> SetModal NoModal
         , openSelectConsumptionModal = \_ -> NoOp
+        , openSelectPackagingModal = \_ -> NoOp
+        , openSelectProcessModal = \_ _ _ _ -> SetModal NoModal
+        , openSelectProductionItem = AddTrimModal >> SetModal
         , query = Component.emptyQuery |> Component.setQueryItems inputs.trims
         , removeConsumption = \_ -> NoOp
         , removePackaging = \_ -> NoOp
@@ -1277,7 +1281,7 @@ view session model =
                                 , onAutocompleteSelect = OnAutocompleteSelect
                                 , placeholderText = "tapez ici un nom d'accesoire pour le rechercher"
                                 , title = "Sélectionnez un accessoire"
-                                , toLabel = .name
+                                , toLabel = Component.productionItemToLabel
                                 , toCategory = always ""
                                 }
 

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -117,6 +117,48 @@ requirementsFromConfig config =
     }
 
 
+type alias Labels =
+    { addComponent : String
+    , addRawElement : String
+    , heading : String
+    , name : String
+    }
+
+
+{-| Scoped label. TODO: we might eventually want to make these configurable.
+-}
+scopeLabels : Context -> Scope -> Labels
+scopeLabels context scope =
+    case ( context, scope ) of
+        ( GenericContext, Scope.Generic Scope.Food2 ) ->
+            { addComponent = "Ajouter un ingrédient complexe"
+            , addRawElement = "Ajouter un ingrédient brut"
+            , heading = "Recette"
+            , name = "Nom de l'ingrédient"
+            }
+
+        ( GenericContext, _ ) ->
+            { addComponent = "Ajouter un matériau complexe"
+            , addRawElement = "Ajouter un matériau brut"
+            , heading = "Production des matériaux"
+            , name = "Nom du matériau"
+            }
+
+        ( TextileTrimsContext, Scope.Textile ) ->
+            { addComponent = "Ajouter un accessoire"
+            , addRawElement = "Ajouter un accessoire brut"
+            , heading = "Accessoires"
+            , name = "Nom de l'accessoire"
+            }
+
+        _ ->
+            { addComponent = "Ajouter un composant"
+            , addRawElement = "Ajouter un élément brut"
+            , heading = "Production des composants"
+            , name = "Nom du composant"
+            }
+
+
 addComponentButton : Config db msg -> Html msg
 addComponentButton { context, db, openSelectComponentModal, scope } =
     let
@@ -138,55 +180,13 @@ addComponentButton { context, db, openSelectComponentModal, scope } =
         ]
         [ Icon.plus
         , scopeLabels context scope
-            |> .add
+            |> .addComponent
             |> text
         ]
 
 
-type alias Labels =
-    { add : String
-    , create : String
-    , heading : String
-    , name : String
-    }
-
-
-{-| Scoped label. TODO: we might eventually want to make these configurable.
--}
-scopeLabels : Context -> Scope -> Labels
-scopeLabels context scope =
-    case ( context, scope ) of
-        ( GenericContext, Scope.Generic Scope.Food2 ) ->
-            { add = "Ajouter un ingrédient"
-            , create = "Créer un nouvel ingrédient"
-            , heading = "Recette"
-            , name = "Nom de l'ingrédient"
-            }
-
-        ( GenericContext, _ ) ->
-            { add = "Ajouter un matériau"
-            , create = "Créer un nouveau matériau"
-            , heading = "Production des matériaux"
-            , name = "Nom du matériau"
-            }
-
-        ( TextileTrimsContext, Scope.Textile ) ->
-            { add = "Ajouter un accessoire"
-            , create = "Créer un nouvel accessoire"
-            , heading = "Accessoires"
-            , name = "Nom de l'accessoire"
-            }
-
-        _ ->
-            { add = "Ajouter un composant"
-            , create = "Créer un nouveau composant"
-            , heading = "Production des composants"
-            , name = "Nom du composant"
-            }
-
-
-createComponentButton : Config db msg -> Html msg
-createComponentButton config =
+addRawElementButton : Config db msg -> Html msg
+addRawElementButton config =
     button
         [ type_ "button"
         , class "btn btn-outline-primary w-100"
@@ -199,7 +199,7 @@ createComponentButton config =
         ]
         [ Icon.plus
         , scopeLabels config.context config.scope
-            |> .create
+            |> .addRawElement
             |> text
         ]
 
@@ -556,18 +556,7 @@ lifeCycleView ({ db, docsUrl, explorerRoute, impact, query, scope } as config) l
                                         )
                                 )
                             ]
-            , case config.context of
-                AdminContext ->
-                    createComponentButton config
-
-                GenericContext ->
-                    div [ class "d-flex gap-1" ]
-                        [ addComponentButton config
-                        , createComponentButton config
-                        ]
-
-                TextileTrimsContext ->
-                    addComponentButton config
+            , productionButtonsView config
             ]
         , if Scope.isGeneric scope && not (List.isEmpty query.items) then
             div []
@@ -597,6 +586,27 @@ lifeCycleView ({ db, docsUrl, explorerRoute, impact, query, scope } as config) l
           else
             text ""
         ]
+
+
+productionButtonsView : Config db msg -> Html msg
+productionButtonsView ({ db, scope } as config) =
+    case config.context of
+        AdminContext ->
+            addRawElementButton config
+
+        GenericContext ->
+            div [ class "d-flex gap-1" ] <|
+                -- when no components are available for the current scope, only show the button to add raw elements
+                if db.components |> List.all (\component -> component.scope /= scope || Component.isEmpty component) then
+                    [ addRawElementButton config ]
+
+                else
+                    [ addComponentButton config
+                    , addRawElementButton config
+                    ]
+
+        TextileTrimsContext ->
+            addComponentButton config
 
 
 documentationLink : Config db msg -> String -> Html msg

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -125,7 +125,6 @@ type alias Labels =
     , name : String
     , search : String
     , select : String
-    , selectRaw : String
     }
 
 
@@ -142,7 +141,6 @@ scopeLabels { context, scope } =
             , name = "Ingrédient"
             , search = "tapez ici le nom de l’ingrédient pour le rechercher"
             , select = "Sélectionnez un ingrédient"
-            , selectRaw = "Sélectionnez un ingrédient brut"
             }
 
         ( GenericContext, _ ) ->
@@ -153,7 +151,6 @@ scopeLabels { context, scope } =
             , name = "Matériau"
             , search = "tapez ici le nom du matériau pour le rechercher"
             , select = "Sélectionnez un matériau"
-            , selectRaw = "Sélectionnez un matériau brut"
             }
 
         ( TextileTrimsContext, Scope.Textile ) ->
@@ -165,7 +162,6 @@ scopeLabels { context, scope } =
             , name = "Accessoire"
             , search = "tapez ici le nom de l’accessoire pour le rechercher"
             , select = "Sélectionnez un accessoire"
-            , selectRaw = "Sélectionnez un accessoire"
             }
 
         _ ->
@@ -176,7 +172,6 @@ scopeLabels { context, scope } =
             , name = "Composant"
             , search = "tapez ici le nom du composant pour le rechercher"
             , select = "Sélectionnez un composant"
-            , selectRaw = "Sélectionnez un procédé matière"
             }
 
 

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -133,8 +133,8 @@ type alias Labels =
 
 {-| Scoped label. TODO: we might eventually want to make these configurable.
 -}
-scopeLabels : Context -> Scope -> Labels
-scopeLabels context scope =
+scopeLabels : { config | context : Context, scope : Scope } -> Labels
+scopeLabels { context, scope } =
     case ( context, scope ) of
         ( GenericContext, Scope.Generic Scope.Food2 ) ->
             { add = "Ajouter un ingrédient transformé"
@@ -187,12 +187,12 @@ scopeLabels context scope =
 
 
 addComponentButton : Config db msg -> Html msg
-addComponentButton { context, db, openSelectComponentModal, scope } =
+addComponentButton ({ db, openSelectComponentModal } as config) =
     let
         availableComponents =
             db.components
                 |> List.filter (not << Component.isEmpty)
-                |> List.filter (.scope >> (==) scope)
+                |> List.filter (.scope >> (==) config.scope)
 
         autocompleteState =
             AutocompleteSelector.init .name availableComponents
@@ -206,9 +206,7 @@ addComponentButton { context, db, openSelectComponentModal, scope } =
         , onClick <| openSelectComponentModal autocompleteState
         ]
         [ Icon.plus
-        , scopeLabels context scope
-            |> .add
-            |> text
+        , scopeLabels config |> .add |> text
         ]
 
 
@@ -225,9 +223,7 @@ addRawElementButton config =
             |> disabled
         ]
         [ Icon.plus
-        , scopeLabels config.context config.scope
-            |> .addRaw
-            |> text
+        , scopeLabels config |> .addRaw |> text
         ]
 
 
@@ -340,12 +336,7 @@ componentView config itemIndex ({ component, elements, quantity } as expandedIte
                         [ th [] []
                         , th [ class "pb-0 fs-8 fw-normal text-muted" ] [ text "Quantité" ]
                         , th [ class "pb-0 fs-8 fw-normal text-muted", colspan 2 ]
-                            [ span []
-                                [ scopeLabels config.context config.scope
-                                    |> .label
-                                    |> text
-                                ]
-                            ]
+                            [ span [] [ scopeLabels config |> .label |> text ] ]
                         , th [ colspan 3 ] []
                         ]
 
@@ -386,9 +377,7 @@ componentView config itemIndex ({ component, elements, quantity } as expandedIte
                                         [ type_ "text"
                                         , class "form-control"
                                         , onInput (config.updateItemName ( component, itemIndex ))
-                                        , scopeLabels config.context config.scope
-                                            |> .label
-                                            |> placeholder
+                                        , scopeLabels config |> .label |> placeholder
                                         , value component.name
                                         ]
                                         []
@@ -517,9 +506,7 @@ lifeCycleView ({ db, docsUrl, explorerRoute, impact, query, scope } as config) l
         [ div [ class "card shadow-sm" ]
             [ div [ class "card-header d-flex align-items-center justify-content-between gap-2" ]
                 [ h2 [ class "h5 mb-0" ]
-                    [ scopeLabels config.context scope
-                        |> .heading
-                        |> text
+                    [ scopeLabels config |> .heading |> text
                     , case explorerRoute of
                         Just route ->
                             Link.smallPillExternal
@@ -551,9 +538,7 @@ lifeCycleView ({ db, docsUrl, explorerRoute, impact, query, scope } as config) l
                 ]
             , if List.isEmpty query.items then
                 div [ class "card-body" ]
-                    [ scopeLabels config.context config.scope
-                        |> .empty
-                        |> text
+                    [ scopeLabels config |> .empty |> text
                     ]
 
               else
@@ -570,9 +555,7 @@ lifeCycleView ({ db, docsUrl, explorerRoute, impact, query, scope } as config) l
                                             [ th [] []
                                             , th [ class "ps-0", Attr.scope "col" ] [ text "Quantité" ]
                                             , th [ Attr.scope "col", colspan 2 ]
-                                                [ scopeLabels config.context config.scope
-                                                    |> .name
-                                                    |> text
+                                                [ scopeLabels config |> .name |> text
                                                 ]
                                             , th [ Attr.scope "col" ] [ text "Masse" ]
                                             , th [ Attr.scope "col" ] [ text "Impact" ]

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -4,6 +4,7 @@ module Views.Component exposing
     , createElementMaterialAutocomplete
     , editorView
     , elementEditModalView
+    , scopeLabels
     )
 
 import Autocomplete exposing (Autocomplete)
@@ -122,6 +123,10 @@ type alias Labels =
     , addRawElement : String
     , heading : String
     , name : String
+    , searchComponent : String
+    , searchRawElement : String
+    , selectComponent : String
+    , selectRawElement : String
     }
 
 
@@ -131,31 +136,48 @@ scopeLabels : Context -> Scope -> Labels
 scopeLabels context scope =
     case ( context, scope ) of
         ( GenericContext, Scope.Generic Scope.Food2 ) ->
-            { addComponent = "Ajouter un ingrédient complexe"
+            { addComponent = "Ajouter un ingrédient transformé"
             , addRawElement = "Ajouter un ingrédient brut"
             , heading = "Recette"
             , name = "Nom de l'ingrédient"
+            , searchComponent = "tapez ici le nom de l’ingrédient pour le rechercher"
+            , searchRawElement = "tapez ici le nom de l’ingrédient brut pour le rechercher"
+            , selectComponent = "Sélectionnez un ingrédient transformé"
+            , selectRawElement = "Sélectionnez un ingrédient brut"
             }
 
         ( GenericContext, _ ) ->
-            { addComponent = "Ajouter un matériau complexe"
+            { addComponent = "Ajouter un matériau transformé"
             , addRawElement = "Ajouter un matériau brut"
             , heading = "Production des matériaux"
             , name = "Nom du matériau"
+            , searchComponent = "tapez ici le nom du matériau pour le rechercher"
+            , searchRawElement = "tapez ici le nom du matériau brut pour le rechercher"
+            , selectComponent = "Sélectionnez un matériau transformé"
+            , selectRawElement = "Sélectionnez un matériau brut"
             }
 
         ( TextileTrimsContext, Scope.Textile ) ->
+            -- Note: in Textile context, raw element handling is not available
             { addComponent = "Ajouter un accessoire"
-            , addRawElement = "Ajouter un accessoire brut"
+            , addRawElement = "Ajouter un accessoire"
             , heading = "Accessoires"
             , name = "Nom de l'accessoire"
+            , searchComponent = "tapez ici le nom de l’accessoire pour le rechercher"
+            , searchRawElement = "tapez ici le nom de l’accessoire pour le rechercher"
+            , selectComponent = "Sélectionnez un accessoire"
+            , selectRawElement = "Sélectionnez un accessoire"
             }
 
         _ ->
             { addComponent = "Ajouter un composant"
-            , addRawElement = "Ajouter un élément brut"
+            , addRawElement = "Créer un composant"
             , heading = "Production des composants"
             , name = "Nom du composant"
+            , searchComponent = "tapez ici le nom du composant pour le rechercher"
+            , searchRawElement = "tapez ici le nom d'un procédé matière pour le rechercher"
+            , selectComponent = "Sélectionnez un composant"
+            , selectRawElement = "Sélectionnez un procédé matière"
             }
 
 
@@ -359,8 +381,6 @@ componentView config itemIndex ({ component, elements, quantity } as expandedIte
                                         [ type_ "text"
                                         , class "form-control"
                                         , onInput (config.updateItemName ( component, itemIndex ))
-
-                                        -- TODO: use element material label if available, otherwide fallback to default
                                         , scopeLabels config.context config.scope
                                             |> .name
                                             |> placeholder

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -131,8 +131,8 @@ type alias Labels =
 
 {-| Scoped label. TODO: we might eventually want to make these configurable.
 -}
-scopeLabels : { context : Context, scope : Scope } -> Labels
-scopeLabels { context, scope } =
+scopeLabels : Context -> Scope -> Labels
+scopeLabels context scope =
     case ( context, scope ) of
         ( GenericContext, Scope.Generic Scope.Food2 ) ->
             { add = "Ajouter un ingrédient"

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -210,6 +210,53 @@ addComponentButton ({ db, openSelectComponentModal } as config) =
         ]
 
 
+type MaterialOrComponent
+    = ComponentItem Component
+    | MaterialItem Process
+
+
+addComponentOrMaterialButton : Config db msg -> Html msg
+addComponentOrMaterialButton ({ db } as config) =
+    let
+        availableComponentsAndMaterials =
+            List.concat
+                [ db.components
+                    |> List.filter (not << Component.isEmpty)
+                    |> List.filter (.scope >> (==) config.scope)
+                    |> List.map ComponentItem
+                , db.processes
+                    |> Scope.anyOf [ config.scope ]
+                    |> List.filter (.visible >> (==) True)
+                    |> List.filter (.categories >> List.member Category.Material)
+                    |> List.map MaterialItem
+                ]
+
+        autocompleteState =
+            AutocompleteSelector.init
+                (\materialOrComponent ->
+                    case materialOrComponent of
+                        ComponentItem { name } ->
+                            name
+
+                        MaterialItem process ->
+                            Process.getDisplayName process
+                )
+                availableComponentsAndMaterials
+    in
+    button
+        [ type_ "button"
+        , class "btn btn-outline-primary w-100"
+        , class "d-flex justify-content-center align-items-center"
+        , class "gap-1 w-100"
+        , disabled <| List.isEmpty availableComponentsAndMaterials
+
+        -- , onClick <| openSelectComponentModal autocompleteState
+        ]
+        [ Icon.plus
+        , scopeLabels config |> .add |> text
+        ]
+
+
 addRawElementButton : Config db msg -> Html msg
 addRawElementButton config =
     button

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -1,7 +1,6 @@
 module Views.Component exposing
     ( Config
     , Context(..)
-    , createElementMaterialAutocomplete
     , editorView
     , elementEditModalView
     , scopeLabels
@@ -20,6 +19,7 @@ import Data.Component as Component
         , ExpandedQuantifiedProcess
         , Index
         , LifeCycle
+        , ProductionItem(..)
         , Quantity
         , Query
         , Requirements
@@ -70,12 +70,11 @@ type alias Config db msg =
     , impact : Definition
     , lifeCycle : Result String LifeCycle
     , noOp : msg
-    , openCreateComponentModal : msg
     , openEditElementModal : Component -> TargetElement -> msg
-    , openSelectComponentModal : Autocomplete Component -> msg
     , openSelectConsumptionModal : Autocomplete Process -> msg
     , openSelectPackagingModal : Autocomplete Process -> msg
     , openSelectProcessModal : Category -> TargetItem -> Maybe Index -> Autocomplete Process -> msg
+    , openSelectProductionItem : Autocomplete ProductionItem -> msg
     , query : Query
     , removeConsumption : Index -> msg
     , removeElement : TargetElement -> msg
@@ -120,7 +119,6 @@ requirementsFromConfig config =
 
 type alias Labels =
     { add : String
-    , addRaw : String
     , empty : String
     , heading : String
     , label : String
@@ -137,33 +135,30 @@ scopeLabels : { config | context : Context, scope : Scope } -> Labels
 scopeLabels { context, scope } =
     case ( context, scope ) of
         ( GenericContext, Scope.Generic Scope.Food2 ) ->
-            { add = "Ajouter un ingrédient transformé"
-            , addRaw = "Ajouter un ingrédient brut"
+            { add = "Ajouter un ingrédient"
             , empty = "Aucun ingrédient"
             , heading = "Recette"
             , label = "Nom de l'ingrédient"
             , name = "Ingrédient"
             , search = "tapez ici le nom de l’ingrédient pour le rechercher"
-            , select = "Sélectionnez un ingrédient transformé"
+            , select = "Sélectionnez un ingrédient"
             , selectRaw = "Sélectionnez un ingrédient brut"
             }
 
         ( GenericContext, _ ) ->
-            { add = "Ajouter un matériau transformé"
-            , addRaw = "Ajouter un matériau brut"
+            { add = "Ajouter un matériau"
             , empty = "Aucun matériau"
             , heading = "Production des matériaux"
             , label = "Nom du matériau"
             , name = "Matériau"
             , search = "tapez ici le nom du matériau pour le rechercher"
-            , select = "Sélectionnez un matériau transformé"
+            , select = "Sélectionnez un matériau"
             , selectRaw = "Sélectionnez un matériau brut"
             }
 
         ( TextileTrimsContext, Scope.Textile ) ->
             -- Note: in Textile context, raw element handling is not available
             { add = "Ajouter un accessoire"
-            , addRaw = "Ajouter un accessoire"
             , empty = "Aucun accessoire"
             , heading = "Accessoires"
             , label = "Nom de l'accessoire"
@@ -175,7 +170,6 @@ scopeLabels { context, scope } =
 
         _ ->
             { add = "Ajouter un composant"
-            , addRaw = "Créer un composant"
             , empty = "Aucun composant"
             , heading = "Production des composants"
             , label = "Nom du composant"
@@ -186,91 +180,40 @@ scopeLabels { context, scope } =
             }
 
 
-addComponentButton : Config db msg -> Html msg
-addComponentButton ({ db, openSelectComponentModal } as config) =
+addProductionItemButton : Config db msg -> Html msg
+addProductionItemButton ({ db } as config) =
     let
         availableComponents =
             db.components
                 |> List.filter (not << Component.isEmpty)
                 |> List.filter (.scope >> (==) config.scope)
+                |> List.map ComponentItem
+
+        availableMaterials =
+            Category.Material
+                |> listAvailableProcesses config
+                -- Exclude packaging materials as they're available in a dedicated section
+                |> List.filter (\{ categories } -> not <| List.member Category.Packaging categories)
+                |> List.map MaterialItem
+
+        availableProductionItems =
+            availableComponents ++ availableMaterials
 
         autocompleteState =
-            AutocompleteSelector.init .name availableComponents
+            availableProductionItems
+                |> List.sortBy Component.productionItemToLabel
+                |> AutocompleteSelector.init Component.productionItemToLabel
     in
     button
         [ type_ "button"
         , class "btn btn-outline-primary w-100"
         , class "d-flex justify-content-center align-items-center"
         , class "gap-1 w-100"
-        , disabled <| List.isEmpty availableComponents
-        , onClick <| openSelectComponentModal autocompleteState
+        , disabled <| List.isEmpty availableProductionItems
+        , onClick <| config.openSelectProductionItem autocompleteState
         ]
         [ Icon.plus
         , scopeLabels config |> .add |> text
-        ]
-
-
-type MaterialOrComponent
-    = ComponentItem Component
-    | MaterialItem Process
-
-
-addComponentOrMaterialButton : Config db msg -> Html msg
-addComponentOrMaterialButton ({ db } as config) =
-    let
-        availableComponentsAndMaterials =
-            List.concat
-                [ db.components
-                    |> List.filter (not << Component.isEmpty)
-                    |> List.filter (.scope >> (==) config.scope)
-                    |> List.map ComponentItem
-                , db.processes
-                    |> Scope.anyOf [ config.scope ]
-                    |> List.filter (.visible >> (==) True)
-                    |> List.filter (.categories >> List.member Category.Material)
-                    |> List.map MaterialItem
-                ]
-
-        autocompleteState =
-            AutocompleteSelector.init
-                (\materialOrComponent ->
-                    case materialOrComponent of
-                        ComponentItem { name } ->
-                            name
-
-                        MaterialItem process ->
-                            Process.getDisplayName process
-                )
-                availableComponentsAndMaterials
-    in
-    button
-        [ type_ "button"
-        , class "btn btn-outline-primary w-100"
-        , class "d-flex justify-content-center align-items-center"
-        , class "gap-1 w-100"
-        , disabled <| List.isEmpty availableComponentsAndMaterials
-
-        -- , onClick <| openSelectComponentModal autocompleteState
-        ]
-        [ Icon.plus
-        , scopeLabels config |> .add |> text
-        ]
-
-
-addRawElementButton : Config db msg -> Html msg
-addRawElementButton config =
-    button
-        [ type_ "button"
-        , class "btn btn-outline-primary w-100"
-        , class "d-flex justify-content-center align-items-center"
-        , class "gap-1 w-100"
-        , onClick config.openCreateComponentModal
-        , listAvailableProcesses config Category.Material
-            |> List.isEmpty
-            |> disabled
-        ]
-        [ Icon.plus
-        , scopeLabels config |> .addRaw |> text
         ]
 
 
@@ -621,7 +564,7 @@ lifeCycleView ({ db, docsUrl, explorerRoute, impact, query, scope } as config) l
                                         )
                                 )
                             ]
-            , productionButtonsView config
+            , addProductionItemButton config
             ]
         , if Scope.isGeneric scope && not (List.isEmpty query.items) then
             div []
@@ -651,27 +594,6 @@ lifeCycleView ({ db, docsUrl, explorerRoute, impact, query, scope } as config) l
           else
             text ""
         ]
-
-
-productionButtonsView : Config db msg -> Html msg
-productionButtonsView ({ db, scope } as config) =
-    case config.context of
-        AdminContext ->
-            addRawElementButton config
-
-        GenericContext ->
-            div [ class "d-flex gap-1" ] <|
-                -- when no components are available for the current scope, only show the button to add raw elements
-                if db.components |> List.all (\component -> component.scope /= scope || Component.isEmpty component) then
-                    [ addRawElementButton config ]
-
-                else
-                    [ addComponentButton config
-                    , addRawElementButton config
-                    ]
-
-        TextileTrimsContext ->
-            addComponentButton config
 
 
 documentationLink : Config db msg -> String -> Html msg

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -121,6 +121,7 @@ requirementsFromConfig config =
 type alias Labels =
     { add : String
     , addRaw : String
+    , empty : String
     , heading : String
     , name : String
     , search : String
@@ -137,6 +138,7 @@ scopeLabels context scope =
         ( GenericContext, Scope.Generic Scope.Food2 ) ->
             { add = "Ajouter un ingrédient transformé"
             , addRaw = "Ajouter un ingrédient brut"
+            , empty = "Aucun ingrédient"
             , heading = "Recette"
             , name = "Nom de l'ingrédient"
             , search = "tapez ici le nom de l’ingrédient pour le rechercher"
@@ -147,6 +149,7 @@ scopeLabels context scope =
         ( GenericContext, _ ) ->
             { add = "Ajouter un matériau transformé"
             , addRaw = "Ajouter un matériau brut"
+            , empty = "Aucun matériau"
             , heading = "Production des matériaux"
             , name = "Nom du matériau"
             , search = "tapez ici le nom du matériau pour le rechercher"
@@ -158,6 +161,7 @@ scopeLabels context scope =
             -- Note: in Textile context, raw element handling is not available
             { add = "Ajouter un accessoire"
             , addRaw = "Ajouter un accessoire"
+            , empty = "Aucun accessoire"
             , heading = "Accessoires"
             , name = "Nom de l'accessoire"
             , search = "tapez ici le nom de l’accessoire pour le rechercher"
@@ -168,6 +172,7 @@ scopeLabels context scope =
         _ ->
             { add = "Ajouter un composant"
             , addRaw = "Créer un composant"
+            , empty = "Aucun composant"
             , heading = "Production des composants"
             , name = "Nom du composant"
             , search = "tapez ici le nom du composant pour le rechercher"
@@ -430,7 +435,9 @@ componentDetailedView config elements itemIndex expandedItem itemResults =
         , if List.isEmpty elements then
             [ tr []
                 [ th [] []
-                , td [] [ text "Aucun élément" ]
+                , td []
+                    [ text "Aucun élément"
+                    ]
                 ]
             ]
 
@@ -538,7 +545,11 @@ lifeCycleView ({ db, docsUrl, explorerRoute, impact, query, scope } as config) l
                 , documentationLink config "production"
                 ]
             , if List.isEmpty query.items then
-                div [ class "card-body" ] [ text "Aucun élément." ]
+                div [ class "card-body" ]
+                    [ scopeLabels config.context config.scope
+                        |> .empty
+                        |> text
+                    ]
 
               else
                 case Component.expandItems db query.items of

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -119,14 +119,13 @@ requirementsFromConfig config =
 
 
 type alias Labels =
-    { addComponent : String
-    , addRawElement : String
+    { add : String
+    , addRaw : String
     , heading : String
     , name : String
-    , searchComponent : String
-    , searchRawElement : String
-    , selectComponent : String
-    , selectRawElement : String
+    , search : String
+    , select : String
+    , selectRaw : String
     }
 
 
@@ -136,48 +135,44 @@ scopeLabels : Context -> Scope -> Labels
 scopeLabels context scope =
     case ( context, scope ) of
         ( GenericContext, Scope.Generic Scope.Food2 ) ->
-            { addComponent = "Ajouter un ingrédient transformé"
-            , addRawElement = "Ajouter un ingrédient brut"
+            { add = "Ajouter un ingrédient transformé"
+            , addRaw = "Ajouter un ingrédient brut"
             , heading = "Recette"
             , name = "Nom de l'ingrédient"
-            , searchComponent = "tapez ici le nom de l’ingrédient pour le rechercher"
-            , searchRawElement = "tapez ici le nom de l’ingrédient brut pour le rechercher"
-            , selectComponent = "Sélectionnez un ingrédient transformé"
-            , selectRawElement = "Sélectionnez un ingrédient brut"
+            , search = "tapez ici le nom de l’ingrédient pour le rechercher"
+            , select = "Sélectionnez un ingrédient transformé"
+            , selectRaw = "Sélectionnez un ingrédient brut"
             }
 
         ( GenericContext, _ ) ->
-            { addComponent = "Ajouter un matériau transformé"
-            , addRawElement = "Ajouter un matériau brut"
+            { add = "Ajouter un matériau transformé"
+            , addRaw = "Ajouter un matériau brut"
             , heading = "Production des matériaux"
             , name = "Nom du matériau"
-            , searchComponent = "tapez ici le nom du matériau pour le rechercher"
-            , searchRawElement = "tapez ici le nom du matériau brut pour le rechercher"
-            , selectComponent = "Sélectionnez un matériau transformé"
-            , selectRawElement = "Sélectionnez un matériau brut"
+            , search = "tapez ici le nom du matériau pour le rechercher"
+            , select = "Sélectionnez un matériau transformé"
+            , selectRaw = "Sélectionnez un matériau brut"
             }
 
         ( TextileTrimsContext, Scope.Textile ) ->
             -- Note: in Textile context, raw element handling is not available
-            { addComponent = "Ajouter un accessoire"
-            , addRawElement = "Ajouter un accessoire"
+            { add = "Ajouter un accessoire"
+            , addRaw = "Ajouter un accessoire"
             , heading = "Accessoires"
             , name = "Nom de l'accessoire"
-            , searchComponent = "tapez ici le nom de l’accessoire pour le rechercher"
-            , searchRawElement = "tapez ici le nom de l’accessoire pour le rechercher"
-            , selectComponent = "Sélectionnez un accessoire"
-            , selectRawElement = "Sélectionnez un accessoire"
+            , search = "tapez ici le nom de l’accessoire pour le rechercher"
+            , select = "Sélectionnez un accessoire"
+            , selectRaw = "Sélectionnez un accessoire"
             }
 
         _ ->
-            { addComponent = "Ajouter un composant"
-            , addRawElement = "Créer un composant"
+            { add = "Ajouter un composant"
+            , addRaw = "Créer un composant"
             , heading = "Production des composants"
             , name = "Nom du composant"
-            , searchComponent = "tapez ici le nom du composant pour le rechercher"
-            , searchRawElement = "tapez ici le nom d'un procédé matière pour le rechercher"
-            , selectComponent = "Sélectionnez un composant"
-            , selectRawElement = "Sélectionnez un procédé matière"
+            , search = "tapez ici le nom du composant pour le rechercher"
+            , select = "Sélectionnez un composant"
+            , selectRaw = "Sélectionnez un procédé matière"
             }
 
 
@@ -202,7 +197,7 @@ addComponentButton { context, db, openSelectComponentModal, scope } =
         ]
         [ Icon.plus
         , scopeLabels context scope
-            |> .addComponent
+            |> .add
             |> text
         ]
 
@@ -221,7 +216,7 @@ addRawElementButton config =
         ]
         [ Icon.plus
         , scopeLabels config.context config.scope
-            |> .addRawElement
+            |> .addRaw
             |> text
         ]
 

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -68,6 +68,7 @@ type alias Config db msg =
     , docsUrl : Maybe String
     , explorerRoute : Maybe Route
     , impact : Definition
+    , labels : Labels
     , lifeCycle : Result String LifeCycle
     , noOp : msg
     , openEditElementModal : Component -> TargetElement -> msg
@@ -130,7 +131,7 @@ type alias Labels =
 
 {-| Scoped label. TODO: we might eventually want to make these configurable.
 -}
-scopeLabels : { config | context : Context, scope : Scope } -> Labels
+scopeLabels : { context : Context, scope : Scope } -> Labels
 scopeLabels { context, scope } =
     case ( context, scope ) of
         ( GenericContext, Scope.Generic Scope.Food2 ) ->
@@ -208,7 +209,7 @@ addProductionItemButton ({ db } as config) =
         , onClick <| config.openSelectProductionItem autocompleteState
         ]
         [ Icon.plus
-        , scopeLabels config |> .add |> text
+        , text config.labels.add
         ]
 
 
@@ -321,7 +322,7 @@ componentView config itemIndex ({ component, elements, quantity } as expandedIte
                         [ th [] []
                         , th [ class "pb-0 fs-8 fw-normal text-muted" ] [ text "Quantité" ]
                         , th [ class "pb-0 fs-8 fw-normal text-muted", colspan 2 ]
-                            [ span [] [ scopeLabels config |> .label |> text ] ]
+                            [ span [] [ text config.labels.label ] ]
                         , th [ colspan 3 ] []
                         ]
 
@@ -362,7 +363,7 @@ componentView config itemIndex ({ component, elements, quantity } as expandedIte
                                         [ type_ "text"
                                         , class "form-control"
                                         , onInput (config.updateItemName ( component, itemIndex ))
-                                        , scopeLabels config |> .label |> placeholder
+                                        , placeholder config.labels.label
                                         , value component.name
                                         ]
                                         []
@@ -491,7 +492,7 @@ lifeCycleView ({ db, docsUrl, explorerRoute, impact, query, scope } as config) l
         [ div [ class "card shadow-sm" ]
             [ div [ class "card-header d-flex align-items-center justify-content-between gap-2" ]
                 [ h2 [ class "h5 mb-0" ]
-                    [ scopeLabels config |> .heading |> text
+                    [ text config.labels.heading
                     , case explorerRoute of
                         Just route ->
                             Link.smallPillExternal
@@ -523,7 +524,7 @@ lifeCycleView ({ db, docsUrl, explorerRoute, impact, query, scope } as config) l
                 ]
             , if List.isEmpty query.items then
                 div [ class "card-body" ]
-                    [ scopeLabels config |> .empty |> text
+                    [ text config.labels.empty
                     ]
 
               else
@@ -540,7 +541,7 @@ lifeCycleView ({ db, docsUrl, explorerRoute, impact, query, scope } as config) l
                                             [ th [] []
                                             , th [ class "ps-0", Attr.scope "col" ] [ text "Quantité" ]
                                             , th [ Attr.scope "col", colspan 2 ]
-                                                [ scopeLabels config |> .name |> text
+                                                [ text config.labels.name
                                                 ]
                                             , th [ Attr.scope "col" ] [ text "Masse" ]
                                             , th [ Attr.scope "col" ] [ text "Impact" ]

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -123,6 +123,7 @@ type alias Labels =
     , addRaw : String
     , empty : String
     , heading : String
+    , label : String
     , name : String
     , search : String
     , select : String
@@ -140,7 +141,8 @@ scopeLabels context scope =
             , addRaw = "Ajouter un ingrédient brut"
             , empty = "Aucun ingrédient"
             , heading = "Recette"
-            , name = "Nom de l'ingrédient"
+            , label = "Nom de l'ingrédient"
+            , name = "Ingrédient"
             , search = "tapez ici le nom de l’ingrédient pour le rechercher"
             , select = "Sélectionnez un ingrédient transformé"
             , selectRaw = "Sélectionnez un ingrédient brut"
@@ -151,7 +153,8 @@ scopeLabels context scope =
             , addRaw = "Ajouter un matériau brut"
             , empty = "Aucun matériau"
             , heading = "Production des matériaux"
-            , name = "Nom du matériau"
+            , label = "Nom du matériau"
+            , name = "Matériau"
             , search = "tapez ici le nom du matériau pour le rechercher"
             , select = "Sélectionnez un matériau transformé"
             , selectRaw = "Sélectionnez un matériau brut"
@@ -163,7 +166,8 @@ scopeLabels context scope =
             , addRaw = "Ajouter un accessoire"
             , empty = "Aucun accessoire"
             , heading = "Accessoires"
-            , name = "Nom de l'accessoire"
+            , label = "Nom de l'accessoire"
+            , name = "Accessoire"
             , search = "tapez ici le nom de l’accessoire pour le rechercher"
             , select = "Sélectionnez un accessoire"
             , selectRaw = "Sélectionnez un accessoire"
@@ -174,7 +178,8 @@ scopeLabels context scope =
             , addRaw = "Créer un composant"
             , empty = "Aucun composant"
             , heading = "Production des composants"
-            , name = "Nom du composant"
+            , label = "Nom du composant"
+            , name = "Composant"
             , search = "tapez ici le nom du composant pour le rechercher"
             , select = "Sélectionnez un composant"
             , selectRaw = "Sélectionnez un procédé matière"
@@ -337,7 +342,7 @@ componentView config itemIndex ({ component, elements, quantity } as expandedIte
                         , th [ class "pb-0 fs-8 fw-normal text-muted", colspan 2 ]
                             [ span []
                                 [ scopeLabels config.context config.scope
-                                    |> .name
+                                    |> .label
                                     |> text
                                 ]
                             ]
@@ -382,7 +387,7 @@ componentView config itemIndex ({ component, elements, quantity } as expandedIte
                                         , class "form-control"
                                         , onInput (config.updateItemName ( component, itemIndex ))
                                         , scopeLabels config.context config.scope
-                                            |> .name
+                                            |> .label
                                             |> placeholder
                                         , value component.name
                                         ]
@@ -564,7 +569,11 @@ lifeCycleView ({ db, docsUrl, explorerRoute, impact, query, scope } as config) l
                                         [ tr [ class "fs-7 text-muted" ]
                                             [ th [] []
                                             , th [ class "ps-0", Attr.scope "col" ] [ text "Quantité" ]
-                                            , th [ Attr.scope "col", colspan 2 ] [ text "Composant" ]
+                                            , th [ Attr.scope "col", colspan 2 ]
+                                                [ scopeLabels config.context config.scope
+                                                    |> .name
+                                                    |> text
+                                                ]
                                             , th [ Attr.scope "col" ] [ text "Masse" ]
                                             , th [ Attr.scope "col" ] [ text "Impact" ]
                                             , th [ Attr.scope "col" ] []


### PR DESCRIPTION
## :wrench: Problem

Fixes #2571

Expose a single button to add either components or raw material processes at the production stage.

A previous simpler alternative solution was suggested in #2645; it is superseded by this one.

## How to test

- [ ] In Food2, Object and Veli simulators, we should see a single "Ajouter un {ingrédient|matériau}" button at the production stage
- [ ] clicking on that button should open a search modal where both components and material processes are listed to be selected
- [ ] packaging processes should be excluded from that list, as well as processes marked as not `visible` in their metadata
- [ ] clicking on one of these entries should add either a component or a material process wrapped in a new component
- [ ] the term "composant" should never appear in the ui, instead we should have "ingrédient" (food2) or "matériau" (object and véli)
- [ ] the existing bookmarks, comparator views and queries should be entirely backward compatible
