### PR TITLE
refactor: explicit genericity wherever applicable

### DIFF
--- a/src/CheckDb.elm
+++ b/src/CheckDb.elm
@@ -208,7 +208,7 @@ checkExampleComponentItem processes components example =
 -}
 checkExamplesComponentIds : Set String -> Db -> List Error
 checkExamplesComponentIds knownComponentStringIds db =
-    db.object.examples
+    db.generic.examples
         |> List.filter (.scope >> Scope.isGeneric)
         |> List.concatMap
             (\example ->
@@ -234,7 +234,7 @@ checkExamplesScope db =
             , componentById db.components
             )
     in
-    db.object.examples
+    db.generic.examples
         |> List.filter (.scope >> Scope.isGeneric)
         |> List.concatMap
             (\example ->

--- a/src/Data/Bookmark.elm
+++ b/src/Data/Bookmark.elm
@@ -4,9 +4,8 @@ module Data.Bookmark exposing
     , decodeJsonList
     , encodeJsonList
     , findByFoodQuery
-    , findByObjectQuery
+    , findByGenericQuery
     , findByTextileQuery
-    , genericQueryFromScope
     , isFood
     , isFood2
     , isObject
@@ -198,24 +197,14 @@ findByFoodQuery foodQuery =
     findByQuery (Food foodQuery)
 
 
-findByObjectQuery : Component.Query -> List Bookmark -> Maybe Bookmark
-findByObjectQuery objectQuery =
-    findByQuery (Generic Scope.Object objectQuery)
+findByGenericQuery : GenericScope -> Component.Query -> List Bookmark -> Maybe Bookmark
+findByGenericQuery genericScope =
+    Generic genericScope >> findByQuery
 
 
 findByTextileQuery : TextileQuery.Query -> List Bookmark -> Maybe Bookmark
 findByTextileQuery textileQuery =
     findByQuery (Textile textileQuery)
-
-
-genericQueryFromScope : Scope -> Component.Query -> Query
-genericQueryFromScope scope_ =
-    case scope_ of
-        Scope.Generic genericScope ->
-            Generic genericScope
-
-        _ ->
-            Generic Scope.Object
 
 
 replace : Bookmark -> List Bookmark -> List Bookmark

--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -3023,7 +3023,7 @@ validateProduct requirements maybeProductId =
                 |> ProductCategory.findById productId
                 |> Result.andThen
                     (\product ->
-                        if product.scope == requirements.scope then
+                        if requirements.scope == Scope.Generic product.scope then
                             Ok productId
 
                         else

--- a/src/Data/Component/ProductCategory.elm
+++ b/src/Data/Component/ProductCategory.elm
@@ -13,7 +13,7 @@ module Data.Component.ProductCategory exposing
 
 import Data.Common.DecodeUtils as DU
 import Data.Process as Process
-import Data.Scope as Scope exposing (Scope)
+import Data.Scope as Scope
 import Data.Uuid as Uuid exposing (Uuid)
 import Json.Decode as Decode exposing (Decoder)
 import Json.Decode.Pipeline as Pipe
@@ -32,7 +32,7 @@ type alias ProductCategory =
     , distribution : Maybe Process.Id
     , id : Id
     , label : String
-    , scope : Scope
+    , scope : Scope.GenericScope
     }
 
 
@@ -43,7 +43,7 @@ decode =
         |> DU.strictOptional "distribution" Process.decodeId
         |> Pipe.required "id" decodeId
         |> Pipe.required "label" Decode.string
-        |> Pipe.required "scope" Scope.decode
+        |> Pipe.required "scope" Scope.decodeGeneric
 
 
 decodeId : Decoder Id
@@ -74,9 +74,9 @@ findById id =
         >> Result.fromMaybe ("Catégorie de produit introuvable id=" ++ idToString id ++ ".")
 
 
-findByScope : Scope -> List ProductCategory -> List ProductCategory
-findByScope scope =
-    List.filter (.scope >> (==) scope)
+findByScope : Scope.GenericScope -> List ProductCategory -> List ProductCategory
+findByScope genericScope =
+    List.filter (.scope >> (==) genericScope)
 
 
 idFromString : String -> Result String Id
@@ -94,5 +94,5 @@ toSearchableString product =
     String.join " "
         [ idToString product.id
         , product.label
-        , Scope.toString product.scope
+        , Scope.toStringGeneric product.scope
         ]

--- a/src/Data/Dataset.elm
+++ b/src/Data/Dataset.elm
@@ -37,7 +37,7 @@ type Dataset
     | GenericExamples Scope.GenericScope (Maybe Uuid)
     | Impacts (Maybe Definition.Trigram)
     | Processes Scope (Maybe Process.Id)
-    | ProductCategory Scope (Maybe ProductCategory.Id)
+    | ProductCategory Scope.GenericScope (Maybe ProductCategory.Id)
     | TextileExamples (Maybe Uuid)
     | TextileMaterials (Maybe Material.Id)
     | TextileProducts (Maybe Product.Id)
@@ -59,7 +59,7 @@ datasets scope =
             , Impacts Nothing
             , Countries Nothing
             , Processes (Scope.Generic Scope.Food2) Nothing
-            , ProductCategory (Scope.Generic Scope.Food2) Nothing
+            , ProductCategory Scope.Food2 Nothing
             ]
 
         Scope.Generic Scope.Object ->
@@ -68,7 +68,7 @@ datasets scope =
             , Countries Nothing
             , Processes (Scope.Generic Scope.Object) Nothing
             , Impacts Nothing
-            , ProductCategory (Scope.Generic Scope.Object) Nothing
+            , ProductCategory Scope.Object Nothing
             ]
 
         Scope.Generic Scope.Veli ->
@@ -77,7 +77,7 @@ datasets scope =
             , Countries Nothing
             , Impacts Nothing
             , Processes (Scope.Generic Scope.Veli) Nothing
-            , ProductCategory (Scope.Generic Scope.Veli) Nothing
+            , ProductCategory Scope.Veli Nothing
             ]
 
         Scope.Textile ->
@@ -129,7 +129,7 @@ fromSlug string =
             Processes (Scope.Generic Scope.Food2) Nothing
 
         "food2-product-categories" ->
-            ProductCategory (Scope.Generic Scope.Food2) Nothing
+            ProductCategory Scope.Food2 Nothing
 
         "impacts" ->
             Impacts Nothing
@@ -150,7 +150,7 @@ fromSlug string =
             Processes (Scope.Generic Scope.Object) Nothing
 
         "object-product-categories" ->
-            ProductCategory (Scope.Generic Scope.Object) Nothing
+            ProductCategory Scope.Object Nothing
 
         "processes" ->
             Processes Scope.Textile Nothing
@@ -174,7 +174,7 @@ fromSlug string =
             Processes (Scope.Generic Scope.Veli) Nothing
 
         "veli-product-categories" ->
-            ProductCategory (Scope.Generic Scope.Veli) Nothing
+            ProductCategory Scope.Veli Nothing
 
         _ ->
             TextileExamples Nothing
@@ -373,8 +373,8 @@ strings dataset =
         Processes scope _ ->
             { label = "Procédés", slug = Scope.toString scope ++ "-processes" }
 
-        ProductCategory scope _ ->
-            { label = "Produits", slug = Scope.toString scope ++ "-product-categories" }
+        ProductCategory genericScope _ ->
+            { label = "Produits", slug = Scope.toString (Scope.Generic genericScope) ++ "-product-categories" }
 
         TextileExamples _ ->
             { label = "Exemples", slug = "textile-examples" }

--- a/src/Data/Dataset.elm
+++ b/src/Data/Dataset.elm
@@ -34,14 +34,13 @@ type Dataset
     | Countries (Maybe CountryCode.Code)
     | FoodExamples (Maybe Uuid)
     | FoodIngredients (Maybe Ingredient.Id)
+    | GenericExamples Scope.GenericScope (Maybe Uuid)
     | Impacts (Maybe Definition.Trigram)
-    | ObjectExamples (Maybe Uuid)
     | Processes Scope (Maybe Process.Id)
     | ProductCategory Scope (Maybe ProductCategory.Id)
     | TextileExamples (Maybe Uuid)
     | TextileMaterials (Maybe Material.Id)
     | TextileProducts (Maybe Product.Id)
-    | VeliExamples (Maybe Uuid)
 
 
 datasets : Scope -> List Dataset
@@ -56,14 +55,15 @@ datasets scope =
             ]
 
         Scope.Generic Scope.Food2 ->
