### PR TITLE
fix(stable): prevent access to detailed impacts

### DIFF
--- a/server.js
+++ b/server.js
@@ -83,6 +83,11 @@ app.use(
   }),
 );
 
+// Deny public access to detailed impacts as a static asset
+// Note: counter intuitively, this must be registered *before* the static file serving
+//       middleware, otherwise it's ignored
+app.get("/data/processes_impacts.json", (_, res) => res.sendStatus(404));
+
 app.use(
   express.static("dist", {
     setHeaders: (res) => {

--- a/tests/server.spec.js
+++ b/tests/server.spec.js
@@ -19,6 +19,12 @@ describe("Web", () => {
     expectStatus(response, 200, "text/html");
     expect(response.text).toContain("<title>Ecobalyse</title>");
   });
+
+  it("should deny public access to detailed impacts", async () => {
+    const response = await request(app).get("/data/processes_impacts.json");
+
+    expect(response.statusCode).toBe(404);
+  });
 });
 
 describe("API", () => {


### PR DESCRIPTION
This is a backport of #2669 to the stable branch

```
$ curl https://ecobalyse-textile-pr2670.osc-secnum-fr1.scalingo.io/data/processes_impacts.json
Not Found%
```