### PR TITLE
fix(stable): prevent bookmarks data loss

### DIFF
--- a/lib/store.js
+++ b/lib/store.js
@@ -7,6 +7,11 @@ function isObjectBookmark(entry) {
   return entry !== null && typeof entry === "object" && !Array.isArray(entry);
 }
 
+/**
+ * Ensure backporting bookmarks saved from a previously bugged stable version which
+ * saved them in the wrong store key, to prevent users losing their existing bookmarks
+ * @see #2680
+ */
 function backportStableBookmarks(localStorage) {
   const stableVersionDict = JSON.parse(localStorage[stableVersionKey] || "{}");
   const ongoingVersionDict = JSON.parse(localStorage[ongoingVersionKey] || "{}");

--- a/lib/store.js
+++ b/lib/store.js
@@ -3,21 +3,49 @@
 const stableVersionKey = "store";
 const ongoingVersionKey = "ecobalyse";
 
+function isObjectBookmark(entry) {
+  return entry !== null && typeof entry === "object" && !Array.isArray(entry);
+}
+
+function backportStableBookmarks(localStorage) {
+  const stableVersionDict = JSON.parse(localStorage[stableVersionKey] || "{}");
+  const ongoingVersionDict = JSON.parse(localStorage[ongoingVersionKey] || "{}");
+  const stableBookmarks = stableVersionDict.bookmarks || [];
+  const ongoingBookmarks = ongoingVersionDict.bookmarks || [];
+
+  if (stableBookmarks.length > 0 || ongoingBookmarks.length === 0) {
+    return;
+  }
+
+  // Only migrate when every entry is a plain js object, which is the bookmark format used
+  // by the stable version. The ongoing version stores bookmarks as JSON strings, so copying
+  // those into current version store would make stable's strict bookmark decoder fail the
+  // whole session (see #2698)
+  if (ongoingBookmarks.every(isObjectBookmark)) {
+    stableVersionDict.bookmarks = ongoingBookmarks;
+    localStorage[stableVersionKey] = JSON.stringify(stableVersionDict);
+  }
+}
+
 function initializeStoreKey(localStorage = window.localStorage) {
   if (localStorage[stableVersionKey] && !localStorage[ongoingVersionKey]) {
-    // Ongoing version store has never been initialized, while the stable version one has already
-    // => Initialize current storage with stable version session data
-    // Note: the ongoing version can always handle and parse old bookmark formats
-    localStorage[ongoingVersionKey] = localStorage[stableVersionKey];
+    // Ongoing version store has never been initialized, while the stable version has one already
+    try {
+      const { auth } = JSON.parse(localStorage[stableVersionKey]);
+      if (auth) {
+        localStorage[ongoingVersionKey] = JSON.stringify({ auth });
+      }
+    } catch (e) {
+      console.error("Unable to retrieve previous valid legacy session data", e);
+    }
   } else if (
     !JSON.parse(localStorage[stableVersionKey] || "{}")?.auth &&
     localStorage[ongoingVersionKey]
   ) {
-    // Stable version store has no valid auth, while the ongoing version one has already
-    // => Backport only auth data, as other stuff is highly unlikely to be compatible
+    // Stable version store has no valid auth, while the ongoing version has one already
     try {
       const { auth } = JSON.parse(localStorage[ongoingVersionKey]);
-      stableVersionDict = JSON.parse(localStorage[stableVersionKey] || "{}");
+      const stableVersionDict = JSON.parse(localStorage[stableVersionKey] || "{}");
       stableVersionDict.auth = auth;
       localStorage[stableVersionKey] = JSON.stringify(stableVersionDict);
     } catch (e) {
@@ -25,7 +53,9 @@ function initializeStoreKey(localStorage = window.localStorage) {
     }
   }
 
-  return ongoingVersionKey;
+  backportStableBookmarks(localStorage);
+
+  return stableVersionKey;
 }
 
 function exportBookmarks(localStorage = window.localStorage) {

--- a/lib/store.js
+++ b/lib/store.js
@@ -29,7 +29,9 @@ function backportStableBookmarks(localStorage) {
 
 function initializeStoreKey(localStorage = window.localStorage) {
   if (localStorage[stableVersionKey] && !localStorage[ongoingVersionKey]) {
-    // Ongoing version store has never been initialized, while the stable version has one already
+    // Ongoing version store has never been initialized, while the stable version one has already
+    // => Initialize current storage with stable version session data
+    // Note: the ongoing version can always handle and parse old bookmark formats
     try {
       const { auth } = JSON.parse(localStorage[stableVersionKey]);
       if (auth) {
@@ -42,7 +44,8 @@ function initializeStoreKey(localStorage = window.localStorage) {
     !JSON.parse(localStorage[stableVersionKey] || "{}")?.auth &&
     localStorage[ongoingVersionKey]
   ) {
-    // Stable version store has no valid auth, while the ongoing version has one already
+    // Stable version store has no valid auth, while the ongoing version one has already
+    // => Backport only auth data, as other stuff is highly unlikely to be compatible
     try {
       const { auth } = JSON.parse(localStorage[ongoingVersionKey]);
       const stableVersionDict = JSON.parse(localStorage[stableVersionKey] || "{}");

--- a/tests/lib/store.spec.js
+++ b/tests/lib/store.spec.js
@@ -20,7 +20,7 @@ describe("lib.store", () => {
   });
 
   describe("initializeStoreKey", () => {
-    test("should initialize ongoing store with auth only when only stable store exists", () => {
+    test("should backport auth only to ongoing store when only stable store exists", () => {
       const authStableStore = {
         auth: { token: "stable-session-token" },
         bookmarks: anonStableStore.bookmarks,
@@ -31,14 +31,15 @@ describe("lib.store", () => {
 
       const key = initializeStoreKey(localStorage);
 
-      expect(key).toBe("ecobalyse");
-      expect(JSON.parse(localStorage.ecobalyse)).toEqual(authStableStore);
+      expect(key).toBe("store");
+      expect(JSON.parse(localStorage.ecobalyse)).toEqual({ auth: authStableStore.auth });
+      expect(JSON.parse(localStorage.store)).toEqual(authStableStore);
     });
 
     test("should backport auth only to stable store when only ongoing store exists", () => {
       const authOngoingStore = {
         auth: { token: "ongoing-session-token" },
-        bookmarks: anonOngoingStore.bookmarks,
+        bookmarks: [`{"created":1,"name":"ongoing version bookmark","query":{}}`],
       };
       const localStorage = {
         ecobalyse: JSON.stringify(authOngoingStore),
@@ -46,7 +47,7 @@ describe("lib.store", () => {
 
       const key = initializeStoreKey(localStorage);
 
-      expect(key).toBe("ecobalyse");
+      expect(key).toBe("store");
       expect(JSON.parse(localStorage.store)).toEqual({ auth: authOngoingStore.auth });
     });
 
@@ -60,19 +61,73 @@ describe("lib.store", () => {
 
       const key = initializeStoreKey(localStorage);
 
-      expect(key).toBe("ecobalyse");
+      expect(key).toBe("store");
       expect(localStorage.store).toBe(JSON.stringify(stableSession));
       expect(localStorage.ecobalyse).toBe(JSON.stringify(ongoingSession));
     });
 
-    test("should return ongoing key when no store is initialized", () => {
+    test("should return stable key when no store is initialized", () => {
       const localStorage = {};
 
       const key = initializeStoreKey(localStorage);
 
-      expect(key).toBe("ecobalyse");
+      expect(key).toBe("store");
       expect(localStorage.store).toBeUndefined();
       expect(localStorage.ecobalyse).toBeUndefined();
+    });
+
+    test("should not migrate string bookmarks from ongoing store to stable store when the latter is empty (#2698)", () => {
+      const ongoingSession = {
+        auth: null,
+        bookmarks: [`{"created":1,"name":"veli bookmark","query":{"kind":"veli"}}`],
+      };
+      const localStorage = {
+        ecobalyse: JSON.stringify(ongoingSession),
+        store: "{}",
+      };
+      const ecobalyseBefore = localStorage.ecobalyse;
+
+      const key = initializeStoreKey(localStorage);
+
+      expect(key).toBe("store");
+      expect(localStorage.ecobalyse).toBe(ecobalyseBefore);
+      expect(JSON.parse(localStorage.store)).toEqual({ auth: null });
+    });
+
+    test("should migrate object bookmarks from ecobalyse to store when store is empty", () => {
+      const stableBookmarks = [
+        { created: 1, name: "Textile bookmark", query: { kind: "textile" } },
+      ];
+      const ongoingSession = {
+        auth: { token: "stable-only-user" },
+        bookmarks: stableBookmarks,
+      };
+      const localStorage = {
+        ecobalyse: JSON.stringify(ongoingSession),
+      };
+
+      const key = initializeStoreKey(localStorage);
+
+      expect(key).toBe("store");
+      expect(JSON.parse(localStorage.store)).toEqual({
+        auth: ongoingSession.auth,
+        bookmarks: stableBookmarks,
+      });
+    });
+
+    test("should not migrate string bookmarks from ongoing store to stable store", () => {
+      const localStorage = {
+        ecobalyse: JSON.stringify({
+          auth: null,
+          bookmarks: [`{"created":1,"name":"veli bookmark","query":{}}`],
+        }),
+        store: "{}",
+      };
+
+      const key = initializeStoreKey(localStorage);
+
+      expect(key).toBe("store");
+      expect(JSON.parse(localStorage.store)).toEqual({ auth: null });
     });
   });
 
@@ -187,6 +242,53 @@ describe("lib.store", () => {
 
       expect(JSON.parse(localStorage.ecobalyse)).toEqual({ bookmarks: ongoingBookmarks });
       expect(JSON.parse(localStorage.store)).toEqual({ bookmarks: stableBookmarks });
+    });
+
+    test("should import legacy export with string bookmarks into the `ecobalyse` key and leave `store` contents unchanged", () => {
+      const ongoingVersionStringBookmarks = [
+        `{"created":1,"name":"veli bookmark","query":{"kind":"veli"}}`,
+      ];
+      const localStorage = {
+        ecobalyse: JSON.stringify({ bookmarks: [] }),
+        store: JSON.stringify({ bookmarks: [] }),
+      };
+
+      global.FileReader = function () {
+        this.result = null;
+        this.addEventListener = (_, handler) => {
+          this.onLoad = handler;
+        };
+        this.readAsText = jest.fn(() => {
+          this.result = JSON.stringify({
+            ecobalyse: ongoingVersionStringBookmarks,
+            store: [],
+          });
+          this.onLoad();
+        });
+      };
+
+      global.document = {
+        location: { reload: jest.fn() },
+        createElement: jest.fn((_) => ({
+          click: jest.fn(),
+          addEventListener: (_, handler) => {
+            fileUploadHandler = handler;
+          },
+        })),
+      };
+
+      global.alert = jest.fn();
+
+      importBookmarks(localStorage);
+
+      fileUploadHandler({
+        target: { files: [{ name: sampleFilename }] },
+      });
+
+      expect(JSON.parse(localStorage.ecobalyse)).toEqual({
+        bookmarks: ongoingVersionStringBookmarks,
+      });
+      expect(JSON.parse(localStorage.store)).toEqual({ bookmarks: [] });
     });
 
     test("should keep existing bookmarks list when import file has no bookmarks", () => {

--- a/tests/lib/store.spec.js
+++ b/tests/lib/store.spec.js
@@ -94,7 +94,7 @@ describe("lib.store", () => {
       expect(JSON.parse(localStorage.store)).toEqual({ auth: null });
     });
 
-    test("should migrate object bookmarks from ecobalyse to store when store is empty", () => {
+    test("should migrate plain-object bookmarks from ongoing store to stable when it's empty", () => {
       const stableBookmarks = [
         { created: 1, name: "Textile bookmark", query: { kind: "textile" } },
       ];

--- a/tests/lib/store.spec.js
+++ b/tests/lib/store.spec.js
@@ -114,21 +114,6 @@ describe("lib.store", () => {
         bookmarks: stableBookmarks,
       });
     });
-
-    test("should not migrate string bookmarks from ongoing store to stable store", () => {
-      const localStorage = {
-        ecobalyse: JSON.stringify({
-          auth: null,
-          bookmarks: [`{"created":1,"name":"veli bookmark","query":{}}`],
-        }),
-        store: "{}",
-      };
-
-      const key = initializeStoreKey(localStorage);
-
-      expect(key).toBe("store");
-      expect(JSON.parse(localStorage.store)).toEqual({ auth: null });
-    });
   });
 
   describe("exportBookmarks", () => {


### PR DESCRIPTION
## :wrench: Problem

Fixes #2698 

Le code de la branche stable/textile renvoie le mauvais nom de clé *localStorage* à utiliser, occasionnant la perte des bookmarks en version règlementaire.

En pratique, après navigation depuis la version courante, la version stable lit les données de session depuis `localStorage.ecobalyse` (et non `store` comme initialement souhaité), échoue au décodage des bookmarks au format JSON brut, affiche une erreur qui propose à l'usager de réinitialiser la session sans autre possibilité de récupération des données qu'elle contenait.

## :cake: Solution

Il semble qu'un bug précédemment corrigé ait été réintroduit dans #2280, occasionnant le comportement observé dans #2698 (`return ongoingVersionKey` au lieu de `return stableVersionKey`). Le présent patch s'assure que les données de session sont enregistrées dans le bon conteneur localStorage, et ajoute quelques tests afin de garantir la bonne implémentation et prévenir des régressions futures.

## :rotating_light:  Points to watch/comments

- Seul la branche `stable/textile` était impactée, la version courante n'est pas concernée
- Cette partie du code est vraiment **très** complexe 🥵 toute suggestion permettant simplification est bienvenue (en n'oubliant pas que c'est une branche stable vouée à le rester, donc tout refactoring massif à considérer avec précaution 😅)

## :desert_island: How to test

- S'assurer d'avoir préalablement monté cette branche `stable/textile` patchée sur une review app de la version courante pour tester l'intégration dans le système complet (courante+stable, comme en production)
- Tester création de bookmarks en version courante puis passage à la version stable : aucune perte de données de session
- Tester import et export des bookmarks de la version stable vers la version courante, et réciproquement