-            [ Impacts Nothing
+            [ GenericExamples Scope.Food2 Nothing
+            , Impacts Nothing
             , Countries Nothing
             , Processes (Scope.Generic Scope.Food2) Nothing
             , ProductCategory (Scope.Generic Scope.Food2) Nothing
             ]
 
         Scope.Generic Scope.Object ->
-            [ ObjectExamples Nothing
+            [ GenericExamples Scope.Object Nothing
             , Components (Scope.Generic Scope.Object) Nothing
             , Countries Nothing
             , Processes (Scope.Generic Scope.Object) Nothing
@@ -72,7 +72,7 @@ datasets scope =
             ]
 
         Scope.Generic Scope.Veli ->
-            [ VeliExamples Nothing
+            [ GenericExamples Scope.Veli Nothing
             , Components (Scope.Generic Scope.Veli) Nothing
             , Countries Nothing
             , Impacts Nothing
@@ -98,13 +98,13 @@ defaultDatasetFor scope =
             FoodExamples Nothing
 
         Scope.Generic Scope.Food2 ->
-            Processes (Scope.Generic Scope.Food2) Nothing
+            GenericExamples Scope.Food2 Nothing
 
         Scope.Generic Scope.Object ->
-            ObjectExamples Nothing
+            GenericExamples Scope.Object Nothing
 
         Scope.Generic Scope.Veli ->
-            VeliExamples Nothing
+            GenericExamples Scope.Veli Nothing
 
         Scope.Textile ->
             TextileExamples Nothing
@@ -121,6 +121,9 @@ fromSlug string =
 
         "food-processes" ->
             Processes Scope.Food Nothing
+
+        "food2-examples" ->
+            GenericExamples Scope.Food2 Nothing
 
         "food2-processes" ->
             Processes (Scope.Generic Scope.Food2) Nothing
@@ -141,7 +144,7 @@ fromSlug string =
             Components (Scope.Generic Scope.Object) Nothing
 
         "object-examples" ->
-            ObjectExamples Nothing
+            GenericExamples Scope.Object Nothing
 
         "object-processes" ->
             Processes (Scope.Generic Scope.Object) Nothing
@@ -165,7 +168,7 @@ fromSlug string =
             Components (Scope.Generic Scope.Veli) Nothing
 
         "veli-examples" ->
-            VeliExamples Nothing
+            GenericExamples Scope.Veli Nothing
 
         "veli-processes" ->
             Processes (Scope.Generic Scope.Veli) Nothing
@@ -192,10 +195,10 @@ isDetailed dataset =
         FoodIngredients (Just _) ->
             True
 
-        Impacts (Just _) ->
+        GenericExamples _ (Just _) ->
             True
 
-        ObjectExamples (Just _) ->
+        Impacts (Just _) ->
             True
 
         Processes _ (Just _) ->
@@ -211,9 +214,6 @@ isDetailed dataset =
             True
 
         TextileProducts (Just _) ->
-            True
-
-        VeliExamples (Just _) ->
             True
 
         _ ->
@@ -245,11 +245,11 @@ reset dataset =
         FoodIngredients _ ->
             FoodIngredients Nothing
 
+        GenericExamples scope _ ->
+            GenericExamples scope Nothing
+
         Impacts _ ->
             Impacts Nothing
-
-        ObjectExamples _ ->
-            ObjectExamples Nothing
 
         Processes scope _ ->
             Processes scope Nothing
@@ -265,9 +265,6 @@ reset dataset =
 
         TextileProducts _ ->
             TextileProducts Nothing
-
-        VeliExamples _ ->
-            VeliExamples Nothing
 
 
 same : Dataset -> Dataset -> Bool
@@ -297,16 +294,13 @@ same a b =
         ( Components scope1 _, Components scope2 _ ) ->
             scope1 == scope2
 
-        ( ObjectExamples _, ObjectExamples _ ) ->
-            True
+        ( GenericExamples scope1 _, GenericExamples scope2 _ ) ->
+            scope1 == scope2
 
         ( TextileMaterials _, TextileMaterials _ ) ->
             True
 
         ( TextileProducts _, TextileProducts _ ) ->
-            True
-
-        ( VeliExamples _, VeliExamples _ ) ->
             True
 
         _ ->
@@ -328,11 +322,11 @@ setIdFromString idString dataset =
         FoodIngredients _ ->
             FoodIngredients (idString |> Ingredient.idFromString |> Result.toMaybe)
 
+        GenericExamples scope _ ->
+            GenericExamples scope (idString |> Uuid.fromString |> Result.toMaybe)
+
         Impacts _ ->
             Impacts (Definition.toTrigram idString |> Result.toMaybe)
-
-        ObjectExamples _ ->
-            ObjectExamples (idString |> Uuid.fromString |> Result.toMaybe)
 
         Processes scope _ ->
             Processes scope (Process.idFromString idString |> Result.toMaybe)
@@ -348,9 +342,6 @@ setIdFromString idString dataset =
 
         TextileProducts _ ->
             TextileProducts (Just (Product.Id idString))
-
-        VeliExamples _ ->
-            VeliExamples (idString |> Uuid.fromString |> Result.toMaybe)
 
 
 slug : Dataset -> String
@@ -373,11 +364,11 @@ strings dataset =
         FoodIngredients _ ->
             { label = "Ingrédients", slug = "ingredients" }
 
+        GenericExamples genericScope _ ->
+            { label = "Exemples", slug = Scope.toString (Scope.Generic genericScope) ++ "-examples" }
+
         Impacts _ ->
             { label = "Impacts", slug = "impacts" }
-
-        ObjectExamples _ ->
-            { label = "Exemples", slug = "object-examples" }
 
         Processes scope _ ->
             { label = "Procédés", slug = Scope.toString scope ++ "-processes" }
@@ -393,9 +384,6 @@ strings dataset =
 
         TextileProducts _ ->
             { label = "Produits", slug = "products" }
-
-        VeliExamples _ ->
-            { label = "Exemples", slug = "veli-examples" }
 
 
 toRoutePath : Dataset -> List String
@@ -425,16 +413,16 @@ toRoutePath dataset =
         FoodIngredients Nothing ->
             [ slug dataset ]
 
+        GenericExamples _ (Just id) ->
+            [ slug dataset, Uuid.toString id ]
+
+        GenericExamples _ Nothing ->
+            [ slug dataset ]
+
         Impacts (Just trigram) ->
             [ slug dataset, Definition.toString trigram ]
 
         Impacts Nothing ->
-            [ slug dataset ]
-
-        ObjectExamples (Just id) ->
-            [ slug dataset, Uuid.toString id ]
-
-        ObjectExamples Nothing ->
             [ slug dataset ]
 
         Processes _ (Just id) ->
@@ -465,10 +453,4 @@ toRoutePath dataset =
             [ slug dataset, Product.idToString id ]
 
         TextileProducts Nothing ->
-            [ slug dataset ]
-
-        VeliExamples (Just id) ->
-            [ slug dataset, Uuid.toString id ]
-
-        VeliExamples Nothing ->
             [ slug dataset ]

--- a/src/Data/Db.elm
+++ b/src/Data/Db.elm
@@ -12,9 +12,9 @@ import Data.Component as Component exposing (Component)
 import Data.Component.ProductCategory as ProductCategory exposing (ProductCategory)
 import Data.Country as Country exposing (Country)
 import Data.Food.Db as FoodDb
+import Data.Generic.Db as GenericDb
 import Data.Impact as Impact
 import Data.Impact.Definition as Definition exposing (Definitions)
-import Data.Object.Db as ObjectDb
 import Data.Process as Process exposing (Process)
 import Data.Textile.Db as TextileDb
 import Data.Transport as Transport exposing (Distances)
@@ -28,7 +28,7 @@ type alias Db =
     , definitions : Definitions
     , distances : Distances
     , food : FoodDb.Db
-    , object : ObjectDb.Db
+    , object : GenericDb.Db
     , processes : List Process
     , products : List ProductCategory
     , textile : TextileDb.Db
@@ -105,7 +105,7 @@ build json =
                                 (extractJsonString json.foodIngredients)
                         )
                     |> RE.andMap
-                        (ObjectDb.buildFromJson
+                        (GenericDb.buildFromJson
                             (extractJsonString json.food2Examples)
                             (extractJsonString json.objectExamples)
                             (extractJsonString json.veliExamples)

--- a/src/Data/Db.elm
+++ b/src/Data/Db.elm
@@ -28,7 +28,7 @@ type alias Db =
     , definitions : Definitions
     , distances : Distances
     , food : FoodDb.Db
-    , object : GenericDb.Db
+    , generic : GenericDb.Db
     , processes : List Process
     , products : List ProductCategory
     , textile : TextileDb.Db

--- a/src/Data/Generic/Db.elm
+++ b/src/Data/Generic/Db.elm
@@ -3,7 +3,7 @@ module Data.Generic.Db exposing
     , buildFromJson
     )
 
-{-| Note: The Object database holds examples all generic scopes
+{-| Note: The generic database holds examples all generic scopes
 -}
 
 import Data.Component as Component

--- a/src/Data/Generic/Db.elm
+++ b/src/Data/Generic/Db.elm
@@ -1,4 +1,4 @@
-module Data.Object.Db exposing
+module Data.Generic.Db exposing
     ( Db
     , buildFromJson
     )

--- a/src/Data/Generic/Simulator.elm
+++ b/src/Data/Generic/Simulator.elm
@@ -1,4 +1,4 @@
-module Data.Object.Simulator exposing
+module Data.Generic.Simulator exposing
     ( compute
     , toStagesImpacts
     )

--- a/src/Data/Scope.elm
+++ b/src/Data/Scope.elm
@@ -17,6 +17,7 @@ module Data.Scope exposing
     , toGenericScope
     , toLabel
     , toString
+    , toStringGeneric
     )
 
 import Dict.Any as AnyDict exposing (AnyDict)

--- a/src/Data/Scope.elm
+++ b/src/Data/Scope.elm
@@ -14,6 +14,7 @@ module Data.Scope exposing
     , fromString
     , isGeneric
     , parse
+    , toGenericScope
     , toLabel
     , toString
     )
@@ -156,6 +157,16 @@ parse : Parser (Scope -> a) a
 parse =
     Parser.custom "SCOPE" <|
         (fromString >> Result.toMaybe)
+
+
+toGenericScope : Scope -> Maybe GenericScope
+toGenericScope scope =
+    case scope of
+        Generic genericScope ->
+            Just genericScope
+
+        _ ->
+            Nothing
 
 
 toLabel : Scope -> String

--- a/src/Data/Session.elm
+++ b/src/Data/Session.elm
@@ -10,6 +10,7 @@ module Data.Session exposing
     , decodeRawStore
     , defaultStore
     , deleteBookmark
+    , genericQuery
     , getAccessToken
     , getAuth
     , hasAccessToDetailedImpacts
@@ -19,7 +20,6 @@ module Data.Session exposing
     , moveBookmark
     , moveListElement
     , notifyBackendError
-    , objectQueryFromScope
     , replaceBookmark
     , saveBookmark
     , selectAllBookmarks
@@ -31,7 +31,7 @@ module Data.Session exposing
     , updateDb
     , updateDbProcesses
     , updateFoodQuery
-    , updateObjectQuery
+    , updateGenericQuery
     , updateTextileQuery
     )
 
@@ -41,7 +41,7 @@ import Data.Common.DecodeUtils as DU
 import Data.Component as Component
 import Data.Db as Db exposing (Db)
 import Data.Food.Query as FoodQuery
-import Data.Scope as Scope exposing (Scope)
+import Data.Scope as Scope exposing (GenericScope)
 import Data.Textile.Query as TextileQuery
 import Data.User as User
 import Json.Decode as Decode exposing (Decoder)
@@ -198,20 +198,17 @@ updateDb fn session =
 -- Queries
 
 
-objectQueryFromScope : Scope -> Session -> Component.Query
-objectQueryFromScope scope session =
-    case scope of
-        Scope.Generic Scope.Food2 ->
+genericQuery : GenericScope -> Session -> Component.Query
+genericQuery genericScope session =
+    case genericScope of
+        Scope.Food2 ->
             session.queries.food2
 
-        Scope.Generic Scope.Object ->
+        Scope.Object ->
             session.queries.object
 
-        Scope.Generic Scope.Veli ->
+        Scope.Veli ->
             session.queries.veli
-
-        _ ->
-            Component.emptyQuery
 
 
 updateFoodQuery : FoodQuery.Query -> Session -> Session
@@ -219,22 +216,17 @@ updateFoodQuery foodQuery ({ queries } as session) =
     { session | queries = { queries | food = foodQuery } }
 
 
-updateObjectQuery : Scope -> Component.Query -> Session -> Session
-updateObjectQuery scope query ({ queries } as session) =
-    case scope of
-        Scope.Generic Scope.Food2 ->
+updateGenericQuery : GenericScope -> Component.Query -> Session -> Session
+updateGenericQuery genericScope query ({ queries } as session) =
+    case genericScope of
+        Scope.Food2 ->
             { session | queries = { queries | food2 = query } }
 
-        Scope.Generic Scope.Object ->
+        Scope.Object ->
             { session | queries = { queries | object = query } }
 
-        Scope.Generic Scope.Veli ->
+        Scope.Veli ->
             { session | queries = { queries | veli = query } }
-
-        _ ->
-            session
-                |> notifyError "Erreur de mise à jour de la requête"
-                    ("La requête " ++ Scope.toString scope ++ " n'est pas générique")
 
 
 updateTextileQuery : TextileQuery.Query -> Session -> Session

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -23,8 +23,8 @@ import Page.Auth as Auth
 import Page.Editorial as Editorial
 import Page.Explore as Explore
 import Page.Food as FoodBuilder
+import Page.Generic as GenericSimulator
 import Page.Home as Home
-import Page.Object as ObjectSimulator
 import Page.Stats as Stats
 import Page.Textile as TextileSimulator
 import Ports
@@ -66,10 +66,10 @@ type Page
     | EditorialPage Editorial.Model
     | ExplorePage Explore.Model
     | FoodBuilderPage FoodBuilder.Model
+    | GenericSimulatorPage GenericSimulator.Model
     | HomePage Home.Model
     | LoadingPage
     | NotFoundPage
-    | ObjectSimulatorPage ObjectSimulator.Model
     | ProcessAdminPage ProcessAdmin.Model
     | RestrictedAccessPage
     | StatsPage Stats.Model
@@ -106,8 +106,8 @@ type Msg
     | EditorialMsg Editorial.Msg
     | ExploreMsg Explore.Msg
     | FoodBuilderMsg FoodBuilder.Msg
+    | GenericSimulatorMsg GenericSimulator.Msg
     | HomeMsg Home.Msg
-    | ObjectSimulatorMsg ObjectSimulator.Msg
     | ProcessAdminMsg ProcessAdmin.Msg
     | RawDataReceived SessionConfig (WebData RawJsonString -> LoadingState -> LoadingState) (WebData RawJsonString)
     | StatsMsg Stats.Msg
@@ -300,20 +300,20 @@ setRoute url ( { state } as model, cmds ) =
                         |> toPage session model cmds FoodBuilderPage FoodBuilderMsg
 
                 Just (Route.GenericSimulator scope trigram maybeQuery) ->
-                    ObjectSimulator.init scope trigram maybeQuery session
-                        |> toPage session model cmds ObjectSimulatorPage ObjectSimulatorMsg
+                    GenericSimulator.init scope trigram maybeQuery session
+                        |> toPage session model cmds GenericSimulatorPage GenericSimulatorMsg
 
                 Just (Route.GenericSimulatorExample scope uuid) ->
-                    ObjectSimulator.initFromExample session scope uuid
-                        |> toPage session model cmds ObjectSimulatorPage ObjectSimulatorMsg
+                    GenericSimulator.initFromExample session scope uuid
+                        |> toPage session model cmds GenericSimulatorPage GenericSimulatorMsg
 
                 Just Route.Home ->
                     Home.init session
                         |> toPage session model cmds HomePage HomeMsg
 
                 Just (Route.GenericSimulatorHome scope) ->
-                    ObjectSimulator.init scope Impact.default Nothing session
-                        |> toPage session model cmds ObjectSimulatorPage ObjectSimulatorMsg
+                    GenericSimulator.init scope Impact.default Nothing session
+                        |> toPage session model cmds GenericSimulatorPage GenericSimulatorMsg
 
                 Just Route.Stats ->
                     Stats.init session
@@ -536,9 +536,9 @@ update rawMsg ({ state } as model) =
                         |> toPage session model Cmd.none HomePage HomeMsg
 
                 -- Object
-                ( ObjectSimulatorMsg objectMsg, ObjectSimulatorPage objectModel ) ->
-                    ObjectSimulator.update session objectMsg objectModel
-                        |> toPage session model Cmd.none ObjectSimulatorPage ObjectSimulatorMsg
+                ( GenericSimulatorMsg objectMsg, GenericSimulatorPage objectModel ) ->
+                    GenericSimulator.update session objectMsg objectModel
+                        |> toPage session model Cmd.none GenericSimulatorPage GenericSimulatorMsg
 
                 -- Process Admin
                 ( ProcessAdminMsg adminMsg, ProcessAdminPage adminModel ) ->
@@ -641,9 +641,9 @@ subscriptions { state } =
                 FoodBuilder.subscriptions subModel
                     |> Sub.map FoodBuilderMsg
 
-            Loaded _ (ObjectSimulatorPage subModel) ->
-                ObjectSimulator.subscriptions subModel
-                    |> Sub.map ObjectSimulatorMsg
+            Loaded _ (GenericSimulatorPage subModel) ->
+                GenericSimulator.subscriptions subModel
+                    |> Sub.map GenericSimulatorMsg
 
             Loaded _ (ProcessAdminPage _) ->
                 ProcessAdmin.subscriptions
@@ -742,6 +742,11 @@ view { dbLoadingState, flags, mobileNavigationOpened, state, tray } =
                         |> mapMsg FoodBuilderMsg
                         |> frame Page.Food
 
+                GenericSimulatorPage simulatorModel ->
+                    GenericSimulator.view session simulatorModel
+                        |> mapMsg GenericSimulatorMsg
+                        |> frame (Page.Generic simulatorModel.scope)
+
                 HomePage _ ->
                     Home.view session
                         |> mapMsg HomeMsg
@@ -754,11 +759,6 @@ view { dbLoadingState, flags, mobileNavigationOpened, state, tray } =
                 NotFoundPage ->
                     ( "404", [ Page.notFound ] )
                         |> frame Page.Other
-
-                ObjectSimulatorPage simulatorModel ->
-                    ObjectSimulator.view session simulatorModel
-                        |> mapMsg ObjectSimulatorMsg
-                        |> frame (Page.Object simulatorModel.scope)
 
                 ProcessAdminPage processAdminModel ->
                     ProcessAdmin.view session processAdminModel

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -535,9 +535,9 @@ update rawMsg ({ state } as model) =
                     Home.update session homeMsg homeModel
                         |> toPage session model Cmd.none HomePage HomeMsg
 
-                -- Object
-                ( GenericSimulatorMsg objectMsg, GenericSimulatorPage objectModel ) ->
-                    GenericSimulator.update session objectMsg objectModel
+                -- Generic simulator
+                ( GenericSimulatorMsg genericMsg, GenericSimulatorPage genericModel ) ->
+                    GenericSimulator.update session genericMsg genericModel
                         |> toPage session model Cmd.none GenericSimulatorPage GenericSimulatorMsg
 
                 -- Process Admin

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -11,6 +11,7 @@ import Data.Food.Query as FoodQuery
 import Data.Impact as Impact
 import Data.Notification as Notification exposing (Notification)
 import Data.Plausible as Plausible
+import Data.Scope as Scope
 import Data.Session as Session exposing (Session)
 import Data.Textile.Query as TextileQuery
 import Html
@@ -299,20 +300,20 @@ setRoute url ( { state } as model, cmds ) =
                     FoodBuilder.init session Impact.default Nothing
                         |> toPage session model cmds FoodBuilderPage FoodBuilderMsg
 
-                Just (Route.GenericSimulator scope trigram maybeQuery) ->
-                    GenericSimulator.init scope trigram maybeQuery session
+                Just (Route.GenericSimulator genericScope trigram maybeQuery) ->
+                    GenericSimulator.init (Scope.Generic genericScope) trigram maybeQuery session
                         |> toPage session model cmds GenericSimulatorPage GenericSimulatorMsg
 
-                Just (Route.GenericSimulatorExample scope uuid) ->
-                    GenericSimulator.initFromExample session scope uuid
+                Just (Route.GenericSimulatorExample genericScope uuid) ->
+                    GenericSimulator.initFromExample session (Scope.Generic genericScope) uuid
                         |> toPage session model cmds GenericSimulatorPage GenericSimulatorMsg
 
                 Just Route.Home ->
                     Home.init session
                         |> toPage session model cmds HomePage HomeMsg
 
-                Just (Route.GenericSimulatorHome scope) ->
-                    GenericSimulator.init scope Impact.default Nothing session
+                Just (Route.GenericSimulatorHome genericScope) ->
+                    GenericSimulator.init (Scope.Generic genericScope) Impact.default Nothing session
                         |> toPage session model cmds GenericSimulatorPage GenericSimulatorMsg
 
                 Just Route.Stats ->

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -11,7 +11,6 @@ import Data.Food.Query as FoodQuery
 import Data.Impact as Impact
 import Data.Notification as Notification exposing (Notification)
 import Data.Plausible as Plausible
-import Data.Scope as Scope
 import Data.Session as Session exposing (Session)
 import Data.Textile.Query as TextileQuery
 import Html
@@ -301,11 +300,11 @@ setRoute url ( { state } as model, cmds ) =
                         |> toPage session model cmds FoodBuilderPage FoodBuilderMsg
 
                 Just (Route.GenericSimulator genericScope trigram maybeQuery) ->
-                    GenericSimulator.init (Scope.Generic genericScope) trigram maybeQuery session
+                    GenericSimulator.init genericScope trigram maybeQuery session
                         |> toPage session model cmds GenericSimulatorPage GenericSimulatorMsg
 
                 Just (Route.GenericSimulatorExample genericScope uuid) ->
-                    GenericSimulator.initFromExample session (Scope.Generic genericScope) uuid
+                    GenericSimulator.initFromExample session genericScope uuid
                         |> toPage session model cmds GenericSimulatorPage GenericSimulatorMsg
 
                 Just Route.Home ->
@@ -313,7 +312,7 @@ setRoute url ( { state } as model, cmds ) =
                         |> toPage session model cmds HomePage HomeMsg
 
                 Just (Route.GenericSimulatorHome genericScope) ->
-                    GenericSimulator.init (Scope.Generic genericScope) Impact.default Nothing session
+                    GenericSimulator.init genericScope Impact.default Nothing session
                         |> toPage session model cmds GenericSimulatorPage GenericSimulatorMsg
 
                 Just Route.Stats ->
@@ -746,7 +745,7 @@ view { dbLoadingState, flags, mobileNavigationOpened, state, tray } =
                 GenericSimulatorPage simulatorModel ->
                     GenericSimulator.view session simulatorModel
                         |> mapMsg GenericSimulatorMsg
-                        |> frame (Page.Generic simulatorModel.scope)
+                        |> frame (Page.Generic simulatorModel.genericScope)
 
                 HomePage _ ->
                     Home.view session

--- a/src/Page/Admin/Component.elm
+++ b/src/Page/Admin/Component.elm
@@ -574,7 +574,7 @@ componentRowView session selected component =
                             , Component.emptyQuery
                                 |> Component.setQueryItems [ Component.createItem (Just componentId) ]
                                 |> Just
-                                |> Route.GenericSimulator (Scope.Generic Scope.Object) Definition.Ecs
+                                |> Route.GenericSimulator Scope.Object Definition.Ecs
                                 |> Route.href
                             ]
                             [ Icon.puzzle ]

--- a/src/Page/Admin/Component.elm
+++ b/src/Page/Admin/Component.elm
@@ -543,7 +543,7 @@ componentRowView session selected component =
                 |> Component.computeImpacts
                     { config = session.componentConfig
                     , db = session.db
-                    , scope = Scope.Generic Scope.Object
+                    , scope = component.scope
                     }
                     Component.defaultTransportOptions
                 |> Result.map
@@ -566,20 +566,20 @@ componentRowView session selected component =
                     , onClick <| DuplicateComponent component
                     ]
                     [ Icon.copy ]
