### PR TITLE
fix(ui): skip OS-level dark styles in Highcharts

### DIFF
--- a/src/Views/Page.elm
+++ b/src/Views/Page.elm
@@ -81,7 +81,7 @@ frame ({ activePage } as config) ( title, content ) =
 
           else
             text ""
-        , main_ [ class "PageContent bg-white" ]
+        , main_ [ class "PageContent bg-white highcharts-light" ]
             [ -- general static notifications
               notificationListView config
 


### PR DESCRIPTION
Fixes #2688 

The fix was simple enough :)