### PR TITLE
fix: json serialization for jsonb

### DIFF
--- a/backend/src/app/config/base.py
+++ b/backend/src/app/config/base.py
@@ -39,7 +39,7 @@ class UUIDEncoder(json.JSONEncoder):
         return json.JSONEncoder.default(self, obj)
 
 
-def encode_json(value: Any, serializer: Callable[[Any], Any] | None = None) -> bytes:
+def encode_json(value: Any, serializer: Callable[[Any], Any] | None = None) -> str:
     """Encode a value into JSON.
 
     Args:
@@ -47,7 +47,7 @@ def encode_json(value: Any, serializer: Callable[[Any], Any] | None = None) -> b
         serializer: Optional callable to support non-natively supported types.
 
     Returns:
-        JSON as bytes
+        JSON as str
 
     Raises:
         SerializationException: If error encoding ``obj``.
@@ -83,7 +83,8 @@ def decode_json(  # type: ignore[misc]
     """
 
     if target_type is Empty:
-        return value
+        return json.loads(value)
+
     return target_type.model_validate_json(value)
 
 

--- a/backend/src/app/domain/journal_entries/schemas.py
+++ b/backend/src/app/domain/journal_entries/schemas.py
@@ -1,14 +1,21 @@
 from __future__ import annotations
 
+import json
 from datetime import datetime  # noqa: TC003
+from typing import Annotated
 from uuid import UUID  # noqa: TC003
 
-from pydantic import Field
-
+from app.config.base import UUIDEncoder
 from app.domain.accounts.schemas import User
 from app.lib.schema import BaseSchema
 
 __all__ = "JournalEntry"
+
+from pydantic import PlainSerializer
+
+
+def value_as_str(value: dict) -> str:
+    return json.dumps(value, cls=UUIDEncoder, indent=2, sort_keys=True)
 
 
 class JournalEntry(BaseSchema):
@@ -21,6 +28,5 @@ class JournalEntry(BaseSchema):
     user: User
     # We want to serialize the value as a string rather than an object
     # so that the frontend doesn’t have to validate it.
-    value_str: str | None = Field(alias="value")
-
+    value: Annotated[dict | None, PlainSerializer(value_as_str)]
     created_at: datetime | None = None

--- a/tests/backend/integration/test_components.py
+++ b/tests/backend/integration/test_components.py
@@ -1,4 +1,3 @@
-import json as jsonp
 import warnings
 from typing import TYPE_CHECKING
 