-                , case component.id of
-                    Just componentId ->
+                , case ( component.id, Scope.toGenericScope component.scope ) of
+                    ( Just componentId, Just genericScope ) ->
                         a
                             [ class "btn btn-outline-primary"
                             , title "Utiliser dans le simulateur"
                             , Component.emptyQuery
                                 |> Component.setQueryItems [ Component.createItem (Just componentId) ]
                                 |> Just
-                                |> Route.GenericSimulator Scope.Object Definition.Ecs
+                                |> Route.GenericSimulator genericScope Definition.Ecs
                                 |> Route.href
                             ]
                             [ Icon.puzzle ]
 
-                    Nothing ->
+                    _ ->
                         button
                             [ class "btn btn-outline-primary"
                             , title "Utiliser dans le simulateur"

--- a/src/Page/Explore.elm
+++ b/src/Page/Explore.elm
@@ -45,8 +45,8 @@ import Page.Explore.Components as Components
 import Page.Explore.Countries as ExploreCountries
 import Page.Explore.FoodExamples as FoodExamples
 import Page.Explore.FoodIngredients as FoodIngredients
+import Page.Explore.GenericExamples as GenericExamples
 import Page.Explore.Impacts as ExploreImpacts
-import Page.Explore.ObjectExamples as ObjectExamples
 import Page.Explore.Processes as Processes
 import Page.Explore.ProductCategories as ProductCategories
 import Page.Explore.Table as Table
@@ -98,11 +98,11 @@ init scope dataset session =
                 Dataset.FoodIngredients _ ->
                     "Identifiant"
 
+                Dataset.GenericExamples _ _ ->
+                    "Coût Environnemental"
+
                 Dataset.Impacts _ ->
                     "Code"
-
-                Dataset.ObjectExamples _ ->
-                    "Coût Environnemental"
 
                 Dataset.Processes _ _ ->
                     "Nom"
@@ -118,9 +118,6 @@ init scope dataset session =
 
                 Dataset.TextileProducts _ ->
                     "Identifiant"
-
-                Dataset.VeliExamples _ ->
-                    "Coût Environnemental"
     in
     createPageUpdate session
         { dataset = dataset
@@ -168,14 +165,13 @@ update session msg model =
                                     Dataset.FoodExamples Nothing
 
                                 Scope.Generic Scope.Food2 ->
-                                    -- FIXME: we should eventually have food2 examples
-                                    Dataset.Processes (Scope.Generic Scope.Food2) Nothing
+                                    Dataset.GenericExamples Scope.Food2 Nothing
 
                                 Scope.Generic Scope.Object ->
-                                    Dataset.ObjectExamples Nothing
+                                    Dataset.GenericExamples Scope.Object Nothing
 
                                 Scope.Generic Scope.Veli ->
-                                    Dataset.VeliExamples Nothing
+                                    Dataset.GenericExamples Scope.Veli Nothing
 
                                 Scope.Textile ->
                                     Dataset.TextileExamples Nothing
@@ -525,19 +521,19 @@ componentsExplorer session scope tableConfig tableState maybeId =
     ]
 
 
-objectExamplesExplorer :
+genericExamplesExplorer :
     Session
     -> Table.Config ( Example Component.Query, { score : Float } ) Msg
     -> SortableTable.State
     -> Scope
     -> Maybe Uuid
     -> List (Html Msg)
-objectExamplesExplorer session tableConfig tableState scope maybeId =
+genericExamplesExplorer session tableConfig tableState scope maybeId =
     let
         scoredExamples =
             session.db.object.examples
                 |> List.filter (\example -> example.scope == scope)
-                |> List.map (\example -> ( example, { score = getObjectScore session scope example } ))
+                |> List.map (\example -> ( example, { score = getGenericScore session scope example } ))
                 |> List.sortBy (Tuple.first >> .name)
 
         max =
@@ -555,7 +551,7 @@ objectExamplesExplorer session tableConfig tableState scope maybeId =
             tableConfig
             tableState
             scope
-            (ObjectExamples.table max)
+            (GenericExamples.table max)
     , case maybeId of
         Just id ->
             detailsModal
@@ -564,8 +560,8 @@ objectExamplesExplorer session tableConfig tableState scope maybeId =
                         alert error
 
                     Ok example ->
-                        ( example, { score = getObjectScore session scope example } )
-                            |> Table.viewDetails scope (ObjectExamples.table max)
+                        ( example, { score = getGenericScore session scope example } )
+                            |> Table.viewDetails scope (GenericExamples.table max)
                 )
 
         Nothing ->
@@ -751,8 +747,8 @@ getFoodScorePer100g db =
         >> Result.withDefault 0
 
 
-getObjectScore : Session -> Scope -> Example Component.Query -> Float
-getObjectScore { componentConfig, db } scope { query } =
+getGenericScore : Session -> Scope -> Example Component.Query -> Float
+getGenericScore { componentConfig, db } scope { query } =
     query
         |> GenericSimulator.compute { config = componentConfig, db = db, scope = scope }
         |> Result.map
