### PR TITLE
chore: fix e2e tests being cancelled with no error

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   build:
-    timeout-minutes: 60
+    timeout-minutes: 55
     runs-on: ubuntu-latest
 
     services:

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -13,8 +13,7 @@ dotenv.config({ path: path.resolve(__dirname, ".env") });
  * @see https://playwright.dev/docs/test-configuration
  */
 export default defineConfig({
-  timeout: process.env.CI ? 120_000 : 10_000,
-
+  timeout: process.env.CI ? 80_000 : 10_000,
   expect: { timeout: process.env.CI ? 10_000 : 2_000 },
 
   testDir: "./e2e",
@@ -23,7 +22,7 @@ export default defineConfig({
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
-  retries: process.env.CI ? 10 : 0,
+  retries: 0,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
 


### PR DESCRIPTION
## :wrench: Problem

When tests are in timeout or cancelled by the next run (every hour) they end up in a neutral state (no error, no success) and thus we are not aware that something is wrong.

## :cake: Solution

Fine tune the timeouts and retries values so that tests are running under 20 minutes even when they are timeouting (80 seconds * 11 tests, no retry). It prevents the tests to hang up for an hour and to be cancelled by Github Actions.

## :desert_island: How to test

I’ve tested the values by reintroducing the regression with Highcharts and the tests are indeed failing this time (instead of being cancelled due to execution timeout before this patch) https://github.com/MTES-MCT/ecobalyse/actions/runs/32855695352

Current values allows the e2e tests to be successful https://github.com/MTES-MCT/ecobalyse/actions/runs/32867840464