@@ -54,7 +53,7 @@ async def test_components_api_create(
         assert len(entries) == 8
         entry = entries[7]
         assert entry.action == m.JournalAction.CREATED
-        assert jsonp.loads(entry.value) == json_response
+        assert entry.value == json_response
 
 
 async def test_components_db_create(
@@ -131,7 +130,7 @@ async def test_components_create_with_scopes(
         entry = entries[7]
         assert entry.action == m.JournalAction.CREATED
         assert entry.table_name == m.Component.__tablename__
-        assert jsonp.loads(entry.value) == json
+        assert entry.value == json
 
 
 async def test_components_access(
@@ -212,15 +211,13 @@ async def test_components_update(
         assert response.status_code == 200
         json = response.json()
 
-        assert jsonp.dumps(json["elements"]) == jsonp.dumps(
-            [
-                {
-                    "amount": 1,
-                    "material": "af42fc20-e3ec-5b99-9b9c-83ba6735e597",
-                    "transforms": ["d25636af-ab36-4857-a6d0-c66d1e7a281b"],
-                }
-            ]
-        )
+        assert json["elements"] == [
+            {
+                "amount": 1,
+                "material": "af42fc20-e3ec-5b99-9b9c-83ba6735e597",
+                "transforms": ["d25636af-ab36-4857-a6d0-c66d1e7a281b"],
+            }
+        ]
 
         assert not json["published"]
 
@@ -250,15 +247,13 @@ async def test_components_update(
         assert json["comment"] == "Comment changed"
         assert json["scopes"] == ["object", "food"]
         assert json["published"]
-        assert jsonp.dumps(json["elements"]) == jsonp.dumps(
-            [
-                {
-                    "amount": 2,
-                    "material": "d25636af-ab36-4857-a6d0-c66d1e7a281b",
-                    "transforms": ["97c209ec-7782-5a29-8c47-af7f17c82d11"],
-                }
-            ]
-        )
+        assert json["elements"] == [
+            {
+                "amount": 2,
+                "material": "d25636af-ab36-4857-a6d0-c66d1e7a281b",
+                "transforms": ["97c209ec-7782-5a29-8c47-af7f17c82d11"],
+            }
+        ]
 
         response = await client.put(
             "/api/components/8ca2ca05-8aec-4121-acaa-7cdcc03150a9",
@@ -287,21 +282,19 @@ async def test_components_update(
 
         assert json["name"] == "Name Changed"
         assert json["comment"] == "Comment changed"
-        assert jsonp.dumps(json["elements"]) == jsonp.dumps(
-            [
-                {
-                    "amount": 3,
-                    "material": "d25636af-ab36-4857-a6d0-c66d1e7a281b",
-                }
-            ]
-        )
+        assert json["elements"] == [
+            {
+                "amount": 3,
+                "material": "d25636af-ab36-4857-a6d0-c66d1e7a281b",
+            }
+        ]
 
         entries = await journal_entries_service.get_many()
         assert len(entries) == 9
         entry = entries[7]
         assert entry.action == m.JournalAction.UPDATED
 
-        assert jsonp.loads(entry.value) == {
+        assert entry.value == {
             "id": "8ca2ca05-8aec-4121-acaa-7cdcc03150a9",
             "name": "Name Changed",
             "scopes": ["object", "food"],
@@ -341,7 +334,7 @@ async def test_components_update(
         assert len(entries) == 10
         entry = entries[9]
         assert entry.action == m.JournalAction.UPDATED
-        assert jsonp.loads(entry.value) == {
+        assert entry.value == {
             "id": "8ca2ca05-8aec-4121-acaa-7cdcc03150a9",
             "name": "Name Changed",
             "comment": "Comment changed",

--- a/tests/backend/integration/test_journal_entries.py
+++ b/tests/backend/integration/test_journal_entries.py
@@ -233,31 +233,30 @@ async def test_components_journal(
         assert json_response[0]["action"] == m.JournalAction.DELETED
         assert json_response[1]["action"] == m.JournalAction.UPDATED
 
+        # The value should be returned as a string rather than an object
+        # so that the frontend doesn’t have to validate it.
         assert isinstance(json_response[1]["value"], str)
 
-        assert json_response[1]["value"] == json.dumps(
-            {
-                "id": "8ca2ca05-8aec-4121-acaa-7cdcc03150a9",
-                "name": "Tissu pour joli canapé",
-                "scopes": ["food"],
-                "elements": [
-                    {
-                        "amount": 1,
-                        "material": "97c209ec-7782-5a29-8c47-af7f17c82d11",
-                        "transforms": [
-                            "af42fc20-e3ec-5b99-9b9c-83ba6735e597",
-                            "d25636af-ab36-4857-a6d0-c66d1e7a281b",
-                        ],
-                    },
-                    {
-                        "amount": 1,
-                        "material": "d25636af-ab36-4857-a6d0-c66d1e7a281b",
-                        "transforms": [
-                            "97c209ec-7782-5a29-8c47-af7f17c82d11",
-                            "af42fc20-e3ec-5b99-9b9c-83ba6735e597",
-                        ],
-                    },
-                ],
-            },
-            ensure_ascii=False,
-        )
+        assert json.loads(json_response[1]["value"]) == {
+            "id": "8ca2ca05-8aec-4121-acaa-7cdcc03150a9",
+            "name": "Tissu pour joli canapé",
+            "scopes": ["food"],
+            "elements": [
+                {
+                    "amount": 1,
+                    "material": "97c209ec-7782-5a29-8c47-af7f17c82d11",
+                    "transforms": [
+                        "af42fc20-e3ec-5b99-9b9c-83ba6735e597",
+                        "d25636af-ab36-4857-a6d0-c66d1e7a281b",
+                    ],
+                },
+                {
+                    "amount": 1,
+                    "material": "d25636af-ab36-4857-a6d0-c66d1e7a281b",
+                    "transforms": [
+                        "97c209ec-7782-5a29-8c47-af7f17c82d11",
+                        "af42fc20-e3ec-5b99-9b9c-83ba6735e597",
+                    ],
+                },
+            ],
+        }


### PR DESCRIPTION
## :wrench: Problem

There is an error in the component admin when trying to load components.

## :cake: Solution

When moving to Pydantic, I overlooked the serialization of the jsonb fields. When they are no Pydantic models to serialize too, we should still decode the json string to an object (that was the cause of the error: Elm was getting a string instead of a dict).


## :rotating_light:  Points to watch/comments

I’ve simplified some tests too and I’ve properly implemented the string serialization of the `JournalEntry` value (as it should be a dict but serialized as a string for the Elm frontend)

## :desert_island: How to test

Go to the Admin in the components section : it should display the list of components as expected.