@@ -814,11 +810,11 @@ exploreView ({ db } as session) { facetValues, scope, dataset, tableState, searc
         Dataset.FoodIngredients maybeId ->
             foodIngredientsExplorer db tableConfig tableState maybeId
 
+        Dataset.GenericExamples genericScope maybeId ->
+            genericExamplesExplorer session tableConfig tableState (Scope.Generic genericScope) maybeId
+
         Dataset.Impacts maybeTrigram ->
             impactsExplorer db.definitions tableConfig tableState scope maybeTrigram
-
-        Dataset.ObjectExamples maybeId ->
-            objectExamplesExplorer session tableConfig tableState (Scope.Generic Scope.Object) maybeId
 
         Dataset.Processes scope_ maybeId ->
             processesExplorer session scope_ tableConfig tableState maybeId
@@ -834,9 +830,6 @@ exploreView ({ db } as session) { facetValues, scope, dataset, tableState, searc
 
         Dataset.TextileProducts maybeId ->
             textileProductsExplorer session tableConfig tableState maybeId
-
-        Dataset.VeliExamples maybeId ->
-            objectExamplesExplorer session tableConfig tableState (Scope.Generic Scope.Veli) maybeId
 
 
 searchInputView : Model -> Html Msg

--- a/src/Page/Explore.elm
+++ b/src/Page/Explore.elm
@@ -686,7 +686,7 @@ productCategoriesExplorer session genericScope tableConfig tableState maybeId =
             Scope.Generic genericScope
     in
     [ session.db.products
-        |> ProductCategory.findByScope scope
+        |> ProductCategory.findByScope genericScope
         |> Table.viewList (.id >> ProductCategory.idToString >> OpenDetail)
             tableConfig
             tableState

--- a/src/Page/Explore.elm
+++ b/src/Page/Explore.elm
@@ -512,7 +512,7 @@ componentsExplorer session scope tableConfig tableState maybeId =
 
 genericExamplesExplorer :
     Session
-    -> Table.Config ( Example Component.Query, { score : Float } ) Msg
+    -> Table.Config ( Example Component.Query, { score : Float, per100g : Float } ) Msg
     -> SortableTable.State
     -> Scope
     -> Maybe Uuid
@@ -522,13 +522,25 @@ genericExamplesExplorer session tableConfig tableState scope maybeId =
         scoredExamples =
             session.db.object.examples
                 |> List.filter (\example -> example.scope == scope)
-                |> List.map (\example -> ( example, { score = getGenericScore session scope example } ))
+                |> List.map
+                    (\example ->
+                        ( example
+                        , { score = getGenericScore session scope example
+                          , per100g = getGenericScorePer100g session scope example
+                          }
+                        )
+                    )
                 |> List.sortBy (Tuple.first >> .name)
 
         max =
             { maxScore =
                 scoredExamples
                     |> List.map (Tuple.second >> .score)
+                    |> List.maximum
+                    |> Maybe.withDefault 0
+            , maxPer100g =
+                scoredExamples
+                    |> List.map (Tuple.second >> .per100g)
                     |> List.maximum
                     |> Maybe.withDefault 0
             }
@@ -549,7 +561,11 @@ genericExamplesExplorer session tableConfig tableState scope maybeId =
                         alert error
 
                     Ok example ->
-                        ( example, { score = getGenericScore session scope example } )
+                        ( example
+                        , { score = getGenericScore session scope example
+                          , per100g = getGenericScorePer100g session scope example
+                          }
+                        )
                             |> Table.viewDetails scope (GenericExamples.table max)
                 )
 
@@ -744,6 +760,21 @@ getGenericScore { componentConfig, db } scope { query } =
             (Component.sumLifeCycleImpacts
                 >> Impact.getImpact Definition.Ecs
                 >> Unit.impactToFloat
+            )
+        |> Result.withDefault 0
+
+
+getGenericScorePer100g : Session -> Scope -> Example Component.Query -> Float
+getGenericScorePer100g { componentConfig, db } scope { query } =
+    query
+        |> GenericSimulator.compute { config = componentConfig, db = db, scope = scope }
+        |> Result.map
+            (\lifeCycle ->
+                lifeCycle
+                    |> Component.sumLifeCycleImpacts
+                    |> Impact.per100grams lifeCycle.productMass
+                    |> Impact.getImpact Definition.Ecs
+                    |> Unit.impactToFloat
             )
         |> Result.withDefault 0
 

--- a/src/Page/Explore.elm
+++ b/src/Page/Explore.elm
@@ -23,10 +23,10 @@ import Data.Example as Example exposing (Example)
 import Data.Food.Ingredient as Ingredient exposing (Ingredient)
 import Data.Food.Query as FoodQuery
 import Data.Food.Recipe as Recipe
+import Data.Generic.Simulator as GenericSimulator
 import Data.Impact as Impact
 import Data.Impact.Definition as Definition exposing (Definition, Definitions)
 import Data.Key as Key
-import Data.Object.Simulator as ObjectSimulator
 import Data.Process as Process exposing (Process)
 import Data.Scope as Scope exposing (Scope)
 import Data.Session exposing (Session)
@@ -754,7 +754,7 @@ getFoodScorePer100g db =
 getObjectScore : Session -> Scope -> Example Component.Query -> Float
 getObjectScore { componentConfig, db } scope { query } =
     query
-        |> ObjectSimulator.compute { config = componentConfig, db = db, scope = scope }
+        |> GenericSimulator.compute { config = componentConfig, db = db, scope = scope }
         |> Result.map
             (Component.sumLifeCycleImpacts
                 >> Impact.getImpact Definition.Ecs

--- a/src/Page/Explore.elm
+++ b/src/Page/Explore.elm
@@ -159,8 +159,13 @@ update session msg model =
                         Dataset.Processes _ _ ->
                             Dataset.Processes scope Nothing
 
-                        Dataset.ProductCategory genericScope _ ->
-                            Dataset.ProductCategory (Scope.toGenericScope scope |> Maybe.withDefault genericScope) Nothing
+                        Dataset.ProductCategory _ _ ->
+                            case Scope.toGenericScope scope of
+                                Just newGenericScope ->
+                                    Dataset.ProductCategory newGenericScope Nothing
+
+                                Nothing ->
+                                    Dataset.defaultDatasetFor scope
 
                         _ ->
                             Dataset.defaultDatasetFor scope
@@ -514,13 +519,16 @@ genericExamplesExplorer :
     Session
     -> Table.Config ( Example Component.Query, { score : Float, per100g : Float } ) Msg
     -> SortableTable.State
-    -> Scope
+    -> Scope.GenericScope
     -> Maybe Uuid
     -> List (Html Msg)
-genericExamplesExplorer session tableConfig tableState scope maybeId =
+genericExamplesExplorer session tableConfig tableState genericScope maybeId =
     let
+        scope =
+            Scope.Generic genericScope
+
         scoredExamples =
-            session.db.object.examples
+            session.db.generic.examples
                 |> List.filter (\example -> example.scope == scope)
                 |> List.map
                     (\example ->
@@ -552,11 +560,11 @@ genericExamplesExplorer session tableConfig tableState scope maybeId =
             tableConfig
             tableState
             scope
-            (GenericExamples.table max)
+            (GenericExamples.table max genericScope)
     , case maybeId of
         Just id ->
             detailsModal
-                (case Example.findByUuid id session.db.object.examples of
+                (case Example.findByUuid id session.db.generic.examples of
                     Err error ->
                         alert error
 
@@ -566,7 +574,7 @@ genericExamplesExplorer session tableConfig tableState scope maybeId =
                           , per100g = getGenericScorePer100g session scope example
                           }
                         )
-                            |> Table.viewDetails scope (GenericExamples.table max)
+                            |> Table.viewDetails scope (GenericExamples.table max genericScope)
                 )
 
         Nothing ->
@@ -667,19 +675,23 @@ textileProductsExplorer session tableConfig tableState maybeId =
 
 productCategoriesExplorer :
     Session
-    -> Scope
+    -> Scope.GenericScope
     -> Table.Config ProductCategory Msg
     -> SortableTable.State
     -> Maybe ProductCategory.Id
     -> List (Html Msg)
-productCategoriesExplorer session scope tableConfig tableState maybeId =
+productCategoriesExplorer session genericScope tableConfig tableState maybeId =
+    let
+        scope =
+            Scope.Generic genericScope
+    in
     [ session.db.products
         |> ProductCategory.findByScope scope
         |> Table.viewList (.id >> ProductCategory.idToString >> OpenDetail)
             tableConfig
             tableState
             scope
-            (ProductCategories.table session)
+            (ProductCategories.table session genericScope)
     , case maybeId of
         Just id ->
             detailsModal
@@ -688,7 +700,7 @@ productCategoriesExplorer session scope tableConfig tableState maybeId =
                         alert error
 
                     Ok product ->
-                        Table.viewDetails scope (ProductCategories.table session) product
+                        Table.viewDetails scope (ProductCategories.table session genericScope) product
                 )
 
         Nothing ->
@@ -831,7 +843,7 @@ exploreView ({ db } as session) { facetValues, scope, dataset, tableState, searc
             foodIngredientsExplorer db tableConfig tableState maybeId
 
         Dataset.GenericExamples genericScope maybeId ->
-            genericExamplesExplorer session tableConfig tableState (Scope.Generic genericScope) maybeId
+            genericExamplesExplorer session tableConfig tableState genericScope maybeId
 
         Dataset.Impacts maybeTrigram ->
             impactsExplorer db.definitions tableConfig tableState scope maybeTrigram
@@ -840,7 +852,7 @@ exploreView ({ db } as session) { facetValues, scope, dataset, tableState, searc
             processesExplorer session scope_ tableConfig tableState maybeId
 
         Dataset.ProductCategory genericScope maybeId ->
-            productCategoriesExplorer session (Scope.Generic genericScope) tableConfig tableState maybeId
+            productCategoriesExplorer session genericScope tableConfig tableState maybeId
 
         Dataset.TextileExamples maybeId ->
             textileExamplesExplorer session tableConfig tableState maybeId

--- a/src/Page/Explore.elm
+++ b/src/Page/Explore.elm
@@ -156,25 +156,14 @@ update session msg model =
                         Dataset.Impacts _ ->
                             Dataset.Impacts Nothing
 
-                        Dataset.ProductCategory _ _ ->
-                            Dataset.ProductCategory scope Nothing
+                        Dataset.Processes _ _ ->
+                            Dataset.Processes scope Nothing
+
+                        Dataset.ProductCategory genericScope _ ->
+                            Dataset.ProductCategory (Scope.toGenericScope scope |> Maybe.withDefault genericScope) Nothing
 
                         _ ->
-                            case scope of
-                                Scope.Food ->
-                                    Dataset.FoodExamples Nothing
-
-                                Scope.Generic Scope.Food2 ->
-                                    Dataset.GenericExamples Scope.Food2 Nothing
-
-                                Scope.Generic Scope.Object ->
-                                    Dataset.GenericExamples Scope.Object Nothing
-
-                                Scope.Generic Scope.Veli ->
-                                    Dataset.GenericExamples Scope.Veli Nothing
-
-                                Scope.Textile ->
-                                    Dataset.TextileExamples Nothing
+                            Dataset.defaultDatasetFor scope
                       )
                         |> Route.Explore scope
                         |> Route.toString
@@ -819,8 +808,8 @@ exploreView ({ db } as session) { facetValues, scope, dataset, tableState, searc
         Dataset.Processes scope_ maybeId ->
             processesExplorer session scope_ tableConfig tableState maybeId
 
-        Dataset.ProductCategory scope_ maybeId ->
-            productCategoriesExplorer session scope_ tableConfig tableState maybeId
+        Dataset.ProductCategory genericScope maybeId ->
+            productCategoriesExplorer session (Scope.Generic genericScope) tableConfig tableState maybeId
 
         Dataset.TextileExamples maybeId ->
             textileExamplesExplorer session tableConfig tableState maybeId

--- a/src/Page/Explore/GenericExamples.elm
+++ b/src/Page/Explore/GenericExamples.elm
@@ -17,6 +17,10 @@ import Route
 import Views.Icon as Icon
 
 
+
+-- TODO: add score per 100g column for all examples
+
+
 table :
     { maxScore : Float }
     -> { detailed : Bool, scope : Scope }

--- a/src/Page/Explore/GenericExamples.elm
+++ b/src/Page/Explore/GenericExamples.elm
@@ -1,6 +1,6 @@
 module Page.Explore.GenericExamples exposing (table)
 
-{-| Note: This module is used to display object, veli and food2 examples.
+{-| Note: This module is used to display generic examples.
 -}
 
 import Data.Component as Component
@@ -17,15 +17,11 @@ import Route
 import Views.Icon as Icon
 
 
-
--- TODO: add score per 100g column for all examples
-
-
 table :
-    { maxScore : Float }
+    { maxScore : Float, maxPer100g : Float }
     -> { detailed : Bool, scope : Scope }
-    -> Table ( Example Component.Query, { score : Float } ) String msg
-table { maxScore } { detailed, scope } =
+    -> Table ( Example Component.Query, { score : Float, per100g : Float } ) String msg
+table { maxScore, maxPer100g } { detailed, scope } =
     let
         genericScope =
             scope |> Scope.toGenericScope |> Maybe.withDefault Scope.Object
@@ -68,6 +64,12 @@ table { maxScore } { detailed, scope } =
           , toCell =
                 \( _, { score } ) ->
                     Common.impactBarGraph detailed maxScore score
+          }
+        , { label = "Coût Environnemental/100g"
+          , toValue = Table.FloatValue (Tuple.second >> .per100g)
+          , toCell =
+                \( _, { per100g } ) ->
+                    Common.impactBarGraph detailed maxPer100g per100g
           }
         , { label = ""
           , toValue = Table.NoValue

--- a/src/Page/Explore/GenericExamples.elm
+++ b/src/Page/Explore/GenericExamples.elm
@@ -1,6 +1,6 @@
-module Page.Explore.ObjectExamples exposing (table)
+module Page.Explore.GenericExamples exposing (table)
 
-{-| Note: This module is used to display both objects and veli examples.
+{-| Note: This module is used to display object, veli and food2 examples.
 -}
 
 import Data.Component as Component
@@ -22,27 +22,18 @@ table :
     -> { detailed : Bool, scope : Scope }
     -> Table ( Example Component.Query, { score : Float } ) String msg
 table { maxScore } { detailed, scope } =
-    { filename = "examples"
+    { filename = Scope.toString scope ++ "-examples"
     , toId = Tuple.first >> .id >> Uuid.toString
     , toRoute =
-        Tuple.first
-            >> .id
-            >> Just
-            >> (case scope of
-                    Scope.Generic Scope.Food2 ->
-                        -- FIXME: we should eventually have food2 examples
-                        Dataset.ObjectExamples
+        \example ->
+            let
+                maybeId =
+                    example |> Tuple.first |> .id |> Just
 
-                    Scope.Generic Scope.Object ->
-                        Dataset.ObjectExamples
-
-                    Scope.Generic Scope.Veli ->
-                        Dataset.VeliExamples
-
-                    _ ->
-                        Dataset.ObjectExamples
-               )
-            >> Route.Explore scope
+                genericScope =
+                    scope |> Scope.toGenericScope |> Maybe.withDefault Scope.Object
+            in
+            Route.Explore scope (Dataset.GenericExamples genericScope maybeId)
     , toSearchableWords = Tuple.first >> Example.toSearchableString >> Text.toWords
     , facets = []
     , legend = []
@@ -55,6 +46,8 @@ table { maxScore } { detailed, scope } =
           , toValue = Table.StringValue (Tuple.first >> .scope >> Scope.toLabel)
           , toCell = Tuple.first >> .scope >> Scope.toLabel >> text
           }
+
+        -- FIXME: this column should eventually be replaced with the product category
         , { label = "Catégorie"
           , toValue = Table.StringValue (Tuple.first >> .category)
           , toCell =
@@ -77,8 +70,6 @@ table { maxScore } { detailed, scope } =
                 \( example, _ ) ->
                     a
                         [ class "btn btn-light btn-sm w-100"
-
-                        -- FIXME: multiple exlorer for Veli
                         , Route.href <| Route.GenericSimulatorExample example.scope example.id
                         , title <| "Charger " ++ example.name
                         ]

--- a/src/Page/Explore/GenericExamples.elm
+++ b/src/Page/Explore/GenericExamples.elm
@@ -19,13 +19,10 @@ import Views.Icon as Icon
 
 table :
     { maxScore : Float, maxPer100g : Float }
+    -> Scope.GenericScope
     -> { detailed : Bool, scope : Scope }
     -> Table ( Example Component.Query, { score : Float, per100g : Float } ) String msg
-table { maxScore, maxPer100g } { detailed, scope } =
-    let
-        genericScope =
-            scope |> Scope.toGenericScope |> Maybe.withDefault Scope.Object
-    in
+table { maxScore, maxPer100g } genericScope { detailed, scope } =
     { filename = Scope.toString scope ++ "-examples"
     , toId = Tuple.first >> .id >> Uuid.toString
     , toRoute =

--- a/src/Page/Explore/GenericExamples.elm
+++ b/src/Page/Explore/GenericExamples.elm
@@ -25,13 +25,7 @@ table :
 table { maxScore, maxPer100g } genericScope { detailed, scope } =
     { filename = Scope.toString scope ++ "-examples"
     , toId = Tuple.first >> .id >> Uuid.toString
-    , toRoute =
-        \example ->
-            let
-                maybeId =
-                    example |> Tuple.first |> .id |> Just
-            in
-            Route.Explore scope (Dataset.GenericExamples genericScope maybeId)
+    , toRoute = Tuple.first >> .id >> Just >> Dataset.GenericExamples genericScope >> Route.Explore scope
     , toSearchableWords = Tuple.first >> Example.toSearchableString >> Text.toWords
     , facets = []
     , legend = []

--- a/src/Page/Explore/GenericExamples.elm
+++ b/src/Page/Explore/GenericExamples.elm
@@ -26,6 +26,10 @@ table :
     -> { detailed : Bool, scope : Scope }
     -> Table ( Example Component.Query, { score : Float } ) String msg
 table { maxScore } { detailed, scope } =
+    let
+        genericScope =
+            scope |> Scope.toGenericScope |> Maybe.withDefault Scope.Object
+    in
     { filename = Scope.toString scope ++ "-examples"
     , toId = Tuple.first >> .id >> Uuid.toString
     , toRoute =
@@ -33,9 +37,6 @@ table { maxScore } { detailed, scope } =
             let
                 maybeId =
                     example |> Tuple.first |> .id |> Just
-
-                genericScope =
-                    scope |> Scope.toGenericScope |> Maybe.withDefault Scope.Object
             in
             Route.Explore scope (Dataset.GenericExamples genericScope maybeId)
     , toSearchableWords = Tuple.first >> Example.toSearchableString >> Text.toWords
@@ -74,7 +75,7 @@ table { maxScore } { detailed, scope } =
                 \( example, _ ) ->
                     a
                         [ class "btn btn-light btn-sm w-100"
-                        , Route.href <| Route.GenericSimulatorExample example.scope example.id
+                        , Route.href <| Route.GenericSimulatorExample genericScope example.id
                         , title <| "Charger " ++ example.name
                         ]
                         [ Icon.search ]

--- a/src/Page/Explore/ProductCategories.elm
+++ b/src/Page/Explore/ProductCategories.elm
@@ -13,9 +13,15 @@ import Route
 
 table : Session -> { detailed : Bool, scope : Scope } -> Table ProductCategory String msg
 table { db } { scope } =
+    let
+        genericScope =
+            scope
+                |> Scope.toGenericScope
+                |> Maybe.withDefault Scope.Object
+    in
     { filename = Scope.toString scope ++ "-product-categories"
     , toId = .id >> ProductCategory.idToString
-    , toRoute = .id >> Just >> Dataset.ProductCategory scope >> Route.Explore scope
+    , toRoute = \{ id } -> Route.Explore scope (Dataset.ProductCategory genericScope (Just id))
     , toSearchableWords = ProductCategory.toSearchableString >> Text.toWords
     , facets =
         [ { key = "Transport réfrigéré"

--- a/src/Page/Explore/ProductCategories.elm
+++ b/src/Page/Explore/ProductCategories.elm
@@ -12,10 +12,10 @@ import Route
 
 
 table : Session -> Scope.GenericScope -> { detailed : Bool, scope : Scope } -> Table ProductCategory String msg
-table { db } genericScope { scope } =
-    { filename = Scope.toString scope ++ "-product-categories"
+table { db } genericScope _ =
+    { filename = Scope.toStringGeneric genericScope ++ "-product-categories"
     , toId = .id >> ProductCategory.idToString
-    , toRoute = \{ id } -> Route.Explore scope (Dataset.ProductCategory genericScope (Just id))
+    , toRoute = \{ id } -> Route.Explore (Scope.Generic genericScope) (Dataset.ProductCategory genericScope (Just id))
     , toSearchableWords = ProductCategory.toSearchableString >> Text.toWords
     , facets =
         [ { key = "Transport réfrigéré"

--- a/src/Page/Explore/ProductCategories.elm
+++ b/src/Page/Explore/ProductCategories.elm
@@ -11,14 +11,8 @@ import Page.Explore.Table as Table exposing (Table)
 import Route
 
 
-table : Session -> { detailed : Bool, scope : Scope } -> Table ProductCategory String msg
-table { db } { scope } =
-    let
-        genericScope =
-            scope
-                |> Scope.toGenericScope
-                |> Maybe.withDefault Scope.Object
-    in
+table : Session -> Scope.GenericScope -> { detailed : Bool, scope : Scope } -> Table ProductCategory String msg
+table { db } genericScope { scope } =
     { filename = Scope.toString scope ++ "-product-categories"
     , toId = .id >> ProductCategory.idToString
     , toRoute = \{ id } -> Route.Explore scope (Dataset.ProductCategory genericScope (Just id))

--- a/src/Page/Generic.elm
+++ b/src/Page/Generic.elm
@@ -27,7 +27,7 @@ import Data.Key as Key
 import Data.Plausible as Plausible
 import Data.Process as Process exposing (Process)
 import Data.Process.Category as Category exposing (Category)
-import Data.Scope exposing (Scope)
+import Data.Scope as Scope exposing (Scope)
 import Data.Session as Session exposing (Session)
 import Data.Split exposing (Split)
 import Data.Unit as Unit
@@ -1009,6 +1009,9 @@ simulatorView ({ componentConfig } as session) ({ scope } as model) =
     let
         currentQuery =
             session |> Session.objectQueryFromScope scope
+
+        genericScope =
+            scope |> Scope.toGenericScope |> Maybe.withDefault Scope.Object
     in
     div [ class "row" ]
         [ div [ class "col-lg-8 bg-white" ]
@@ -1021,8 +1024,7 @@ simulatorView ({ componentConfig } as session) ({ scope } as model) =
                     , helpUrl = Nothing
                     , onOpen = SelectExampleModal >> List.singleton >> SetModals
                     , routes =
-                        -- FIXME: explore route object/veli
-                        { explore = Route.Explore scope (Dataset.ObjectExamples Nothing)
+                        { explore = Route.Explore scope (Dataset.GenericExamples genericScope Nothing)
                         , load = Route.GenericSimulatorExample scope
                         , scopeHome = Route.GenericSimulatorHome scope
                         }

--- a/src/Page/Generic.elm
+++ b/src/Page/Generic.elm
@@ -21,9 +21,9 @@ import Data.Country.Code as CountryCode
 import Data.Dataset as Dataset
 import Data.Db exposing (Db)
 import Data.Example as Example exposing (Example)
+import Data.Generic.Simulator as Simulator
 import Data.Impact.Definition as Definition exposing (Definition)
 import Data.Key as Key
-import Data.Object.Simulator as Simulator
 import Data.Plausible as Plausible
 import Data.Process as Process exposing (Process)
 import Data.Process.Category as Category exposing (Category)

--- a/src/Page/Generic.elm
+++ b/src/Page/Generic.elm
@@ -330,6 +330,9 @@ updateQuery query ({ model, session } as pageUpdate) =
 update : Session -> Msg -> Model -> PageUpdate Model Msg
 update ({ navKey } as session) msg model =
     let
+        globalScope =
+            Scope.Generic model.genericScope
+
         query =
             session
                 |> Session.genericQuery model.genericScope
@@ -534,7 +537,7 @@ update ({ navKey } as session) msg model =
         ( OpenComparator, _ ) ->
             { model | modals = [ ComparatorModal ] }
                 |> createPageUpdate (session |> Session.checkComparedSimulations)
-                |> App.withCmds [ Plausible.send session <| Plausible.ComparatorOpened (Scope.Generic model.genericScope) ]
+                |> App.withCmds [ Plausible.send session <| Plausible.ComparatorOpened globalScope ]
 
         ( RemoveComponentItem itemIndex, _ ) ->
             { model
@@ -545,7 +548,7 @@ update ({ navKey } as session) msg model =
             }
                 |> createPageUpdate session
                 |> updateQuery (query |> Component.mapItems (LE.removeAt itemIndex))
-                |> App.withCmds [ Plausible.send session <| Plausible.ComponentUpdated (Scope.Generic model.genericScope) ]
+                |> App.withCmds [ Plausible.send session <| Plausible.ComponentUpdated globalScope ]
 
         ( RemoveAssemblyOperation index, _ ) ->
             createPageUpdate session model
@@ -558,7 +561,7 @@ update ({ navKey } as session) msg model =
         ( RemoveElement targetElement, _ ) ->
             createPageUpdate session model
                 |> updateQuery (query |> Component.mapItems (Component.removeElement targetElement))
-                |> App.withCmds [ Plausible.send session <| Plausible.ComponentUpdated (Scope.Generic model.genericScope) ]
+                |> App.withCmds [ Plausible.send session <| Plausible.ComponentUpdated globalScope ]
 
         ( RemoveElementTransform targetElement transformIndex, _ ) ->
             createPageUpdate session model
@@ -567,7 +570,7 @@ update ({ navKey } as session) msg model =
                         |> Component.mapItems
                             (Component.removeElementTransform targetElement transformIndex)
                     )
-                |> App.withCmds [ Plausible.send session <| Plausible.ComponentUpdated (Scope.Generic model.genericScope) ]
+                |> App.withCmds [ Plausible.send session <| Plausible.ComponentUpdated globalScope ]
 
         ( RemovePackaging index, _ ) ->
             createPageUpdate session model
@@ -594,7 +597,7 @@ update ({ navKey } as session) msg model =
                                 |> Bookmark.Generic model.genericScope
                                 |> SaveBookmarkWithTime model.bookmarkName
                             )
-                    , Plausible.send session <| Plausible.BookmarkSaved (Scope.Generic model.genericScope)
+                    , Plausible.send session <| Plausible.BookmarkSaved globalScope
                     ]
 
         ( SaveBookmarkWithTime name bookmarkQuery now, _ ) ->
@@ -638,7 +641,7 @@ update ({ navKey } as session) msg model =
                 |> createPageUpdate session
                 |> App.withCmds
                     [ ComparatorView.comparisonTypeToString displayChoice
-                        |> Plausible.ComparisonTypeSelected (Scope.Generic model.genericScope)
+                        |> Plausible.ComparisonTypeSelected globalScope
                         |> Plausible.send session
                     ]
 
@@ -653,7 +656,7 @@ update ({ navKey } as session) msg model =
                         |> Route.GenericSimulator model.genericScope trigram
                         |> Route.toString
                         |> Navigation.pushUrl navKey
-                    , Plausible.send session <| Plausible.ImpactSelected (Scope.Generic model.genericScope) trigram
+                    , Plausible.send session <| Plausible.ImpactSelected globalScope trigram
                     ]
 
         ( SwitchImpactsTab impactsTab, _ ) ->
@@ -661,7 +664,7 @@ update ({ navKey } as session) msg model =
                 |> createPageUpdate session
                 |> App.withCmds
                     [ ImpactTabs.tabToString impactsTab
-                        |> Plausible.TabSelected (Scope.Generic model.genericScope)
+                        |> Plausible.TabSelected globalScope
                         |> Plausible.send session
                     ]
 
@@ -698,7 +701,7 @@ update ({ navKey } as session) msg model =
                     (query
                         |> Component.mapItems (Component.updateItem itemIndex (\item -> { item | quantity = quantity }))
                     )
-                |> App.withCmds [ Plausible.send session <| Plausible.ComponentUpdated (Scope.Generic model.genericScope) ]
+                |> App.withCmds [ Plausible.send session <| Plausible.ComponentUpdated globalScope ]
 
         ( UpdateConsumptionAmount index (Just amount), _ ) ->
             createPageUpdate session model
@@ -745,7 +748,7 @@ update ({ navKey } as session) msg model =
                         |> Component.mapItems
                             (Component.updateElementMaterialCountry targetElement maybeCountryCode)
                     )
-                |> App.withCmds [ Plausible.send session <| Plausible.ComponentUpdated (Scope.Generic model.genericScope) ]
+                |> App.withCmds [ Plausible.send session <| Plausible.ComponentUpdated globalScope ]
 
         ( UpdateElementTransformCountry targetElement transformIndex maybeCountryCode, _ ) ->
             createPageUpdate session model
@@ -754,7 +757,7 @@ update ({ navKey } as session) msg model =
                         |> Component.mapItems
                             (Component.updateElementTransformCountry targetElement transformIndex maybeCountryCode)
                     )
-                |> App.withCmds [ Plausible.send session <| Plausible.ComponentUpdated (Scope.Generic model.genericScope) ]
+                |> App.withCmds [ Plausible.send session <| Plausible.ComponentUpdated globalScope ]
 
         ( UpdatePackagingAmount index (Just amount), _ ) ->
             createPageUpdate session model

--- a/src/Page/Generic.elm
+++ b/src/Page/Generic.elm
@@ -27,7 +27,7 @@ import Data.Key as Key
 import Data.Plausible as Plausible
 import Data.Process as Process exposing (Process)
 import Data.Process.Category as Category exposing (Category)
-import Data.Scope as Scope exposing (Scope)
+import Data.Scope as Scope exposing (GenericScope, Scope)
 import Data.Session as Session exposing (Session)
 import Data.Split exposing (Split)
 import Data.Unit as Unit
@@ -76,7 +76,7 @@ type alias Model =
     , initialQuery : Component.Query
     , modals : List Modal
     , lifeCycle : Result String Component.LifeCycle
-    , scope : Scope
+    , genericScope : GenericScope
     }
 
 
@@ -155,21 +155,24 @@ type Msg
     | UpdateRenamedBookmarkName Bookmark String
 
 
-init : Scope -> Definition.Trigram -> Maybe Component.Query -> Session -> PageUpdate Model Msg
-init scope trigram maybeUrlQuery session =
+init : GenericScope -> Definition.Trigram -> Maybe Component.Query -> Session -> PageUpdate Model Msg
+init genericScope trigram maybeUrlQuery session =
     let
+        scope =
+            Scope.Generic genericScope
+
         initialQuery =
             -- If we received a serialized query from the URL, use it
             -- Otherwise, fallback to use session query
             maybeUrlQuery
-                |> Maybe.withDefault (Session.objectQueryFromScope scope session)
+                |> Maybe.withDefault (Session.genericQuery genericScope session)
 
         examples =
-            session.db.object.examples
+            session.db.generic.examples
                 |> Example.forScope scope
     in
     { activeImpactsTab = ImpactTabs.StagesImpactsTab
-    , bookmarkName = initialQuery |> suggestBookmarkName session scope examples
+    , bookmarkName = initialQuery |> suggestBookmarkName session genericScope examples
     , bookmarkTab = BookmarkView.SaveTab
     , comparisonType =
         if Session.isAuthenticated session then
@@ -195,9 +198,9 @@ init scope trigram maybeUrlQuery session =
                 , db = session.db
                 , scope = scope
                 }
-    , scope = scope
+    , genericScope = genericScope
     }
-        |> createPageUpdate (session |> Session.updateObjectQuery scope initialQuery)
+        |> createPageUpdate (session |> Session.updateGenericQuery genericScope initialQuery)
         |> App.withCmds
             (case maybeUrlQuery of
                 -- If we do have an URL query, we either come from a bookmark, a saved simulation click or
@@ -212,11 +215,14 @@ init scope trigram maybeUrlQuery session =
             )
 
 
-initFromExample : Session -> Scope -> Uuid -> PageUpdate Model Msg
-initFromExample session scope uuid =
+initFromExample : Session -> GenericScope -> Uuid -> PageUpdate Model Msg
+initFromExample session genericScope uuid =
     let
+        scope =
+            Scope.Generic genericScope
+
         examples =
-            session.db.object.examples
+            session.db.generic.examples
                 |> Example.forScope scope
 
         example =
@@ -226,10 +232,10 @@ initFromExample session scope uuid =
         exampleQuery =
             example
                 |> Result.map .query
-                |> Result.withDefault (Session.objectQueryFromScope scope session)
+                |> Result.withDefault (Session.genericQuery genericScope session)
     in
     { activeImpactsTab = ImpactTabs.StagesImpactsTab
-    , bookmarkName = exampleQuery |> suggestBookmarkName session scope examples
+    , bookmarkName = exampleQuery |> suggestBookmarkName session genericScope examples
     , bookmarkTab = BookmarkView.SaveTab
     , comparisonType = ComparatorView.Subscores
     , contributionDescription = ""
@@ -250,9 +256,9 @@ initFromExample session scope uuid =
                 , db = session.db
                 , scope = scope
                 }
-    , scope = scope
+    , genericScope = genericScope
     }
-        |> createPageUpdate (session |> Session.updateObjectQuery scope exampleQuery)
+        |> createPageUpdate (session |> Session.updateGenericQuery genericScope exampleQuery)
         |> App.withCmds [ Ports.scrollTo { x = 0, y = 0 } ]
 
 
@@ -271,17 +277,13 @@ selectProductCategory session query maybeProductId =
             updateQuery (query |> Component.updateProduct Nothing)
 
 
-suggestBookmarkName : Session -> Scope -> List (Example Component.Query) -> Component.Query -> String
-suggestBookmarkName { db, store } scope examples query =
+suggestBookmarkName : Session -> GenericScope -> List (Example Component.Query) -> Component.Query -> String
+suggestBookmarkName { db, store } genericScope examples query =
     let
         -- Existing user bookmark?
         userBookmark =
-            Scope.toGenericScope scope
-                |> Maybe.andThen
-                    (\genericScope ->
-                        store.bookmarks
-                            |> Bookmark.findByGenericQuery genericScope query
-                    )
+            store.bookmarks
+                |> Bookmark.findByGenericQuery genericScope query
 
         -- Matching product example name?
         exampleName =
@@ -304,20 +306,24 @@ suggestBookmarkName { db, store } scope examples query =
 
 updateQuery : Component.Query -> PageUpdate Model Msg -> PageUpdate Model Msg
 updateQuery query ({ model, session } as pageUpdate) =
+    let
+        scope =
+            Scope.Generic model.genericScope
+    in
     { pageUpdate
         | model =
             { model
                 | initialQuery = query
-                , bookmarkName = query |> suggestBookmarkName session model.scope model.examples
+                , bookmarkName = query |> suggestBookmarkName session model.genericScope model.examples
                 , lifeCycle =
                     query
                         |> Simulator.compute
                             { config = session.componentConfig
                             , db = session.db
-                            , scope = model.scope
+                            , scope = scope
                             }
             }
-        , session = session |> Session.updateObjectQuery model.scope query
+        , session = session |> Session.updateGenericQuery model.genericScope query
     }
 
 
@@ -326,12 +332,7 @@ update ({ navKey } as session) msg model =
     let
         query =
             session
-                |> Session.objectQueryFromScope model.scope
-
-        genericScope =
-            model.scope
-                |> Scope.toGenericScope
-                |> Maybe.withDefault Scope.Object
+                |> Session.genericQuery model.genericScope
     in
     case ( msg, model.modals ) of
         ( AppendModal modal, modals ) ->
@@ -533,7 +534,7 @@ update ({ navKey } as session) msg model =
         ( OpenComparator, _ ) ->
             { model | modals = [ ComparatorModal ] }
                 |> createPageUpdate (session |> Session.checkComparedSimulations)
-                |> App.withCmds [ Plausible.send session <| Plausible.ComparatorOpened model.scope ]
+                |> App.withCmds [ Plausible.send session <| Plausible.ComparatorOpened (Scope.Generic model.genericScope) ]
 
         ( RemoveComponentItem itemIndex, _ ) ->
             { model
@@ -544,7 +545,7 @@ update ({ navKey } as session) msg model =
             }
                 |> createPageUpdate session
                 |> updateQuery (query |> Component.mapItems (LE.removeAt itemIndex))
-                |> App.withCmds [ Plausible.send session <| Plausible.ComponentUpdated model.scope ]
+                |> App.withCmds [ Plausible.send session <| Plausible.ComponentUpdated (Scope.Generic model.genericScope) ]
 
         ( RemoveAssemblyOperation index, _ ) ->
             createPageUpdate session model
@@ -557,7 +558,7 @@ update ({ navKey } as session) msg model =
         ( RemoveElement targetElement, _ ) ->
             createPageUpdate session model
                 |> updateQuery (query |> Component.mapItems (Component.removeElement targetElement))
-                |> App.withCmds [ Plausible.send session <| Plausible.ComponentUpdated model.scope ]
+                |> App.withCmds [ Plausible.send session <| Plausible.ComponentUpdated (Scope.Generic model.genericScope) ]
 
         ( RemoveElementTransform targetElement transformIndex, _ ) ->
             createPageUpdate session model
@@ -566,7 +567,7 @@ update ({ navKey } as session) msg model =
                         |> Component.mapItems
                             (Component.removeElementTransform targetElement transformIndex)
                     )
-                |> App.withCmds [ Plausible.send session <| Plausible.ComponentUpdated model.scope ]
+                |> App.withCmds [ Plausible.send session <| Plausible.ComponentUpdated (Scope.Generic model.genericScope) ]
 
         ( RemovePackaging index, _ ) ->
             createPageUpdate session model
@@ -590,19 +591,19 @@ update ({ navKey } as session) msg model =
                     [ Time.now
                         |> Task.perform
                             (query
-                                |> Bookmark.Generic genericScope
+                                |> Bookmark.Generic model.genericScope
                                 |> SaveBookmarkWithTime model.bookmarkName
                             )
-                    , Plausible.send session <| Plausible.BookmarkSaved model.scope
+                    , Plausible.send session <| Plausible.BookmarkSaved (Scope.Generic model.genericScope)
                     ]
 
-        ( SaveBookmarkWithTime name objectQuery now, _ ) ->
+        ( SaveBookmarkWithTime name bookmarkQuery now, _ ) ->
             model
                 |> createPageUpdate
                     (session
                         |> Session.saveBookmark
                             { name = String.trim name
-                            , query = objectQuery
+                            , query = bookmarkQuery
                             , created = now
                             , genericScope = Nothing
                             }
@@ -628,7 +629,7 @@ update ({ navKey } as session) msg model =
             { model | bookmarkTab = bookmarkTab }
                 |> createPageUpdate session
                 |> App.withCmds
-                    [ Plausible.TabSelected model.scope "Partager"
+                    [ Plausible.TabSelected (Scope.Generic model.genericScope) "Partager"
                         |> Plausible.sendIf session (bookmarkTab == BookmarkView.ShareTab)
                     ]
 
@@ -637,7 +638,7 @@ update ({ navKey } as session) msg model =
                 |> createPageUpdate session
                 |> App.withCmds
                     [ ComparatorView.comparisonTypeToString displayChoice
-                        |> Plausible.ComparisonTypeSelected model.scope
+                        |> Plausible.ComparisonTypeSelected (Scope.Generic model.genericScope)
                         |> Plausible.send session
                     ]
 
@@ -649,10 +650,10 @@ update ({ navKey } as session) msg model =
             createPageUpdate session model
                 |> App.withCmds
                     [ Just query
-                        |> Route.GenericSimulator genericScope trigram
+                        |> Route.GenericSimulator model.genericScope trigram
                         |> Route.toString
                         |> Navigation.pushUrl navKey
-                    , Plausible.send session <| Plausible.ImpactSelected model.scope trigram
+                    , Plausible.send session <| Plausible.ImpactSelected (Scope.Generic model.genericScope) trigram
                     ]
 
         ( SwitchImpactsTab impactsTab, _ ) ->
@@ -660,7 +661,7 @@ update ({ navKey } as session) msg model =
                 |> createPageUpdate session
                 |> App.withCmds
                     [ ImpactTabs.tabToString impactsTab
-                        |> Plausible.TabSelected model.scope
+                        |> Plausible.TabSelected (Scope.Generic model.genericScope)
                         |> Plausible.send session
                     ]
 
@@ -697,7 +698,7 @@ update ({ navKey } as session) msg model =
                     (query
                         |> Component.mapItems (Component.updateItem itemIndex (\item -> { item | quantity = quantity }))
                     )
-                |> App.withCmds [ Plausible.send session <| Plausible.ComponentUpdated model.scope ]
+                |> App.withCmds [ Plausible.send session <| Plausible.ComponentUpdated (Scope.Generic model.genericScope) ]
 
         ( UpdateConsumptionAmount index (Just amount), _ ) ->
             createPageUpdate session model
@@ -744,7 +745,7 @@ update ({ navKey } as session) msg model =
                         |> Component.mapItems
                             (Component.updateElementMaterialCountry targetElement maybeCountryCode)
                     )
-                |> App.withCmds [ Plausible.send session <| Plausible.ComponentUpdated model.scope ]
+                |> App.withCmds [ Plausible.send session <| Plausible.ComponentUpdated (Scope.Generic model.genericScope) ]
 
         ( UpdateElementTransformCountry targetElement transformIndex maybeCountryCode, _ ) ->
             createPageUpdate session model
@@ -753,7 +754,7 @@ update ({ navKey } as session) msg model =
                         |> Component.mapItems
                             (Component.updateElementTransformCountry targetElement transformIndex maybeCountryCode)
                     )
-                |> App.withCmds [ Plausible.send session <| Plausible.ComponentUpdated model.scope ]
+                |> App.withCmds [ Plausible.send session <| Plausible.ComponentUpdated (Scope.Generic model.genericScope) ]
 
         ( UpdatePackagingAmount index (Just amount), _ ) ->
             createPageUpdate session model
@@ -809,7 +810,7 @@ createExampleContribData model =
             { description = cleanDescription
             , name = cleanName
             , query = model.initialQuery
-            , scope = model.scope
+            , scope = Scope.Generic model.genericScope
             }
 
 
@@ -845,14 +846,14 @@ selectExample autocompleteState ({ model } as pageUpdate) =
     pageUpdate
         |> updateQuery exampleQuery
         |> App.apply update (SetModals [])
-        |> App.withCmds [ Plausible.send pageUpdate.session <| Plausible.ExampleSelected model.scope ]
+        |> App.withCmds [ Plausible.send pageUpdate.session <| Plausible.ExampleSelected (Scope.Generic model.genericScope) ]
 
 
 selectProductionItem : Component.Query -> Autocomplete Component.ProductionItem -> PageUpdate Model Msg -> PageUpdate Model Msg
 selectProductionItem query autocompleteState ({ model, session } as pageUpdate) =
     let
         plausibleCommand =
-            Plausible.send pageUpdate.session <| Plausible.ComponentAdded model.scope
+            Plausible.send pageUpdate.session <| Plausible.ComponentAdded (Scope.Generic model.genericScope)
     in
     case Autocomplete.selectedValue autocompleteState of
         Just (Component.ComponentItem component) ->
@@ -918,7 +919,7 @@ selectConsumption query autocompleteState ({ model } as pageUpdate) =
                                 ++ [ Component.consumption (Amount.fromFloat 1) process.id ]
                     }
                 |> App.apply update (SetModals [])
-                |> App.withCmds [ Plausible.send pageUpdate.session <| Plausible.ConsumptionAdded model.scope ]
+                |> App.withCmds [ Plausible.send pageUpdate.session <| Plausible.ConsumptionAdded (Scope.Generic model.genericScope) ]
 
         Nothing ->
             pageUpdate |> App.notifyWarning "Aucun composant sélectionné"
@@ -964,14 +965,18 @@ selectProcess category targetItem maybeElementIndex autocompleteState query ({ m
                     pageUpdate
                         |> updateQuery validQuery
                         |> App.apply update (SetModals (List.drop 1 model.modals))
-                        |> App.withCmds [ Plausible.send pageUpdate.session <| Plausible.ComponentUpdated model.scope ]
+                        |> App.withCmds [ Plausible.send pageUpdate.session <| Plausible.ComponentUpdated (Scope.Generic model.genericScope) ]
 
         Nothing ->
             pageUpdate |> App.notifyWarning "Aucun composant sélectionné"
 
 
 editorConfig : Session -> Model -> ComponentView.Config Db Msg
-editorConfig session ({ scope } as model) =
+editorConfig session ({ genericScope } as model) =
+    let
+        scope =
+            Scope.Generic genericScope
+    in
     { componentConfig = session.componentConfig
     , context = ComponentView.GenericContext
     , db = session.db
@@ -988,7 +993,7 @@ editorConfig session ({ scope } as model) =
     , openSelectPackagingModal = SelectPackagingModal >> List.singleton >> SetModals
     , openSelectProcessModal = \c ti mi ac -> AppendModal (SelectProcessModal c ti mi ac)
     , openSelectProductionItem = AddProductionItemModal >> List.singleton >> SetModals
-    , query = session |> Session.objectQueryFromScope model.scope
+    , query = session |> Session.genericQuery genericScope
     , removeAssemblyOperation = RemoveAssemblyOperation
     , removeConsumption = RemoveConsumption
     , removeElement = RemoveElement
@@ -1014,13 +1019,13 @@ editorConfig session ({ scope } as model) =
 
 
 simulatorView : Session -> Model -> Html Msg
-simulatorView ({ componentConfig } as session) ({ scope } as model) =
+simulatorView ({ componentConfig } as session) ({ genericScope } as model) =
     let
-        currentQuery =
-            session |> Session.objectQueryFromScope scope
+        scope =
+            Scope.Generic genericScope
 
-        genericScope =
-            scope |> Scope.toGenericScope |> Maybe.withDefault Scope.Object
+        currentQuery =
+            session |> Session.genericQuery genericScope
     in
     div [ class "row" ]
         [ div [ class "col-lg-8 bg-white" ]
@@ -1058,7 +1063,7 @@ simulatorView ({ componentConfig } as session) ({ scope } as model) =
               SidebarView.view
                 { noOp = NoOp
                 , session = session
-                , scope = model.scope
+                , scope = scope
 
                 -- Impact selector
                 , selectedImpact = model.impact
@@ -1074,7 +1079,7 @@ simulatorView ({ componentConfig } as session) ({ scope } as model) =
                 , impactTabsConfig =
                     SwitchImpactsTab
                         |> ImpactTabs.createConfig session model.impact model.activeImpactsTab (always NoOp)
-                        |> ImpactTabs.forObject session.db.definitions lifeCycle
+                        |> ImpactTabs.forGeneric session.db.definitions lifeCycle
                         |> Just
 
                 -- Bookmarks
@@ -1203,7 +1208,7 @@ modalView : Session -> Model -> Modal -> Html Msg
 modalView session ({ modals } as model) modal =
     let
         scopeLabels =
-            ComponentView.scopeLabels ComponentView.GenericContext model.scope
+            ComponentView.scopeLabels ComponentView.GenericContext (Scope.Generic model.genericScope)
     in
     case modal of
         AddProductionItemModal autocompleteState ->

--- a/src/Page/Generic.elm
+++ b/src/Page/Generic.elm
@@ -323,6 +323,11 @@ update ({ navKey } as session) msg model =
         query =
             session
                 |> Session.objectQueryFromScope model.scope
+
+        genericScope =
+            model.scope
+                |> Scope.toGenericScope
+                |> Maybe.withDefault Scope.Object
     in
     case ( msg, model.modals ) of
         ( AppendModal modal, modals ) ->
@@ -640,7 +645,7 @@ update ({ navKey } as session) msg model =
             createPageUpdate session model
                 |> App.withCmds
                     [ Just query
-                        |> Route.GenericSimulator model.scope trigram
+                        |> Route.GenericSimulator genericScope trigram
                         |> Route.toString
                         |> Navigation.pushUrl navKey
                     , Plausible.send session <| Plausible.ImpactSelected model.scope trigram
@@ -1025,8 +1030,8 @@ simulatorView ({ componentConfig } as session) ({ scope } as model) =
                     , onOpen = SelectExampleModal >> List.singleton >> SetModals
                     , routes =
                         { explore = Route.Explore scope (Dataset.GenericExamples genericScope Nothing)
-                        , load = Route.GenericSimulatorExample scope
-                        , scopeHome = Route.GenericSimulatorHome scope
+                        , load = Route.GenericSimulatorExample genericScope
+                        , scopeHome = Route.GenericSimulatorHome genericScope
                         }
                     }
                 , ComponentView.productCategorySelectorView

--- a/src/Page/Generic.elm
+++ b/src/Page/Generic.elm
@@ -1,4 +1,4 @@
-module Page.Object exposing
+module Page.Generic exposing
     ( Model
     , Msg
     , init

--- a/src/Page/Generic.elm
+++ b/src/Page/Generic.elm
@@ -169,7 +169,7 @@ init scope trigram maybeUrlQuery session =
                 |> Example.forScope scope
     in
     { activeImpactsTab = ImpactTabs.StagesImpactsTab
-    , bookmarkName = initialQuery |> suggestBookmarkName session examples
+    , bookmarkName = initialQuery |> suggestBookmarkName session scope examples
     , bookmarkTab = BookmarkView.SaveTab
     , comparisonType =
         if Session.isAuthenticated session then
@@ -229,7 +229,7 @@ initFromExample session scope uuid =
                 |> Result.withDefault (Session.objectQueryFromScope scope session)
     in
     { activeImpactsTab = ImpactTabs.StagesImpactsTab
-    , bookmarkName = exampleQuery |> suggestBookmarkName session examples
+    , bookmarkName = exampleQuery |> suggestBookmarkName session scope examples
     , bookmarkTab = BookmarkView.SaveTab
     , comparisonType = ComparatorView.Subscores
     , contributionDescription = ""
@@ -271,13 +271,17 @@ selectProductCategory session query maybeProductId =
             updateQuery (query |> Component.updateProduct Nothing)
 
 
-suggestBookmarkName : Session -> List (Example Component.Query) -> Component.Query -> String
-suggestBookmarkName { db, store } examples query =
+suggestBookmarkName : Session -> Scope -> List (Example Component.Query) -> Component.Query -> String
+suggestBookmarkName { db, store } scope examples query =
     let
         -- Existing user bookmark?
         userBookmark =
-            store.bookmarks
-                |> Bookmark.findByObjectQuery query
+            Scope.toGenericScope scope
+                |> Maybe.andThen
+                    (\genericScope ->
+                        store.bookmarks
+                            |> Bookmark.findByGenericQuery genericScope query
+                    )
 
         -- Matching product example name?
         exampleName =
@@ -304,7 +308,7 @@ updateQuery query ({ model, session } as pageUpdate) =
         | model =
             { model
                 | initialQuery = query
-                , bookmarkName = query |> suggestBookmarkName session model.examples
+                , bookmarkName = query |> suggestBookmarkName session model.scope model.examples
                 , lifeCycle =
                     query
                         |> Simulator.compute
@@ -586,7 +590,7 @@ update ({ navKey } as session) msg model =
                     [ Time.now
                         |> Task.perform
                             (query
-                                |> Bookmark.genericQueryFromScope model.scope
+                                |> Bookmark.Generic genericScope
                                 |> SaveBookmarkWithTime model.bookmarkName
                             )
                     , Plausible.send session <| Plausible.BookmarkSaved model.scope

--- a/src/Page/Generic.elm
+++ b/src/Page/Generic.elm
@@ -1050,7 +1050,7 @@ simulatorView ({ componentConfig } as session) ({ genericScope } as model) =
                     { onSelect = UpdateProduct
                     , products = session.db.products
                     , query = currentQuery
-                    , scope = scope
+                    , scope = genericScope
                     }
                 ]
             , durabilityView componentConfig scope currentQuery.durability

--- a/src/Page/Home.elm
+++ b/src/Page/Home.elm
@@ -120,7 +120,7 @@ viewHero { enabledSections } =
                 , { label = "Calculer l’impact d’un objet"
                   , subLabel = Just "Simulateur en construction"
                   , callToAction = False
-                  , link = RouteLink <| Route.GenericSimulatorHome (Scope.Generic Scope.Object)
+                  , link = RouteLink <| Route.GenericSimulatorHome Scope.Object
                   , testId = "object-callout-button"
                   }
                 )
@@ -128,7 +128,7 @@ viewHero { enabledSections } =
                 , { label = "Calculer l’impact d’un véhicule"
                   , subLabel = Just "Simulateur en construction"
                   , callToAction = False
-                  , link = RouteLink <| Route.GenericSimulatorHome (Scope.Generic Scope.Veli)
+                  , link = RouteLink <| Route.GenericSimulatorHome Scope.Veli
                   , testId = "veli-callout-button"
                   }
                 )

--- a/src/Route.elm
+++ b/src/Route.elm
@@ -32,9 +32,9 @@ type Route
     | FoodBuilder Definition.Trigram (Maybe FoodQuery.Query)
     | FoodBuilderExample Uuid
     | FoodBuilderHome
-    | GenericSimulator Scope Definition.Trigram (Maybe Component.Query)
-    | GenericSimulatorExample Scope Uuid
-    | GenericSimulatorHome Scope
+    | GenericSimulator Scope.GenericScope Definition.Trigram (Maybe Component.Query)
+    | GenericSimulatorExample Scope.GenericScope Uuid
+    | GenericSimulatorHome Scope.GenericScope
     | Home
     | Stats
     | TextileSimulator Definition.Trigram (Maybe TextileQuery.Query)
@@ -63,6 +63,11 @@ parser =
         , Parser.map Explore
             (Parser.s "explore" </> Scope.parse </> Dataset.parseSlug)
 
+        -- Generic simulator routes
+        , parseGenericSimulatorRoutes Scope.Food2 "food2"
+        , parseGenericSimulatorRoutes Scope.Object "object"
+        , parseGenericSimulatorRoutes Scope.Veli "veli"
+
         --
         -- Food specific routes
         --
@@ -78,34 +83,6 @@ parser =
                 </> Example.parseUuid
             )
 
-        -- Food2 specific routes
-        , Parser.map (GenericSimulatorHome (Scope.Generic Scope.Food2))
-            (Parser.s "food2" </> Parser.s "simulator")
-        , Parser.map (GenericSimulator (Scope.Generic Scope.Food2)) <|
-            Parser.s "food2"
-                </> Parser.s "simulator"
-                </> Impact.parseTrigram
-                </> Component.parseBase64Query
-        , Parser.map (GenericSimulatorExample (Scope.Generic Scope.Food2))
-            (Parser.s "food2"
-                </> Parser.s "edit-example"
-                </> Example.parseUuid
-            )
-
-        -- Object specific routes
-        , Parser.map (GenericSimulatorHome (Scope.Generic Scope.Object))
-            (Parser.s "object" </> Parser.s "simulator")
-        , Parser.map (GenericSimulator (Scope.Generic Scope.Object)) <|
-            Parser.s "object"
-                </> Parser.s "simulator"
-                </> Impact.parseTrigram
-                </> Component.parseBase64Query
-        , Parser.map (GenericSimulatorExample (Scope.Generic Scope.Object))
-            (Parser.s "object"
-                </> Parser.s "edit-example"
-                </> Example.parseUuid
-            )
-
         -- Textile specific routes
         , Parser.map TextileSimulatorHome
             (Parser.s "textile" </> Parser.s "simulator")
@@ -115,17 +92,21 @@ parser =
                 </> Parser.s "edit-example"
                 </> Example.parseUuid
             )
+        ]
 
-        -- Veli specific routes
-        , Parser.map (GenericSimulatorHome (Scope.Generic Scope.Veli))
-            (Parser.s "veli" </> Parser.s "simulator")
-        , Parser.map (GenericSimulator (Scope.Generic Scope.Veli)) <|
-            Parser.s "veli"
+
+parseGenericSimulatorRoutes : Scope.GenericScope -> String -> Parser (Route -> a) a
+parseGenericSimulatorRoutes genericScope path =
+    Parser.oneOf
+        [ Parser.map (GenericSimulatorHome genericScope)
+            (Parser.s path </> Parser.s "simulator")
+        , Parser.map (GenericSimulator genericScope) <|
+            Parser.s path
                 </> Parser.s "simulator"
                 </> Impact.parseTrigram
                 </> Component.parseBase64Query
-        , Parser.map (GenericSimulatorExample (Scope.Generic Scope.Veli))
-            (Parser.s "veli"
+        , Parser.map (GenericSimulatorExample genericScope)
+            (Parser.s path
                 </> Parser.s "edit-example"
                 </> Example.parseUuid
             )
@@ -238,24 +219,29 @@ toString route =
                 FoodBuilderHome ->
                     [ "food" ]
 
-                GenericSimulator scope trigram (Just query) ->
-                    [ Scope.toString scope
+                GenericSimulator genericScope trigram (Just query) ->
+                    [ Scope.toString (Scope.Generic genericScope)
                     , "simulator"
                     , Definition.toString trigram
                     , Component.encodeBase64Query query
                     ]
 
-                GenericSimulator scope trigram Nothing ->
-                    [ Scope.toString scope
+                GenericSimulator genericScope trigram Nothing ->
+                    [ Scope.toString (Scope.Generic genericScope)
                     , "simulator"
                     , Definition.toString trigram
                     ]
 
-                GenericSimulatorExample scope uuid ->
-                    [ Scope.toString scope, "edit-example", Uuid.toString uuid ]
+                GenericSimulatorExample genericScope uuid ->
+                    [ Scope.toString (Scope.Generic genericScope)
+                    , "edit-example"
+                    , Uuid.toString uuid
+                    ]
 
-                GenericSimulatorHome scope ->
-                    [ Scope.toString scope, "simulator" ]
+                GenericSimulatorHome genericScope ->
+                    [ Scope.toString (Scope.Generic genericScope)
+                    , "simulator"
+                    ]
 
                 Home ->
                     []

--- a/src/Views/Bookmark.elm
+++ b/src/Views/Bookmark.elm
@@ -359,8 +359,8 @@ bookmarkView cfg ({ name, query } as bookmark) =
                     Just foodQuery
                         |> Route.FoodBuilder cfg.impact.trigram
 
-                Bookmark.Generic genericScope food2Query ->
-                    Just food2Query
+                Bookmark.Generic genericScope genericQuery ->
+                    Just genericQuery
                         |> Route.GenericSimulator genericScope cfg.impact.trigram
 
                 Bookmark.Textile textileQuery ->
@@ -443,12 +443,20 @@ contributeExampleTabView ({ scope, session } as config) =
         isAuthenticated =
             Session.isAuthenticated session
 
+        currentQuery =
+            case Scope.toGenericScope scope of
+                Just genericScope ->
+                    Session.genericQuery genericScope session
+
+                Nothing ->
+                    Component.emptyQuery
+
         simulationIsEmpty =
-            Session.objectQueryFromScope scope session == Component.emptyQuery
+            currentQuery == Component.emptyQuery
 
         simulationExists =
-            session.db.object.examples
-                |> List.any (.query >> (==) (Session.objectQueryFromScope scope session))
+            session.db.generic.examples
+                |> List.any (.query >> (==) currentQuery)
 
         disabledForm =
             config.contribRequestPending || not isAuthenticated || simulationIsEmpty || simulationExists

--- a/src/Views/Bookmark.elm
+++ b/src/Views/Bookmark.elm
@@ -96,9 +96,9 @@ view cfg =
         }
 
 
-buildObjectApiQuery : Scope -> Maybe String -> String -> Component.Query -> String
-buildObjectApiQuery scope maybeToken clientUrl query =
-    -- FIXME: the Food2/Object/Veli API doesn't exist just yet, but we already expose what
+buildGenericApiQuery : Scope -> Maybe String -> String -> Component.Query -> String
+buildGenericApiQuery scope maybeToken clientUrl query =
+    -- FIXME: the generic Food2/Object/Veli API doesn't exist just yet, but we already expose what
     -- could be used when it's live
     (clientUrl ++ "/api/" ++ Scope.toString scope ++ "/simulator")
         |> Text.buildCurlCommand maybeToken
@@ -137,7 +137,7 @@ shareTabView { copyToClipBoard, impact, scope, session } =
                         |> (++) "/"
                         |> (++) session.clientUrl
                     , query
-                        |> buildObjectApiQuery scope (Session.getAccessToken session) session.clientUrl
+                        |> buildGenericApiQuery scope (Session.getAccessToken session) session.clientUrl
                     , Component.encodeQuery query
                         |> Encode.encode 2
                     )
@@ -153,7 +153,7 @@ shareTabView { copyToClipBoard, impact, scope, session } =
                         |> (++) "/"
                         |> (++) session.clientUrl
                     , query
-                        |> buildObjectApiQuery scope (Session.getAccessToken session) session.clientUrl
+                        |> buildGenericApiQuery scope (Session.getAccessToken session) session.clientUrl
                     , Component.encodeQuery query
                         |> Encode.encode 2
                     )
@@ -169,7 +169,7 @@ shareTabView { copyToClipBoard, impact, scope, session } =
                         |> (++) "/"
                         |> (++) session.clientUrl
                     , query
-                        |> buildObjectApiQuery scope (Session.getAccessToken session) session.clientUrl
+                        |> buildGenericApiQuery scope (Session.getAccessToken session) session.clientUrl
                     , Component.encodeQuery query
                         |> Encode.encode 2
                     )

--- a/src/Views/Bookmark.elm
+++ b/src/Views/Bookmark.elm
@@ -132,7 +132,7 @@ shareTabView { copyToClipBoard, impact, scope, session } =
                             session.queries.food2
                     in
                     ( Just query
-                        |> Route.GenericSimulator scope impact.trigram
+                        |> Route.GenericSimulator Scope.Food2 impact.trigram
                         |> Route.toString
                         |> (++) "/"
                         |> (++) session.clientUrl
@@ -148,7 +148,7 @@ shareTabView { copyToClipBoard, impact, scope, session } =
                             session.queries.object
                     in
                     ( Just query
-                        |> Route.GenericSimulator scope impact.trigram
+                        |> Route.GenericSimulator Scope.Object impact.trigram
                         |> Route.toString
                         |> (++) "/"
                         |> (++) session.clientUrl
@@ -164,7 +164,7 @@ shareTabView { copyToClipBoard, impact, scope, session } =
                             session.queries.veli
                     in
                     ( Just query
-                        |> Route.GenericSimulator scope impact.trigram
+                        |> Route.GenericSimulator Scope.Veli impact.trigram
                         |> Route.toString
                         |> (++) "/"
                         |> (++) session.clientUrl
@@ -361,7 +361,7 @@ bookmarkView cfg ({ name, query } as bookmark) =
 
                 Bookmark.Generic genericScope food2Query ->
                     Just food2Query
-                        |> Route.GenericSimulator (Scope.Generic genericScope) cfg.impact.trigram
+                        |> Route.GenericSimulator genericScope cfg.impact.trigram
 
                 Bookmark.Textile textileQuery ->
                     Just textileQuery

--- a/src/Views/Comparator.elm
+++ b/src/Views/Comparator.elm
@@ -8,9 +8,9 @@ import Data.Bookmark as Bookmark exposing (Bookmark)
 import Data.Complement as Complement
 import Data.Component as Component
 import Data.Food.Recipe as Recipe
+import Data.Generic.Simulator as GenericSimulator
 import Data.Impact as Impact
 import Data.Impact.Definition as Definition exposing (Definition, Definitions)
-import Data.Object.Simulator as ObjectSimulator
 import Data.Scope as Scope
 import Data.Session as Session exposing (Session)
 import Data.Textile.Simulator as TextileSimulator
@@ -140,7 +140,7 @@ addToComparison session { name, query } =
 
         Bookmark.Generic genericScope food2Query ->
             food2Query
-                |> ObjectSimulator.compute
+                |> GenericSimulator.compute
                     { config = session.componentConfig
                     , db = session.db
                     , scope = Scope.Generic genericScope
@@ -152,7 +152,7 @@ addToComparison session { name, query } =
                         , label = name
                         , stagesImpacts =
                             lifeCycle
-                                |> ObjectSimulator.toStagesImpacts Definition.Ecs
+                                |> GenericSimulator.toStagesImpacts Definition.Ecs
                         }
                     )
 

--- a/src/Views/Comparator.elm
+++ b/src/Views/Comparator.elm
@@ -138,8 +138,8 @@ addToComparison session { name, query } =
                         }
                     )
 
-        Bookmark.Generic genericScope food2Query ->
-            food2Query
+        Bookmark.Generic genericScope genericQuery ->
+            genericQuery
                 |> GenericSimulator.compute
                     { config = session.componentConfig
                     , db = session.db

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -1848,7 +1848,7 @@ type alias ProductCategorySelector msg =
     { onSelect : Maybe ProductCategory.Id -> msg
     , products : List ProductCategory
     , query : Query
-    , scope : Scope
+    , scope : Scope.GenericScope
     }
 
 

--- a/src/Views/ImpactTabs.elm
+++ b/src/Views/ImpactTabs.elm
@@ -3,7 +3,7 @@ module Views.ImpactTabs exposing
     , Tab(..)
     , createConfig
     , forFood
-    , forObject
+    , forGeneric
     , forTextile
     , tabToString
     , view
@@ -223,8 +223,8 @@ forFood results config =
     }
 
 
-forObject : Definitions -> Component.LifeCycle -> Config msg -> Config msg
-forObject definitions lifeCycle config =
+forGeneric : Definitions -> Component.LifeCycle -> Config msg -> Config msg
+forGeneric definitions lifeCycle config =
     { config
         | complementsImpact =
             lifeCycle.production

--- a/src/Views/Page.elm
+++ b/src/Views/Page.elm
@@ -254,11 +254,11 @@ mainMenuLinks enabledSections =
         , addRouteIf enabledSections.food <|
             Internal [ text "Alimentaire" ] Route.FoodBuilderHome Food
         , addRouteIf enabledSections.objects <|
-            Internal [ text "Alimentaire", sup [] [ text "BÉTA" ] ] (Route.GenericSimulatorHome (Scope.Generic Scope.Food2)) (Generic (Scope.Generic Scope.Food2))
+            Internal [ text "Alimentaire", sup [] [ text "BÉTA" ] ] (Route.GenericSimulatorHome Scope.Food2) (Generic (Scope.Generic Scope.Food2))
         , addRouteIf enabledSections.objects <|
-            Internal [ text "Objets" ] (Route.GenericSimulatorHome (Scope.Generic Scope.Object)) (Generic (Scope.Generic Scope.Object))
+            Internal [ text "Objets" ] (Route.GenericSimulatorHome Scope.Object) (Generic (Scope.Generic Scope.Object))
         , addRouteIf enabledSections.veli <|
-            Internal [ text "Véhicules" ] (Route.GenericSimulatorHome (Scope.Generic Scope.Veli)) (Generic (Scope.Generic Scope.Veli))
+            Internal [ text "Véhicules" ] (Route.GenericSimulatorHome Scope.Veli) (Generic (Scope.Generic Scope.Veli))
         , Just <| Internal [ text "Explorateur" ] (Route.Explore Scope.Textile (Dataset.TextileExamples Nothing)) Explore
         , Just <| Internal [ text "API" ] Route.Api Api
         , Just <| MailTo "Contact" Env.contactEmail
@@ -276,7 +276,7 @@ secondaryMenuLinks enabledSections =
         , Just <| External "CGU" Env.cguUrl
         , Just <| Internal [ text "Admin" ] (Route.Admin AdminSection.ComponentSection) Admin
         , addRouteIf enabledSections.food2 <|
-            Internal [ text "Alimentaire²" ] (Route.GenericSimulatorHome (Scope.Generic Scope.Food2)) (Generic (Scope.Generic Scope.Food2))
+            Internal [ text "Alimentaire²" ] (Route.GenericSimulatorHome Scope.Food2) (Generic (Scope.Generic Scope.Food2))
         ]
 
 

--- a/src/Views/Page.elm
+++ b/src/Views/Page.elm
@@ -40,6 +40,7 @@ type ActivePage
     | Editorial String
     | Explore
     | Food
+      -- FIXME: should be Generic Scope.GenericScope
     | Generic Scope
     | Home
     | Other

--- a/src/Views/Page.elm
+++ b/src/Views/Page.elm
@@ -40,8 +40,8 @@ type ActivePage
     | Editorial String
     | Explore
     | Food
+    | Generic Scope
     | Home
-    | Object Scope
     | Other
     | Stats
     | TextileSimulator
@@ -126,14 +126,14 @@ commonNotices msg activePage =
                 , Markdown.simple [] "**Méthodologie stabilisée.** Calculette en cours de développement"
                 ]
 
-        Object (Scope.Generic Scope.Food2) ->
+        Generic (Scope.Generic Scope.Food2) ->
             Notice.info
                 [ Icon.info
                 , Markdown.simple [] "**Méthodologie stabilisée. Cette version de la calculette remplacera à terme la version initiale.**"
                 , """Contribuez via notre [forum utilisateur](https://chat.ecobalyse.fr/ecobalyse/channels/02_alimentaire_general).""" |> Markdown.simple []
                 ]
 
-        Object (Scope.Generic Scope.Object) ->
+        Generic (Scope.Generic Scope.Object) ->
             Notice.info
                 [ Icon.info
                 , Markdown.simple [] "**Cette version est en cours de développement.**"
@@ -141,7 +141,7 @@ commonNotices msg activePage =
                     |> Markdown.simple []
                 ]
 
-        Object (Scope.Generic Scope.Veli) ->
+        Generic (Scope.Generic Scope.Veli) ->
             Notice.info
                 [ Icon.info
                 , Markdown.simple [] "**Cette version est en cours de développement.** Elle est réservée à des beta-testeurs."
@@ -253,11 +253,11 @@ mainMenuLinks enabledSections =
         , addRouteIf enabledSections.food <|
             Internal [ text "Alimentaire" ] Route.FoodBuilderHome Food
         , addRouteIf enabledSections.objects <|
-            Internal [ text "Alimentaire", sup [] [ text "BÉTA" ] ] (Route.GenericSimulatorHome (Scope.Generic Scope.Food2)) (Object (Scope.Generic Scope.Food2))
+            Internal [ text "Alimentaire", sup [] [ text "BÉTA" ] ] (Route.GenericSimulatorHome (Scope.Generic Scope.Food2)) (Generic (Scope.Generic Scope.Food2))
         , addRouteIf enabledSections.objects <|
-            Internal [ text "Objets" ] (Route.GenericSimulatorHome (Scope.Generic Scope.Object)) (Object (Scope.Generic Scope.Object))
+            Internal [ text "Objets" ] (Route.GenericSimulatorHome (Scope.Generic Scope.Object)) (Generic (Scope.Generic Scope.Object))
         , addRouteIf enabledSections.veli <|
-            Internal [ text "Véhicules" ] (Route.GenericSimulatorHome (Scope.Generic Scope.Veli)) (Object (Scope.Generic Scope.Veli))
+            Internal [ text "Véhicules" ] (Route.GenericSimulatorHome (Scope.Generic Scope.Veli)) (Generic (Scope.Generic Scope.Veli))
         , Just <| Internal [ text "Explorateur" ] (Route.Explore Scope.Textile (Dataset.TextileExamples Nothing)) Explore
         , Just <| Internal [ text "API" ] Route.Api Api
         , Just <| MailTo "Contact" Env.contactEmail
@@ -275,7 +275,7 @@ secondaryMenuLinks enabledSections =
         , Just <| External "CGU" Env.cguUrl
         , Just <| Internal [ text "Admin" ] (Route.Admin AdminSection.ComponentSection) Admin
         , addRouteIf enabledSections.food2 <|
-            Internal [ text "Alimentaire²" ] (Route.GenericSimulatorHome (Scope.Generic Scope.Food2)) (Object (Scope.Generic Scope.Food2))
+            Internal [ text "Alimentaire²" ] (Route.GenericSimulatorHome (Scope.Generic Scope.Food2)) (Generic (Scope.Generic Scope.Food2))
         ]
 
 

--- a/src/Views/Page.elm
+++ b/src/Views/Page.elm
@@ -13,7 +13,7 @@ import Browser exposing (Document)
 import Data.Dataset as Dataset
 import Data.Env as Env
 import Data.Notification as Notification exposing (Notification)
-import Data.Scope as Scope exposing (Scope)
+import Data.Scope as Scope exposing (GenericScope)
 import Data.Session as Session
 import Html exposing (..)
 import Html.Attributes exposing (..)
@@ -40,8 +40,7 @@ type ActivePage
     | Editorial String
     | Explore
     | Food
-      -- FIXME: should be Generic Scope.GenericScope
-    | Generic Scope
+    | Generic GenericScope
     | Home
     | Other
     | Stats
@@ -127,14 +126,14 @@ commonNotices msg activePage =
                 , Markdown.simple [] "**Méthodologie stabilisée.** Calculette en cours de développement"
                 ]
 
-        Generic (Scope.Generic Scope.Food2) ->
+        Generic Scope.Food2 ->
             Notice.info
                 [ Icon.info
                 , Markdown.simple [] "**Méthodologie stabilisée. Cette version de la calculette remplacera à terme la version initiale.**"
                 , """Contribuez via notre [forum utilisateur](https://chat.ecobalyse.fr/ecobalyse/channels/02_alimentaire_general).""" |> Markdown.simple []
                 ]
 
-        Generic (Scope.Generic Scope.Object) ->
+        Generic Scope.Object ->
             Notice.info
                 [ Icon.info
                 , Markdown.simple [] "**Cette version est en cours de développement.**"
@@ -142,7 +141,7 @@ commonNotices msg activePage =
                     |> Markdown.simple []
                 ]
 
-        Generic (Scope.Generic Scope.Veli) ->
+        Generic Scope.Veli ->
             Notice.info
                 [ Icon.info
                 , Markdown.simple [] "**Cette version est en cours de développement.** Elle est réservée à des beta-testeurs."
@@ -254,11 +253,11 @@ mainMenuLinks enabledSections =
         , addRouteIf enabledSections.food <|
             Internal [ text "Alimentaire" ] Route.FoodBuilderHome Food
         , addRouteIf enabledSections.objects <|
-            Internal [ text "Alimentaire", sup [] [ text "BÉTA" ] ] (Route.GenericSimulatorHome Scope.Food2) (Generic (Scope.Generic Scope.Food2))
+            Internal [ text "Alimentaire", sup [] [ text "BÉTA" ] ] (Route.GenericSimulatorHome Scope.Food2) (Generic Scope.Food2)
         , addRouteIf enabledSections.objects <|
-            Internal [ text "Objets" ] (Route.GenericSimulatorHome Scope.Object) (Generic (Scope.Generic Scope.Object))
+            Internal [ text "Objets" ] (Route.GenericSimulatorHome Scope.Object) (Generic Scope.Object)
         , addRouteIf enabledSections.veli <|
-            Internal [ text "Véhicules" ] (Route.GenericSimulatorHome Scope.Veli) (Generic (Scope.Generic Scope.Veli))
+            Internal [ text "Véhicules" ] (Route.GenericSimulatorHome Scope.Veli) (Generic Scope.Veli)
         , Just <| Internal [ text "Explorateur" ] (Route.Explore Scope.Textile (Dataset.TextileExamples Nothing)) Explore
         , Just <| Internal [ text "API" ] Route.Api Api
         , Just <| MailTo "Contact" Env.contactEmail
@@ -276,7 +275,7 @@ secondaryMenuLinks enabledSections =
         , Just <| External "CGU" Env.cguUrl
         , Just <| Internal [ text "Admin" ] (Route.Admin AdminSection.ComponentSection) Admin
         , addRouteIf enabledSections.food2 <|
-            Internal [ text "Alimentaire²" ] (Route.GenericSimulatorHome Scope.Food2) (Generic (Scope.Generic Scope.Food2))
+            Internal [ text "Alimentaire²" ] (Route.GenericSimulatorHome Scope.Food2) (Generic Scope.Food2)
         ]
 
 

--- a/tests/Data/BookmarkTest.elm
+++ b/tests/Data/BookmarkTest.elm
@@ -136,13 +136,6 @@ suite =
                     |> Expect.equal Nothing
                 )
             ]
-        , describe "genericQueryFromScope"
-            [ it "should build a generic query for the given scope"
-                (Component.emptyQuery
-                    |> Bookmark.Generic Scope.Veli
-                    |> Expect.equal (Bookmark.Generic Scope.Veli Component.emptyQuery)
-                )
-            ]
         ]
 
 

--- a/tests/Data/BookmarkTest.elm
+++ b/tests/Data/BookmarkTest.elm
@@ -104,6 +104,45 @@ suite =
                     |> expectQueryDecoded (Bookmark.Generic Scope.Veli Component.emptyQuery)
                 )
             ]
+        , describe "findByGenericQuery"
+            [ it "should find a bookmark for the matching generic scope"
+                (let
+                    food2Bookmark =
+                        { created = Time.millisToPosix 1
+                        , genericScope = Just Scope.Food2
+                        , name = "food2 bookmark"
+                        , query = Bookmark.Generic Scope.Food2 Component.emptyQuery
+                        }
+
+                    objectBookmark =
+                        { created = Time.millisToPosix 2
+                        , genericScope = Just Scope.Object
+                        , name = "object bookmark"
+                        , query = Bookmark.Generic Scope.Object Component.emptyQuery
+                        }
+                 in
+                 [ food2Bookmark, objectBookmark ]
+                    |> Bookmark.findByGenericQuery Scope.Food2 Component.emptyQuery
+                    |> Expect.equal (Just food2Bookmark)
+                )
+            , it "should not match a bookmark from another generic scope"
+                ([ { created = Time.millisToPosix 1
+                   , genericScope = Just Scope.Object
+                   , name = "object bookmark"
+                   , query = Bookmark.Generic Scope.Object Component.emptyQuery
+                   }
+                 ]
+                    |> Bookmark.findByGenericQuery Scope.Veli Component.emptyQuery
+                    |> Expect.equal Nothing
+                )
+            ]
+        , describe "genericQueryFromScope"
+            [ it "should build a generic query for the given scope"
+                (Component.emptyQuery
+                    |> Bookmark.Generic Scope.Veli
+                    |> Expect.equal (Bookmark.Generic Scope.Veli Component.emptyQuery)
+                )
+            ]
         ]
 
 


### PR DESCRIPTION
This is mainly a large architectural refactor, aiming at having consistency across the whole codebase handling generic scopes and associated features (simulator, route parsing, examples, explorer etc. for food2, object and veli). It cleans up a bunch of tech debt and todos we had laying around for months, maybe years 🥰

The main idea is to disambiguate *"Object"* as a scope name (currently used for amenity) from *"Object"* as generic simulation for basically anything, including amenity, food and vehicles, by introducing the *"Generic"* name/prefix for the latter.

The patch also adds an examples explorer for food2, and add a new computed column featuring the score per 100g of product per simulation for all generic scopes, as we had with food1.

### :rotating_light:  Points to watch/comments

- I resisted the urge to rename `Scope.Object` to `Scope.Furnishings` as I felt like this would require a kind of strategic approval first 

### :desert_island: How to test

- This is a rather large refactor, touching the fundations of the house, so… Apart from testing the whole app manually, I guess we'll have to heavily rely on our test suite here 😅
- Check the new added examples explorer for food2, and the cost per 100g impl.