### PR TITLE
fix: deny access to detailed impacts

### DIFF
--- a/server.js
+++ b/server.js
@@ -84,6 +84,9 @@ app.use(
   }),
 );
 
+// Deny public access to detailed impacts as a static asset
+app.get("/data/processes_impacts.json", (_, res) => res.sendStatus(404));
+
 app.use(
   express.static("dist", {
     setHeaders: (res) => {

--- a/server.js
+++ b/server.js
@@ -85,6 +85,8 @@ app.use(
 );
 
 // Deny public access to detailed impacts as a static asset
+// Note: counter intuitively, this must be registered *before* the static file serving
+//       middleware, otherwise it's ignored
 app.get("/data/processes_impacts.json", (_, res) => res.sendStatus(404));
 
 app.use(

--- a/tests/server.spec.js
+++ b/tests/server.spec.js
@@ -32,6 +32,12 @@ describe("Web", () => {
     expectStatus(response, 200, "text/html");
     expect(response.text).toContain("<title>Ecobalyse</title>");
   });
+
+  it("should deny public access to detailed impacts", async () => {
+    const response = await request(app).get("/data/processes_impacts.json");
+
+    expect(response.statusCode).toBe(404);
+  });
 });
 
 describe("API", () => {


### PR DESCRIPTION
Prevent direct access to restricted data file over http

## How to test

```
$ curl https://ecobalyse-staging-pr2669.osc-fr1.scalingo.io/data/processes_impacts.json
Not Found%
```