### PR TITLE
feat(generic): add product category default consumptions

### DIFF
--- a/public/data/food2/categories.json
+++ b/public/data/food2/categories.json
@@ -1,8 +1,6 @@
 [
   {
-    "consumptions": [
-      "b4642cec-b72e-4116-81c5-5dbfccb46055"
-    ],
+    "consumptions": ["b4642cec-b72e-4116-81c5-5dbfccb46055"],
     "cooling": true,
     "distribution": "be66b80b-1500-4e3b-bfd2-87a89ff54031",
     "id": "2ab49980-2bc8-40b9-8db2-010d0d14ce50",
@@ -10,9 +8,7 @@
     "scope": "food2"
   },
   {
-    "consumptions": [
-      "b4642cec-b72e-4116-81c5-5dbfccb46055"
-    ],
+    "consumptions": ["b4642cec-b72e-4116-81c5-5dbfccb46055"],
     "cooling": true,
     "distribution": "29118025-efa0-47bb-94e2-f5ccba31a903",
     "id": "8ff16df9-acff-47b3-bc6d-c25afca653e0",
@@ -20,9 +16,7 @@
     "scope": "food2"
   },
   {
-    "consumptions": [
-      "21e4283e-6bbf-4b2a-b52b-4440022525ad"
-    ],
+    "consumptions": ["21e4283e-6bbf-4b2a-b52b-4440022525ad"],
     "cooling": false,
     "distribution": "29118025-efa0-47bb-94e2-f5ccba31a903",
     "id": "ed82925c-7f21-4101-b9be-056e3c185749",
@@ -52,9 +46,7 @@
     "scope": "food2"
   },
   {
-    "consumptions": [
-      "21e4283e-6bbf-4b2a-b52b-4440022525ad"
-    ],
+    "consumptions": ["21e4283e-6bbf-4b2a-b52b-4440022525ad"],
     "cooling": false,
     "distribution": "29118025-efa0-47bb-94e2-f5ccba31a903",
     "id": "0f5377d4-efce-45f7-8547-169ac0e124d0",
@@ -84,9 +76,7 @@
     "scope": "food2"
   },
   {
-    "consumptions": [
-      "b4642cec-b72e-4116-81c5-5dbfccb46055"
-    ],
+    "consumptions": ["b4642cec-b72e-4116-81c5-5dbfccb46055"],
     "cooling": true,
     "distribution": "be66b80b-1500-4e3b-bfd2-87a89ff54031",
     "id": "3d69eb9f-0126-4e97-a017-d47f00fdcabb",
@@ -94,9 +84,7 @@
     "scope": "food2"
   },
   {
-    "consumptions": [
-      "b4642cec-b72e-4116-81c5-5dbfccb46055"
-    ],
+    "consumptions": ["b4642cec-b72e-4116-81c5-5dbfccb46055"],
     "cooling": false,
     "distribution": "29118025-efa0-47bb-94e2-f5ccba31a903",
     "id": "73b44868-899b-476f-bab6-1ecb4877ade2",

--- a/public/data/food2/categories.json
+++ b/public/data/food2/categories.json
@@ -1,5 +1,10 @@
 [
   {
+    "consumptions": [
+      {
+        "processId": "b4642cec-b72e-4116-81c5-5dbfccb46055"
+      }
+    ],
     "cooling": true,
     "distribution": "be66b80b-1500-4e3b-bfd2-87a89ff54031",
     "id": "2ab49980-2bc8-40b9-8db2-010d0d14ce50",
@@ -7,6 +12,11 @@
     "scope": "food2"
   },
   {
+    "consumptions": [
+      {
+        "processId": "b4642cec-b72e-4116-81c5-5dbfccb46055"
+      }
+    ],
     "cooling": true,
     "distribution": "29118025-efa0-47bb-94e2-f5ccba31a903",
     "id": "8ff16df9-acff-47b3-bc6d-c25afca653e0",
@@ -14,6 +24,11 @@
     "scope": "food2"
   },
   {
+    "consumptions": [
+      {
+        "processId": "21e4283e-6bbf-4b2a-b52b-4440022525ad"
+      }
+    ],
     "cooling": false,
     "distribution": "29118025-efa0-47bb-94e2-f5ccba31a903",
     "id": "ed82925c-7f21-4101-b9be-056e3c185749",
@@ -21,6 +36,14 @@
     "scope": "food2"
   },
   {
+    "consumptions": [
+      {
+        "processId": "b4642cec-b72e-4116-81c5-5dbfccb46055"
+      },
+      {
+        "processId": "a49670fc-0642-43f6-a673-fe15dc7d88da"
+      }
+    ],
     "cooling": true,
     "distribution": "be66b80b-1500-4e3b-bfd2-87a89ff54031",
     "id": "22bd618d-effb-4769-86ff-e326b7fe78b6",
@@ -28,6 +51,14 @@
     "scope": "food2"
   },
   {
+    "consumptions": [
+      {
+        "processId": "b4642cec-b72e-4116-81c5-5dbfccb46055"
+      },
+      {
+        "processId": "21e4283e-6bbf-4b2a-b52b-4440022525ad"
+      }
+    ],
     "cooling": true,
     "distribution": "29118025-efa0-47bb-94e2-f5ccba31a903",
     "id": "d6ba3a8b-cd58-497c-8872-b436c1659ec9",
@@ -35,6 +66,11 @@
     "scope": "food2"
   },
   {
+    "consumptions": [
+      {
+        "processId": "21e4283e-6bbf-4b2a-b52b-4440022525ad"
+      }
+    ],
     "cooling": false,
     "distribution": "29118025-efa0-47bb-94e2-f5ccba31a903",
     "id": "0f5377d4-efce-45f7-8547-169ac0e124d0",
@@ -42,6 +78,14 @@
     "scope": "food2"
   },
   {
+    "consumptions": [
+      {
+        "processId": "b4642cec-b72e-4116-81c5-5dbfccb46055"
+      },
+      {
+        "processId": "1040ee69-9dff-47f1-a989-c7cd04d2c419"
+      }
+    ],
     "cooling": true,
     "distribution": "be66b80b-1500-4e3b-bfd2-87a89ff54031",
     "id": "18fdea50-1a04-4948-bf13-7b54e169235b",
@@ -49,6 +93,14 @@
     "scope": "food2"
   },
   {
+    "consumptions": [
+      {
+        "processId": "0048f6f5-5f8f-4a34-acde-4e0d909883d4"
+      },
+      {
+        "processId": "a49670fc-0642-43f6-a673-fe15dc7d88da"
+      }
+    ],
     "cooling": true,
     "distribution": "a7b3d399-4c7b-4556-9826-a79f952feb7f",
     "id": "1eacb555-5f0c-498e-8e97-f4c9104642e4",
@@ -56,6 +108,11 @@
     "scope": "food2"
   },
   {
+    "consumptions": [
+      {
+        "processId": "b4642cec-b72e-4116-81c5-5dbfccb46055"
+      }
+    ],
     "cooling": true,
     "distribution": "be66b80b-1500-4e3b-bfd2-87a89ff54031",
     "id": "3d69eb9f-0126-4e97-a017-d47f00fdcabb",
@@ -63,6 +120,11 @@
     "scope": "food2"
   },
   {
+    "consumptions": [
+      {
+        "processId": "b4642cec-b72e-4116-81c5-5dbfccb46055"
+      }
+    ],
     "cooling": false,
     "distribution": "29118025-efa0-47bb-94e2-f5ccba31a903",
     "id": "73b44868-899b-476f-bab6-1ecb4877ade2",
@@ -70,6 +132,14 @@
     "scope": "food2"
   },
   {
+    "consumptions": [
+      {
+        "processId": "b4642cec-b72e-4116-81c5-5dbfccb46055"
+      },
+      {
+        "processId": "21e4283e-6bbf-4b2a-b52b-4440022525ad"
+      }
+    ],
     "cooling": true,
     "distribution": "be66b80b-1500-4e3b-bfd2-87a89ff54031",
     "id": "18c80093-442d-469c-9a22-6297e97ba1a7",

--- a/public/data/food2/categories.json
+++ b/public/data/food2/categories.json
@@ -1,9 +1,7 @@
 [
   {
     "consumptions": [
-      {
-        "processId": "b4642cec-b72e-4116-81c5-5dbfccb46055"
-      }
+      "b4642cec-b72e-4116-81c5-5dbfccb46055"
     ],
     "cooling": true,
     "distribution": "be66b80b-1500-4e3b-bfd2-87a89ff54031",
@@ -13,9 +11,7 @@
   },
   {
     "consumptions": [
-      {
-        "processId": "b4642cec-b72e-4116-81c5-5dbfccb46055"
-      }
+      "b4642cec-b72e-4116-81c5-5dbfccb46055"
     ],
     "cooling": true,
     "distribution": "29118025-efa0-47bb-94e2-f5ccba31a903",
@@ -25,9 +21,7 @@
   },
   {
     "consumptions": [
-      {
-        "processId": "21e4283e-6bbf-4b2a-b52b-4440022525ad"
-      }
+      "21e4283e-6bbf-4b2a-b52b-4440022525ad"
     ],
     "cooling": false,
     "distribution": "29118025-efa0-47bb-94e2-f5ccba31a903",
@@ -37,12 +31,8 @@
   },
   {
     "consumptions": [
-      {
-        "processId": "b4642cec-b72e-4116-81c5-5dbfccb46055"
-      },
-      {
-        "processId": "a49670fc-0642-43f6-a673-fe15dc7d88da"
-      }
+      "b4642cec-b72e-4116-81c5-5dbfccb46055",
+      "a49670fc-0642-43f6-a673-fe15dc7d88da"
     ],
     "cooling": true,
     "distribution": "be66b80b-1500-4e3b-bfd2-87a89ff54031",
@@ -52,12 +42,8 @@
   },
   {
     "consumptions": [
-      {
-        "processId": "b4642cec-b72e-4116-81c5-5dbfccb46055"
-      },
-      {
-        "processId": "21e4283e-6bbf-4b2a-b52b-4440022525ad"
-      }
+      "b4642cec-b72e-4116-81c5-5dbfccb46055",
+      "21e4283e-6bbf-4b2a-b52b-4440022525ad"
     ],
     "cooling": true,
     "distribution": "29118025-efa0-47bb-94e2-f5ccba31a903",
@@ -67,9 +53,7 @@
   },
   {
     "consumptions": [
-      {
-        "processId": "21e4283e-6bbf-4b2a-b52b-4440022525ad"
-      }
+      "21e4283e-6bbf-4b2a-b52b-4440022525ad"
     ],
     "cooling": false,
     "distribution": "29118025-efa0-47bb-94e2-f5ccba31a903",
@@ -79,12 +63,8 @@
   },
   {
     "consumptions": [
-      {
-        "processId": "b4642cec-b72e-4116-81c5-5dbfccb46055"
-      },
-      {
-        "processId": "1040ee69-9dff-47f1-a989-c7cd04d2c419"
-      }
+      "b4642cec-b72e-4116-81c5-5dbfccb46055",
+      "1040ee69-9dff-47f1-a989-c7cd04d2c419"
     ],
     "cooling": true,
     "distribution": "be66b80b-1500-4e3b-bfd2-87a89ff54031",
@@ -94,12 +74,8 @@
   },
   {
     "consumptions": [
-      {
-        "processId": "0048f6f5-5f8f-4a34-acde-4e0d909883d4"
-      },
-      {
-        "processId": "a49670fc-0642-43f6-a673-fe15dc7d88da"
-      }
+      "0048f6f5-5f8f-4a34-acde-4e0d909883d4",
+      "a49670fc-0642-43f6-a673-fe15dc7d88da"
     ],
     "cooling": true,
     "distribution": "a7b3d399-4c7b-4556-9826-a79f952feb7f",
@@ -109,9 +85,7 @@
   },
   {
     "consumptions": [
-      {
-        "processId": "b4642cec-b72e-4116-81c5-5dbfccb46055"
-      }
+      "b4642cec-b72e-4116-81c5-5dbfccb46055"
     ],
     "cooling": true,
     "distribution": "be66b80b-1500-4e3b-bfd2-87a89ff54031",
@@ -121,9 +95,7 @@
   },
   {
     "consumptions": [
-      {
-        "processId": "b4642cec-b72e-4116-81c5-5dbfccb46055"
-      }
+      "b4642cec-b72e-4116-81c5-5dbfccb46055"
     ],
     "cooling": false,
     "distribution": "29118025-efa0-47bb-94e2-f5ccba31a903",
@@ -133,12 +105,8 @@
   },
   {
     "consumptions": [
-      {
-        "processId": "b4642cec-b72e-4116-81c5-5dbfccb46055"
-      },
-      {
-        "processId": "21e4283e-6bbf-4b2a-b52b-4440022525ad"
-      }
+      "b4642cec-b72e-4116-81c5-5dbfccb46055",
+      "21e4283e-6bbf-4b2a-b52b-4440022525ad"
     ],
     "cooling": true,
     "distribution": "be66b80b-1500-4e3b-bfd2-87a89ff54031",

--- a/src/CheckDb.elm
+++ b/src/CheckDb.elm
@@ -244,6 +244,7 @@ checkExamplesScope db =
                     [ example.query.items
                         |> List.concatMap (checkExampleComponentItem processesMap componentsMap example)
                     , example.query.consumptions
+                        |> Maybe.withDefault []
                         |> List.concatMap (checkExampleConsumption processesMap example)
                     ]
             )

--- a/src/CheckDb.elm
+++ b/src/CheckDb.elm
@@ -2,9 +2,11 @@ port module CheckDb exposing (main)
 
 import Data.Component as Component exposing (Component)
 import Data.Component.Config as ComponentConfig
+import Data.Component.ProductCategory as ProductCategory exposing (ProductCategory)
 import Data.Db exposing (Db)
 import Data.Example exposing (Example)
 import Data.Process as Process exposing (Process)
+import Data.Process.Category as ProcessCategory
 import Data.Scope as Scope
 import Data.Uuid as Uuid
 import Dict exposing (Dict)
@@ -247,6 +249,53 @@ checkExamplesScope db =
             )
 
 
+{-| Checks that a product category consumption references an existing, scope-compatible process.
+When amount is omitted, the process _must_ be product-mass-dependent.
+-}
+checkProductCategoryConsumption : Dict String Process -> ProductCategory -> ProductCategory.DefaultConsumption -> List Error
+checkProductCategoryConsumption processes product { amount, processId } =
+    let
+        processIdString =
+            Process.idToString processId
+    in
+    case processes |> Dict.get processIdString of
+        Just process ->
+            if process.scopes |> List.member (Scope.Generic product.scope) |> not then
+                formatError
+                    [ "Product category " ++ productCategoryLabel product
+                    , "references process " ++ processLabel process
+                    , "in consumptions but isn't scoped for " ++ backtick (Scope.toStringGeneric product.scope)
+                    ]
+
+            else if amount == Nothing && not (List.member ProcessCategory.ProductMassDependent process.categories) then
+                formatError
+                    [ "Product category " ++ productCategoryLabel product
+                    , "references process " ++ processLabel process
+                    , "in consumptions without an amount, but the process is not productmassdependent"
+                    ]
+
+            else
+                []
+
+        Nothing ->
+            formatError
+                [ "Product category " ++ productCategoryLabel product
+                , "references missing process " ++ processIdString ++ " in consumptions"
+                ]
+
+
+{-| Validates process references used by generic product category consumptions.
+-}
+checkProductCategoryConsumptions : Db -> List Error
+checkProductCategoryConsumptions db =
+    db.products
+        |> List.concatMap
+            (\product ->
+                product.consumptions
+                    |> List.concatMap (product |> checkProductCategoryConsumption (processById db.processes))
+            )
+
+
 {-| Reports a missing process id referenced from a component field.
 -}
 checkProcessId : Set String -> Component -> String -> Process.Id -> List Error
@@ -288,6 +337,7 @@ checkStaticDatabase config dbName dbResult =
             []
                 |> addGroupedErrors (section "Examples components checks") (checkExamplesComponentIds knownComponentStringIds db)
                 |> addGroupedErrors (section "Components processes checks") (checkComponentsProcessIds knownProcessStringIds db)
+                |> addGroupedErrors (section "Product category consumptions checks") (checkProductCategoryConsumptions db)
                 |> addGroupedErrors (section "Scoping checks") (checkExamplesScope db)
                 |> addGroupedErrors (section "Component config checks") (checkComponentConfig db config)
 
@@ -393,6 +443,16 @@ processLabel process =
     quote (Process.getDisplayName process)
         ++ " ("
         ++ Process.idToString process.id
+        ++ ")"
+
+
+productCategoryLabel : ProductCategory -> String
+productCategoryLabel product =
+    quote product.label
+        ++ " ("
+        ++ backtick (Scope.toStringGeneric product.scope)
+        ++ ", "
+        ++ ProductCategory.idToString product.id
         ++ ")"
 
 

--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -27,6 +27,7 @@ module Data.Component exposing
     , TargetItem
     , TransportOptions
     , addAssemblyOperation
+    , addConsumption
     , addElement
     , addElementTransform
     , addItem
@@ -78,6 +79,7 @@ module Data.Component exposing
     , findById
     , getAvailableDistributionProcesses
     , getConsumptionProcessId
+    , getConsumptions
     , getDistributionProcessId
     , getDocLink
     , getEndOfLifeDetailedImpacts
@@ -87,6 +89,7 @@ module Data.Component exposing
     , getPackagingProcessId
     , getResultedElement
     , getTotalImpacts
+    , getTransportCooling
     , idFromString
     , idToString
     , isEmpty
@@ -200,7 +203,7 @@ type alias EnergyMixes =
 
 type alias Query =
     { assembly : Assembly
-    , consumptions : List Consumption
+    , consumptions : Maybe (List Consumption)
     , distribution : Maybe Process.Id
 
     -- Note: component durability is experimental, future work may eventually be needed to
@@ -372,7 +375,7 @@ type Quantity
 
 type alias TransportOptions =
     { byAir : Split
-    , cooling : Bool
+    , cooling : Maybe Bool
     }
 
 
@@ -457,6 +460,17 @@ addAssemblyOperation process ({ assembly } as query) =
             { assembly
                 | operations = assembly.operations ++ [ process.id ]
             }
+    }
+
+
+addConsumption : Requirements db -> Process.Id -> Query -> Query
+addConsumption requirements processId query =
+    { query
+        | consumptions =
+            Just
+                (getConsumptions requirements query
+                    ++ [ consumption (Amount.fromFloat 1) processId ]
+                )
     }
 
 
@@ -843,7 +857,7 @@ computeElementResults requirements transportOptions =
                                 |> applyTransforms requirements
                                     -- pre-assembly transport cooling is always driven automatically by the material
                                     -- process, and bypasses any user-provided transportOptions.cooling option
-                                    { transportOptions | cooling = Process.isTransportedCooled material.process }
+                                    { transportOptions | cooling = Just (Process.isTransportedCooled material.process) }
                                     material.country
                                     material.process.unit
                                     transforms
@@ -1161,7 +1175,7 @@ computeTransportedMassImpacts ({ config } as requirements) ({ byAir, cooling } a
             )
         -- remap cooled transportation modes if needed
         |> Result.map
-            (if cooling then
+            (if Maybe.withDefault False cooling then
                 Transport.makeCooled
 
              else
@@ -1213,7 +1227,7 @@ computeTransports ({ config, db } as requirements) ({ assembly, transportOptions
                                     --   - cooling before assembly is automatic and driven by the material process
                                     { transportOptions
                                         | byAir = Split.zero
-                                        , cooling = Process.isTransportedCooled expandedElement.material.process
+                                        , cooling = Just (Process.isTransportedCooled expandedElement.material.process)
                                     }
                                     (getFinalElementCountry expandedElement)
                                     maybeAssemblyCountry
@@ -1221,7 +1235,7 @@ computeTransports ({ config, db } as requirements) ({ assembly, transportOptions
                     -- toDistribution
                     (lifeCycle.productMass
                         |> computeTransportedMassImpacts requirements
-                            transportOptions
+                            { transportOptions | cooling = Just (getTransportCooling requirements query) }
                             maybeAssemblyCountry
                             (Just config.distribution.country)
                     )
@@ -1232,8 +1246,8 @@ computeTransports ({ config, db } as requirements) ({ assembly, transportOptions
 
 
 computeUseImpacts : Requirements db -> Query -> LifeCycle -> Result String LifeCycle
-computeUseImpacts { config, db } { consumptions } lifeCycle =
-    consumptions
+computeUseImpacts ({ config, db } as requirements) query lifeCycle =
+    getConsumptions requirements query
         |> expandConsumptions db.processes
         |> Result.map
             (\expandedQuantifiedProcesses ->
@@ -1401,7 +1415,7 @@ decodeQuery =
         |> Decode.andThen
             (\assembly ->
                 Decode.succeed (Query assembly)
-                    |> Decode.optional "consumptions" (Decode.list decodeConsumption) []
+                    |> DU.strictOptional "consumptions" (Decode.list decodeConsumption)
                     |> DU.strictOptional "distribution" Process.decodeId
                     |> DU.strictOptional "durability" Unit.decodeRatio
                     |> Decode.required "components" (Decode.list decodeItem)
@@ -1432,7 +1446,7 @@ decodeTransportOptions : Decoder TransportOptions
 decodeTransportOptions =
     Decode.succeed TransportOptions
         |> Decode.optional "byAir" Split.decodePercent Split.zero
-        |> Decode.optional "cooling" Decode.bool False
+        |> DU.strictOptional "cooling" Decode.bool
 
 
 defaultDurability : Unit.Ratio
@@ -1443,7 +1457,7 @@ defaultDurability =
 defaultTransportOptions : TransportOptions
 defaultTransportOptions =
     { byAir = Split.zero
-    , cooling = False
+    , cooling = Nothing
     }
 
 
@@ -1514,7 +1528,7 @@ emptyLifeCycleTransports =
 emptyQuery : Query
 emptyQuery =
     { assembly = emptyAssembly
-    , consumptions = []
+    , consumptions = Nothing
     , distribution = Nothing
     , durability = Nothing
     , items = []
@@ -1682,13 +1696,7 @@ encodeQuery query =
                 encodeAssembly query.assembly |> Just
           )
         , ( "components", query.items |> Encode.list encodeItem |> Just )
-        , ( "consumptions"
-          , if List.isEmpty query.consumptions then
-                Nothing
-
-            else
-                query.consumptions |> Encode.list encodeConsumption |> Just
-          )
+        , ( "consumptions", query.consumptions |> Maybe.map (Encode.list encodeConsumption) )
         , ( "distribution", query.distribution |> Maybe.map Process.encodeId )
         , ( "durability", query.durability |> Maybe.map Unit.encodeRatio )
         , ( "packagings"
@@ -1768,23 +1776,22 @@ encodeResults maybeTrigram (Results results) =
 
 encodeTransportOptions : TransportOptions -> Maybe Encode.Value
 encodeTransportOptions { byAir, cooling } =
-    -- Encode only JSON keys that are different from defaults
-    case ( byAir == defaultTransportOptions.byAir, cooling == defaultTransportOptions.cooling ) of
-        ( True, True ) ->
-            Nothing
+    let
+        fields =
+            List.filterMap identity
+                [ if byAir == defaultTransportOptions.byAir then
+                    Nothing
 
-        ( False, True ) ->
-            Just <| Encode.object [ ( "byAir", Split.encodePercent byAir ) ]
+                  else
+                    Just ( "byAir", Split.encodePercent byAir )
+                , cooling |> Maybe.map (\c -> ( "cooling", Encode.bool c ))
+                ]
+    in
+    if List.isEmpty fields then
+        Nothing
 
-        ( True, False ) ->
-            Just <| Encode.object [ ( "cooling", Encode.bool cooling ) ]
-
-        ( False, False ) ->
-            [ ( "byAir", Split.encodePercent byAir )
-            , ( "cooling", Encode.bool cooling )
-            ]
-                |> Encode.object
-                |> Just
+    else
+        Just (Encode.object fields)
 
 
 {-| Common reusable error strings
@@ -1982,6 +1989,31 @@ getAvailableDistributionProcesses db scope =
 getConsumptionProcessId : Consumption -> Process.Id
 getConsumptionProcessId (Consumption { processId }) =
     processId
+
+
+{-| Get the use-stage consumptions:
+
+  - from the query itself when set (`Just`, including an explicit empty list)
+  - or the ones from the product category if not set
+  - or an empty list if product category is not set
+
+-}
+getConsumptions : Requirements db -> Query -> List Consumption
+getConsumptions { db } query =
+    case query.consumptions of
+        Just consumptions ->
+            consumptions
+
+        Nothing ->
+            query.product
+                |> Maybe.andThen
+                    (\productId ->
+                        db.products
+                            |> ProductCategory.findById productId
+                            |> Result.toMaybe
+                            |> Maybe.map (.consumptions >> List.map consumptionFromCategory)
+                    )
+                |> Maybe.withDefault []
 
 
 {-| Get the distribution process:
@@ -2285,6 +2317,31 @@ getTransformDefaultCountry targetItem maybeElementIndex items =
             )
 
 
+{-| Get the to-distribution cooling option:
+
+  - from the query itself when set
+  - or the one from the product category if not set
+  - or `False` if product category is not set
+
+-}
+getTransportCooling : Requirements db -> Query -> Bool
+getTransportCooling { db } query =
+    case query.transportOptions.cooling of
+        Just cooling ->
+            cooling
+
+        Nothing ->
+            query.product
+                |> Maybe.andThen
+                    (\productId ->
+                        db.products
+                            |> ProductCategory.findById productId
+                            |> Result.toMaybe
+                            |> Maybe.map .cooling
+                    )
+                |> Maybe.withDefault False
+
+
 idFromString : String -> Result String Id
 idFromString =
     Uuid.fromString >> Result.map Id
@@ -2457,9 +2514,9 @@ removeAssemblyOperation index ({ assembly } as query) =
     }
 
 
-removeConsumption : Index -> Query -> Query
-removeConsumption index query =
-    { query | consumptions = query.consumptions |> LE.removeAt index }
+removeConsumption : Requirements db -> Index -> Query -> Query
+removeConsumption requirements index query =
+    { query | consumptions = Just (getConsumptions requirements query |> LE.removeAt index) }
 
 
 {-| Remove an element from an item
@@ -2572,7 +2629,7 @@ setTransportByAir byAir ({ transportOptions } as query) =
 
 setTransportCooling : Bool -> Query -> Query
 setTransportCooling cooling ({ transportOptions } as query) =
-    { query | transportOptions = { transportOptions | cooling = cooling } }
+    { query | transportOptions = { transportOptions | cooling = Just cooling } }
 
 
 stagesImpacts : LifeCycle -> Stages (Maybe Impacts)
@@ -2697,12 +2754,14 @@ updateAssemblyCountry country ({ assembly } as query) =
     { query | assembly = { assembly | country = country } }
 
 
-updateConsumptionAmount : Index -> Amount -> Query -> Query
-updateConsumptionAmount index amount query =
+updateConsumptionAmount : Requirements db -> Index -> Amount -> Query -> Query
+updateConsumptionAmount requirements index amount query =
     { query
         | consumptions =
-            query.consumptions
-                |> LE.updateAt index (\(Consumption c) -> Consumption { c | amount = amount })
+            Just
+                (getConsumptions requirements query
+                    |> LE.updateAt index (\(Consumption c) -> Consumption { c | amount = amount })
+                )
     }
 
 
@@ -2738,27 +2797,26 @@ updateDistribution maybeProcessId query =
 {-| Update the product in the query, resetting product-dependent fields along the way
 -}
 updateProduct : Maybe ProductCategory -> Query -> Query
-updateProduct maybeProduct query =
+updateProduct maybeProduct ({ transportOptions } as query) =
+    let
+        reset maybeProductId =
+            { query
+                | consumptions = Nothing
+                , distribution = Nothing
+                , product = maybeProductId
+                , transportOptions = { transportOptions | cooling = Nothing }
+            }
+    in
     case maybeProduct of
         Just product ->
             if query.product == Just product.id then
                 query
 
             else
-                { query
-                    | consumptions = List.map consumptionFromCategory product.consumptions
-                    , distribution = Nothing
-                    , product = Just product.id
-                }
-                    |> setTransportCooling product.cooling
+                reset (Just product.id)
 
         Nothing ->
-            { query
-                | consumptions = []
-                , distribution = Nothing
-                , product = Nothing
-            }
-                |> setTransportCooling defaultTransportOptions.cooling
+            reset Nothing
 
 
 updateDurability : Unit.Ratio -> Query -> Query
@@ -3017,7 +3075,11 @@ validateQuery : Requirements db -> Query -> Result String Query
 validateQuery ({ db } as requirements) query =
     Ok Query
         |> RE.andMap (validateAssembly requirements query.assembly)
-        |> RE.andMap (query.consumptions |> RE.combineMap (validateConsumption requirements))
+        |> RE.andMap
+            (getConsumptions requirements query
+                |> RE.combineMap (validateConsumption requirements)
+                |> Result.map (always query.consumptions)
+            )
         |> RE.andMap (validateDistribution requirements (getDistributionProcessId requirements query))
         |> RE.andMap (validateDurability requirements query.durability)
         |> RE.andMap (query.items |> RE.combineMap (validateItem db.components))

--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -796,6 +796,11 @@ consumption amount =
     QuantifiedProcess amount >> Consumption
 
 
+consumptionFromCategory : ProductCategory.DefaultConsumption -> Consumption
+consumptionFromCategory { amount, processId } =
+    consumption (Maybe.withDefault (Amount.fromFloat 1) amount) processId
+
+
 computeDistributionImpacts : Requirements db -> Query -> LifeCycle -> Result String LifeCycle
 computeDistributionImpacts ({ config } as requirements) query ({ distribution, productMass } as lifeCycle) =
     let
@@ -2740,11 +2745,19 @@ updateProduct maybeProduct query =
                 query
 
             else
-                { query | distribution = Nothing, product = Just product.id }
+                { query
+                    | consumptions = List.map consumptionFromCategory product.consumptions
+                    , distribution = Nothing
+                    , product = Just product.id
+                }
                     |> setTransportCooling product.cooling
 
         Nothing ->
-            { query | distribution = Nothing, product = Nothing }
+            { query
+                | consumptions = []
+                , distribution = Nothing
+                , product = Nothing
+            }
                 |> setTransportCooling defaultTransportOptions.cooling
 
 

--- a/src/Data/Component/ProductCategory.elm
+++ b/src/Data/Component/ProductCategory.elm
@@ -28,6 +28,7 @@ type Id
 
 {-| A default use-stage consumption for a product category.
 
+JSON may be a process id string, or an object with `processId` and optional `amount`.
 When `amount` is omitted, the process is treated as product-mass-dependent.
 
 -}
@@ -61,11 +62,22 @@ decode =
         |> Pipe.required "scope" Scope.decodeGeneric
 
 
+{-| accepts either a long or a short form for JSON def
+
+  - long form: consumptions: [{ "processId": "<uuid1>" }, { "processId": "<uuid2>" }, …]
+  -            consumptions: [{ "processId": "<uuid1>", "amount": 1 }, { "processId": "<uuid2>", "amount": 2 }, …]
+  - short form: consumptions: ["<uuid1>", "<uuid2>", …]
+
+-}
 decodeDefaultConsumption : Decoder DefaultConsumption
 decodeDefaultConsumption =
-    Decode.succeed DefaultConsumption
-        |> DU.strictOptional "amount" Amount.decode
-        |> Pipe.required "processId" Process.decodeId
+    Decode.oneOf
+        [ Decode.succeed DefaultConsumption
+            |> DU.strictOptional "amount" Amount.decode
+            |> Pipe.required "processId" Process.decodeId
+        , Process.decodeId
+            |> Decode.map (\processId -> { amount = Nothing, processId = processId })
+        ]
 
 
 decodeId : Decoder Id

--- a/src/Data/Component/ProductCategory.elm
+++ b/src/Data/Component/ProductCategory.elm
@@ -1,5 +1,6 @@
 module Data.Component.ProductCategory exposing
-    ( Id
+    ( DefaultConsumption
+    , Id
     , ProductCategory
     , decodeId
     , decodeListFromJsonString
@@ -12,6 +13,7 @@ module Data.Component.ProductCategory exposing
     )
 
 import Data.Common.DecodeUtils as DU
+import Data.Component.Amount as Amount exposing (Amount)
 import Data.Process as Process
 import Data.Scope as Scope
 import Data.Uuid as Uuid exposing (Uuid)
@@ -24,11 +26,23 @@ type Id
     = Id Uuid
 
 
+{-| A default use-stage consumption for a product category.
+
+When `amount` is omitted, the process is treated as product-mass-dependent.
+
+-}
+type alias DefaultConsumption =
+    { amount : Maybe Amount
+    , processId : Process.Id
+    }
+
+
 {-| A generic product category, providing sensible defaults for common characteristics
-like transport cooling and distribution process.
+like transport cooling, distribution process and use-stage consumptions.
 -}
 type alias ProductCategory =
-    { cooling : Bool
+    { consumptions : List DefaultConsumption
+    , cooling : Bool
     , distribution : Maybe Process.Id
     , id : Id
     , label : String
@@ -39,11 +53,19 @@ type alias ProductCategory =
 decode : Decoder ProductCategory
 decode =
     Decode.succeed ProductCategory
+        |> DU.strictOptionalWithDefault "consumptions" (Decode.list decodeDefaultConsumption) []
         |> Pipe.required "cooling" Decode.bool
         |> DU.strictOptional "distribution" Process.decodeId
         |> Pipe.required "id" decodeId
         |> Pipe.required "label" Decode.string
         |> Pipe.required "scope" Scope.decodeGeneric
+
+
+decodeDefaultConsumption : Decoder DefaultConsumption
+decodeDefaultConsumption =
+    Decode.succeed DefaultConsumption
+        |> DU.strictOptional "amount" Amount.decode
+        |> Pipe.required "processId" Process.decodeId
 
 
 decodeId : Decoder Id

--- a/src/Page/Explore/ProductCategories.elm
+++ b/src/Page/Explore/ProductCategories.elm
@@ -26,6 +26,9 @@ table { db } genericScope _ =
         , { key = "Distribution"
           , toValues = distributionLabel db.processes >> List.singleton
           }
+        , { key = "Consommations"
+          , toValues = consumptionsFacetValues db.processes
+          }
         ]
     , legend = []
     , columns =
@@ -47,8 +50,48 @@ table { db } genericScope _ =
           , toValue = Table.StringValue <| distributionLabel db.processes
           , toCell = distributionLabel db.processes >> text
           }
+        , { label = "Consommations"
+          , toValue = Table.StringValue <| consumptionsLabel db.processes
+          , toCell = consumptionsLabel db.processes >> text
+          }
         ]
     }
+
+
+emptyLabel : String
+emptyLabel =
+    "—"
+
+
+consumptionProcessName : List Process.Process -> ProductCategory.DefaultConsumption -> String
+consumptionProcessName processes { processId } =
+    case processes |> Process.findById processId |> Result.map Process.getDisplayName of
+        Err err ->
+            "Erreur\u{00A0}: " ++ err
+
+        Ok displayName ->
+            displayName
+
+
+consumptionsFacetValues : List Process.Process -> ProductCategory -> List String
+consumptionsFacetValues processes product =
+    if List.isEmpty product.consumptions then
+        [ emptyLabel ]
+
+    else
+        product.consumptions
+            |> List.map (consumptionProcessName processes)
+
+
+consumptionsLabel : List Process.Process -> ProductCategory -> String
+consumptionsLabel processes product =
+    if List.isEmpty product.consumptions then
+        emptyLabel
+
+    else
+        product.consumptions
+            |> List.map (consumptionProcessName processes)
+            |> String.join ", "
 
 
 distributionLabel : List Process.Process -> ProductCategory -> String
@@ -63,4 +106,4 @@ distributionLabel processes product =
                     displayName
 
         Nothing ->
-            "—"
+            emptyLabel

--- a/src/Page/Generic.elm
+++ b/src/Page/Generic.elm
@@ -336,6 +336,12 @@ update ({ navKey } as session) msg model =
         query =
             session
                 |> Session.genericQuery model.genericScope
+
+        requirements =
+            { config = session.componentConfig
+            , db = session.db
+            , scope = globalScope
+            }
     in
     case ( msg, model.modals ) of
         ( AppendModal modal, modals ) ->
@@ -484,7 +490,7 @@ update ({ navKey } as session) msg model =
 
         ( OnAutocompleteSelectConsumption, (SelectConsumptionModal autocompleteState) :: _ ) ->
             createPageUpdate session model
-                |> selectConsumption query autocompleteState
+                |> selectConsumption requirements query autocompleteState
 
         ( OnAutocompleteSelectConsumption, _ ) ->
             createPageUpdate session model
@@ -556,7 +562,7 @@ update ({ navKey } as session) msg model =
 
         ( RemoveConsumption index, _ ) ->
             createPageUpdate session model
-                |> updateQuery (query |> Component.removeConsumption index)
+                |> updateQuery (query |> Component.removeConsumption requirements index)
 
         ( RemoveElement targetElement, _ ) ->
             createPageUpdate session model
@@ -705,7 +711,7 @@ update ({ navKey } as session) msg model =
 
         ( UpdateConsumptionAmount index (Just amount), _ ) ->
             createPageUpdate session model
-                |> updateQuery (query |> Component.updateConsumptionAmount index amount)
+                |> updateQuery (query |> Component.updateConsumptionAmount requirements index amount)
 
         ( UpdateConsumptionAmount _ Nothing, _ ) ->
             createPageUpdate session model
@@ -910,17 +916,17 @@ selectAssemblyOperation query autocompleteState pageUpdate =
             pageUpdate |> App.notifyWarning "Aucun procédé d’assemblage sélectionné"
 
 
-selectConsumption : Component.Query -> Autocomplete Process -> PageUpdate Model Msg -> PageUpdate Model Msg
-selectConsumption query autocompleteState ({ model } as pageUpdate) =
+selectConsumption :
+    Component.Requirements db
+    -> Component.Query
+    -> Autocomplete Process
+    -> PageUpdate Model Msg
+    -> PageUpdate Model Msg
+selectConsumption requirements query autocompleteState ({ model } as pageUpdate) =
     case Autocomplete.selectedValue autocompleteState of
         Just process ->
             pageUpdate
-                |> updateQuery
-                    { query
-                        | consumptions =
-                            query.consumptions
-                                ++ [ Component.consumption (Amount.fromFloat 1) process.id ]
-                    }
+                |> updateQuery (query |> Component.addConsumption requirements process.id)
                 |> App.apply update (SetModals [])
                 |> App.withCmds [ Plausible.send pageUpdate.session <| Plausible.ConsumptionAdded (Scope.Generic model.genericScope) ]
 

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -822,7 +822,7 @@ airTransportToggler ({ query } as config) =
 cooledTransportToggler : Config db msg -> Html msg
 cooledTransportToggler ({ query } as config) =
     togglerView
-        { checked = query.transportOptions.cooling
+        { checked = query |> Component.getTransportCooling (requirementsFromConfig config)
         , id = "transportCoolingSwitch"
         , label = "réfrigéré"
         , onCheck = config.toggleTransportCooling
@@ -1205,7 +1205,7 @@ elementTransportView ({ query } as config) attributes cooling transportedMass ma
                     -- Notes:
                     --   - air transport is always disabled before assembly (see Component.computeTransports)
                     --   - cooling before assembly is driven by the material process, not the transport option
-                    { transportOptions | byAir = Split.zero, cooling = cooling }
+                    { transportOptions | byAir = Split.zero, cooling = Just cooling }
                     maybeFrom
                     maybeTo
     in
@@ -1634,7 +1634,8 @@ useStageView ({ impact, query } as config) lifeCycle =
             , documentationLink config "use"
             ]
         , div [ class "d-flex flex-column p-0" ]
-            [ query.consumptions
+            [ query
+                |> Component.getConsumptions (requirementsFromConfig config)
                 |> quantifiedProcessList config
                     lifeCycle
                     { deletionLabel = "Supprimer cette consommation"
@@ -1656,7 +1657,8 @@ addConsumptionButton ({ openSelectConsumptionModal, query } as config) =
             listAvailableProcesses config Category.Use
                 |> List.filter
                     (\{ id } ->
-                        query.consumptions
+                        query
+                            |> Component.getConsumptions (requirementsFromConfig config)
                             |> List.map Component.getConsumptionProcessId
                             |> List.member id
                             |> not

--- a/tests/Data/ComponentTest.elm
+++ b/tests/Data/ComponentTest.elm
@@ -2218,6 +2218,37 @@ suite =
                                             )
                                         )
                             )
+                        , itFromResult2 "should decode product category consumptions from process ids"
+                            (findProcessByLabel requirements "Réfrigération")
+                            (findProcessByLabel requirements "Cuisson au four")
+                            (\refrigeration ovenCooking ->
+                                ("""[{
+                                      "cooling": false,
+                                      "consumptions": ["""
+                                    ++ Encode.encode 0 (Process.encodeId refrigeration.id)
+                                    ++ ", "
+                                    ++ Encode.encode 0 (Process.encodeId ovenCooking.id)
+                                    ++ """],
+                                      "id": "5fad4e70-5736-552d-a686-97e4fb627c37",
+                                      "label": "Test category",
+                                      "scope": "food2"
+                                    }]"""
+                                )
+                                    |> Product.decodeListFromJsonString
+                                    |> Result.map (List.head >> Maybe.map .consumptions)
+                                    |> Expect.equal
+                                        (Ok
+                                            (Just
+                                                [ { amount = Nothing
+                                                  , processId = refrigeration.id
+                                                  }
+                                                , { amount = Nothing
+                                                  , processId = ovenCooking.id
+                                                  }
+                                                ]
+                                            )
+                                        )
+                            )
                         , itFromResult "should clear product, distribution, consumptions, and category cooling when unset"
                             (requirements.db.products |> List.head |> Result.fromMaybe "no product categories in test db")
                             (\categoryProduct ->

--- a/tests/Data/ComponentTest.elm
+++ b/tests/Data/ComponentTest.elm
@@ -2175,10 +2175,10 @@ suite =
                             )
                         , it "should default product category consumptions to an empty list when omitted" <|
                             ("""[{
-                                    "cooling": false,
-                                    "id": "5fad4e70-5736-552d-a686-97e4fb627c37",
-                                    "label": "Test",
-                                    "scope": "food2"
+                                  "cooling": false,
+                                  "id": "5fad4e70-5736-552d-a686-97e4fb627c37",
+                                  "label": "Test",
+                                  "scope": "food2"
                                 }]"""
                                 |> Product.decodeListFromJsonString
                                 |> Result.map (List.head >> Maybe.map .consumptions)
@@ -2189,19 +2189,17 @@ suite =
                             (findProcessByLabel requirements "Cuisson à la poêle")
                             (\refrigeration panCooking ->
                                 ("""[{
-                                    "cooling": false,
-                                    "consumptions": [
-                                      { "processId": """
-                                    ++ Encode.encode 0 (Process.encodeId refrigeration.id)
-                                    ++ """ },
-                                      { "amount": 5.5, "processId": """
-                                    ++ Encode.encode 0 (Process.encodeId panCooking.id)
-                                    ++ """ }
-                                    ],
-                                    "id": "5fad4e70-5736-552d-a686-97e4fb627c37",
-                                    "label": "Test",
-                                    "scope": "food2"
-                                }]"""
+                                      "cooling": false,
+                                      "consumptions": [
+                                        { "processId": "{{refrigerationId}}" },
+                                        { "amount": 5.5, "processId": "{{panCookingId}}" }
+                                      ],
+                                      "id": "5fad4e70-5736-552d-a686-97e4fb627c37",
+                                      "label": "Test",
+                                      "scope": "food2"
+                                    }]"""
+                                    |> String.replace "{{refrigerationId}}" (Process.idToString refrigeration.id)
+                                    |> String.replace "{{panCookingId}}" (Process.idToString panCooking.id)
                                 )
                                     |> Product.decodeListFromJsonString
                                     |> Result.map (List.head >> Maybe.map .consumptions)
@@ -2224,15 +2222,13 @@ suite =
                             (\refrigeration ovenCooking ->
                                 ("""[{
                                       "cooling": false,
-                                      "consumptions": ["""
-                                    ++ Encode.encode 0 (Process.encodeId refrigeration.id)
-                                    ++ ", "
-                                    ++ Encode.encode 0 (Process.encodeId ovenCooking.id)
-                                    ++ """],
+                                      "consumptions": ["{{refrigerationId}}", "{{ovenCookingId}}"],
                                       "id": "5fad4e70-5736-552d-a686-97e4fb627c37",
                                       "label": "Test category",
                                       "scope": "food2"
                                     }]"""
+                                    |> String.replace "{{refrigerationId}}" (Process.idToString refrigeration.id)
+                                    |> String.replace "{{ovenCookingId}}" (Process.idToString ovenCooking.id)
                                 )
                                     |> Product.decodeListFromJsonString
                                     |> Result.map (List.head >> Maybe.map .consumptions)

--- a/tests/Data/ComponentTest.elm
+++ b/tests/Data/ComponentTest.elm
@@ -642,13 +642,13 @@ suite =
                     , describe "computeElementResults"
                         [ suiteFromResult "basic tests"
                             -- setup
-                            (Process.idFromString "f0dbe27b-1e74-55d0-88a2-bda812441744"
+                            (findProcessByLabel requirements "Production de fibres de coton"
                                 |> Result.andThen
-                                    (\cottonId ->
+                                    (\cotton ->
                                         Component.computeElementResults requirements
                                             defaultTransportOptions
                                             { amount = Amount.fromFloat 1
-                                            , material = { country = Nothing, id = cottonId }
+                                            , material = { country = Nothing, id = cotton.id }
 
                                             -- Note: weaving waste: 0.06253, fading: 0
                                             , transforms =
@@ -1274,11 +1274,11 @@ suite =
                                 |> Result.fromMaybe ("No test country available scoped " ++ Scope.toString requirements.scope)
                             )
                             -- cotton
-                            (Process.idFromString "f0dbe27b-1e74-55d0-88a2-bda812441744")
+                            (findProcessByLabel requirements "Production de fibres de coton")
                             -- tests
-                            (\country materialId ->
+                            (\country cotton ->
                                 { amount = Amount.fromFloat 1
-                                , material = { country = Just country.code, id = materialId }
+                                , material = { country = Just country.code, id = cotton.id }
                                 , transforms =
                                     [ { id = fading.id
                                       , country = Just country.code
@@ -2185,29 +2185,34 @@ suite =
                                 |> Expect.equal (Ok (Just []))
                             )
                         , itFromResult2 "should decode product category consumptions with optional amounts"
-                            (Process.idFromString "b4642cec-b72e-4116-81c5-5dbfccb46055")
-                            (Process.idFromString "21e4283e-6bbf-4b2a-b52b-4440022525ad")
-                            (\refrigerationId panCookingId ->
-                                """[{
+                            (findProcessByLabel requirements "Réfrigération")
+                            (findProcessByLabel requirements "Cuisson à la poêle")
+                            (\refrigeration panCooking ->
+                                ("""[{
                                     "cooling": false,
                                     "consumptions": [
-                                      { "processId": "b4642cec-b72e-4116-81c5-5dbfccb46055" },
-                                      { "amount": 5.5, "processId": "21e4283e-6bbf-4b2a-b52b-4440022525ad" }
+                                      { "processId": """
+                                    ++ Encode.encode 0 (Process.encodeId refrigeration.id)
+                                    ++ """ },
+                                      { "amount": 5.5, "processId": """
+                                    ++ Encode.encode 0 (Process.encodeId panCooking.id)
+                                    ++ """ }
                                     ],
                                     "id": "5fad4e70-5736-552d-a686-97e4fb627c37",
                                     "label": "Test",
                                     "scope": "food2"
                                 }]"""
+                                )
                                     |> Product.decodeListFromJsonString
                                     |> Result.map (List.head >> Maybe.map .consumptions)
                                     |> Expect.equal
                                         (Ok
                                             (Just
                                                 [ { amount = Nothing
-                                                  , processId = refrigerationId
+                                                  , processId = refrigeration.id
                                                   }
                                                 , { amount = Just (Amount.fromFloat 5.5)
-                                                  , processId = panCookingId
+                                                  , processId = panCooking.id
                                                   }
                                                 ]
                                             )
@@ -2228,13 +2233,13 @@ suite =
                             )
                         , itFromResult2 "should apply category default consumptions when selecting a product"
                             (findProductCategoryByLabel requirements "Charcuterie")
-                            (Process.idFromString "b4642cec-b72e-4116-81c5-5dbfccb46055")
-                            (\categoryProduct refrigerationId ->
+                            (findProcessByLabel requirements "Réfrigération")
+                            (\categoryProduct refrigeration ->
                                 emptyQuery
                                     |> Component.updateProduct (Just categoryProduct)
                                     |> .consumptions
                                     |> List.map Component.getConsumptionProcessId
-                                    |> Expect.equal [ refrigerationId ]
+                                    |> Expect.equal [ refrigeration.id ]
                             )
                         , itFromResult2 "should replace consumptions when selecting another product category"
                             (findProductCategoryByLabel requirements "Charcuterie")
@@ -2331,6 +2336,14 @@ extractEcsImpact =
 extractComplementEcsImpact : Component.Results -> Float
 extractComplementEcsImpact =
     Component.extractComplementsImpacts >> Complement.mergeComplementsResultsImpacts >> getEcsImpact
+
+
+findProcessByLabel : Requirements db -> String -> Result String Process
+findProcessByLabel { db } label =
+    db.processes
+        |> List.filter (Process.getDisplayName >> (==) label)
+        |> List.head
+        |> Result.fromMaybe ("Procédé introuvable label=" ++ label)
 
 
 findProductCategoryByLabel : Requirements db -> String -> Result String Product.ProductCategory

--- a/tests/Data/ComponentTest.elm
+++ b/tests/Data/ComponentTest.elm
@@ -2173,7 +2173,47 @@ suite =
                                 |> Result.map .product
                                 |> Expect.equal (Ok Nothing)
                             )
-                        , itFromResult "should clear product, distribution, and category cooling when unset"
+                        , it "should default product category consumptions to an empty list when omitted" <|
+                            ("""[{
+                                    "cooling": false,
+                                    "id": "5fad4e70-5736-552d-a686-97e4fb627c37",
+                                    "label": "Test",
+                                    "scope": "food2"
+                                }]"""
+                                |> Product.decodeListFromJsonString
+                                |> Result.map (List.head >> Maybe.map .consumptions)
+                                |> Expect.equal (Ok (Just []))
+                            )
+                        , itFromResult2 "should decode product category consumptions with optional amounts"
+                            (Process.idFromString "b4642cec-b72e-4116-81c5-5dbfccb46055")
+                            (Process.idFromString "21e4283e-6bbf-4b2a-b52b-4440022525ad")
+                            (\refrigerationId panCookingId ->
+                                """[{
+                                    "cooling": false,
+                                    "consumptions": [
+                                      { "processId": "b4642cec-b72e-4116-81c5-5dbfccb46055" },
+                                      { "amount": 5.5, "processId": "21e4283e-6bbf-4b2a-b52b-4440022525ad" }
+                                    ],
+                                    "id": "5fad4e70-5736-552d-a686-97e4fb627c37",
+                                    "label": "Test",
+                                    "scope": "food2"
+                                }]"""
+                                    |> Product.decodeListFromJsonString
+                                    |> Result.map (List.head >> Maybe.map .consumptions)
+                                    |> Expect.equal
+                                        (Ok
+                                            (Just
+                                                [ { amount = Nothing
+                                                  , processId = refrigerationId
+                                                  }
+                                                , { amount = Just (Amount.fromFloat 5.5)
+                                                  , processId = panCookingId
+                                                  }
+                                                ]
+                                            )
+                                        )
+                            )
+                        , itFromResult "should clear product, distribution, consumptions, and category cooling when unset"
                             (requirements.db.products |> List.head |> Result.fromMaybe "no product categories in test db")
                             (\categoryProduct ->
                                 emptyQuery
@@ -2182,8 +2222,40 @@ suite =
                                     |> Expect.all
                                         [ .product >> Expect.equal Nothing
                                         , .distribution >> Expect.equal Nothing
+                                        , .consumptions >> Expect.equal []
                                         , .transportOptions >> .cooling >> Expect.equal defaultTransportOptions.cooling
                                         ]
+                            )
+                        , itFromResult2 "should apply category default consumptions when selecting a product"
+                            (findProductCategoryByLabel requirements "Charcuterie")
+                            (Process.idFromString "b4642cec-b72e-4116-81c5-5dbfccb46055")
+                            (\categoryProduct refrigerationId ->
+                                emptyQuery
+                                    |> Component.updateProduct (Just categoryProduct)
+                                    |> .consumptions
+                                    |> List.map Component.getConsumptionProcessId
+                                    |> Expect.equal [ refrigerationId ]
+                            )
+                        , itFromResult2 "should replace consumptions when selecting another product category"
+                            (findProductCategoryByLabel requirements "Charcuterie")
+                            (findProductCategoryByLabel requirements "Produits congelés")
+                            (\charcuterie frozen ->
+                                emptyQuery
+                                    |> Component.updateProduct (Just charcuterie)
+                                    |> Component.updateProduct (Just frozen)
+                                    |> .consumptions
+                                    |> List.map Component.getConsumptionProcessId
+                                    |> Expect.equal (List.map .processId frozen.consumptions)
+                            )
+                        , itFromResult "should not reset consumptions when re-selecting the same product"
+                            (findProductCategoryByLabel requirements "Charcuterie")
+                            (\categoryProduct ->
+                                emptyQuery
+                                    |> Component.updateProduct (Just categoryProduct)
+                                    |> (\query -> { query | consumptions = [] })
+                                    |> Component.updateProduct (Just categoryProduct)
+                                    |> .consumptions
+                                    |> Expect.equal []
                             )
                         , it "should reject a query carrying an unknown product id" <|
                             (Product.idFromString nonExistentUuid
@@ -2259,6 +2331,14 @@ extractEcsImpact =
 extractComplementEcsImpact : Component.Results -> Float
 extractComplementEcsImpact =
     Component.extractComplementsImpacts >> Complement.mergeComplementsResultsImpacts >> getEcsImpact
+
+
+findProductCategoryByLabel : Requirements db -> String -> Result String Product.ProductCategory
+findProductCategoryByLabel { db } label =
+    db.products
+        |> List.filter (.label >> (==) label)
+        |> List.head
+        |> Result.fromMaybe ("Catégorie de produit introuvable label=" ++ label)
 
 
 getEcsImpact : Impacts -> Float

--- a/tests/Data/ComponentTest.elm
+++ b/tests/Data/ComponentTest.elm
@@ -1464,7 +1464,7 @@ suite =
                             , it "should include cooled transport when the option is set"
                                 (Mass.kilogram
                                     |> Component.computeTransportedMassImpacts requirements
-                                        { defaultTransportOptions | cooling = True }
+                                        { defaultTransportOptions | cooling = Just True }
                                         (Just portugal)
                                         (Just france)
                                     |> Result.map (.roadCooled >> Length.inKilometers)
@@ -2058,8 +2058,7 @@ suite =
                                 [ it "should reject a non-positive amount" <|
                                     ({ emptyQuery
                                         | consumptions =
-                                            [ Component.consumption (Amount.fromFloat -1) steelProcess.id
-                                            ]
+                                            Just [ Component.consumption (Amount.fromFloat -1) steelProcess.id ]
                                      }
                                         |> Component.validateQuery { requirements | scope = Scope.Generic Scope.Food2 }
                                         |> expectResultErrorContains "Une quantité doit être supérieure ou égale à zéro"
@@ -2128,8 +2127,7 @@ suite =
                                 [ it "should reject a consumption referencing a missing process" <|
                                     ({ emptyQuery
                                         | consumptions =
-                                            [ Component.consumption (Amount.fromFloat 1) nonExistingProcessId
-                                            ]
+                                            Just [ Component.consumption (Amount.fromFloat 1) nonExistingProcessId ]
                                      }
                                         |> Component.validateQuery requirements
                                         |> expectResultErrorContains ("Aucun procédé scopé Objets avec cet id: " ++ Process.idToString nonExistingProcessId)
@@ -2138,8 +2136,7 @@ suite =
                                     ({ emptyQuery
                                         | consumptions =
                                             -- Note: the sawing process isn't scoped for Food2
-                                            [ Component.consumption (Amount.fromFloat 1) sawingProcess.id
-                                            ]
+                                            Just [ Component.consumption (Amount.fromFloat 1) sawingProcess.id ]
                                      }
                                         |> Component.validateQuery { requirements | scope = Scope.Generic Scope.Food2 }
                                         |> expectResultErrorContains ("Aucun procédé scopé Alimentaire BÉTA avec cet id: " ++ Process.idToString sawingProcess.id)
@@ -2167,12 +2164,57 @@ suite =
                             ]
                         )
                     , describe "optional product category"
-                        [ it "should decode a query with no product field defined" <|
-                            ("""{"components":[]}"""
-                                |> decodeJson Component.decodeQuery
-                                |> Result.map .product
-                                |> Expect.equal (Ok Nothing)
-                            )
+                        [ describe "decoding"
+                            [ it "should decode a query with no product field defined" <|
+                                ("""{"components":[]}"""
+                                    |> decodeJson Component.decodeQuery
+                                    |> Result.map .product
+                                    |> Expect.equal (Ok Nothing)
+                                )
+                            , it "should decode omitted consumptions and cooling as unspecified" <|
+                                ("""{"components":[]}"""
+                                    |> decodeJson Component.decodeQuery
+                                    |> Result.map (\query -> ( query.consumptions, query.transportOptions.cooling ))
+                                    |> Expect.equal (Ok ( Nothing, Nothing ))
+                                )
+                            , it "should decode an explicit empty consumptions list" <|
+                                ("""{"components":[],"consumptions":[]}"""
+                                    |> decodeJson Component.decodeQuery
+                                    |> Result.map .consumptions
+                                    |> Expect.equal (Ok (Just []))
+                                )
+                            , it "should decode explicitly disabled cooling" <|
+                                ("""{"components":[],"transportOptions":{"cooling":false}}"""
+                                    |> decodeJson Component.decodeQuery
+                                    |> Result.map (.transportOptions >> .cooling)
+                                    |> Expect.equal (Ok (Just False))
+                                )
+                            ]
+                        , describe "encoding"
+                            [ it "should omit unspecified consumptions and cooling when encoding" <|
+                                (emptyQuery
+                                    |> Component.encodeQuery
+                                    |> Encode.encode 0
+                                    |> Expect.all
+                                        [ String.contains "\"consumptions\"" >> Expect.equal False
+                                        , String.contains "\"cooling\"" >> Expect.equal False
+                                        ]
+                                )
+                            , it "should encode an explicit empty consumptions list" <|
+                                ({ emptyQuery | consumptions = Just [] }
+                                    |> Component.encodeQuery
+                                    |> Encode.encode 0
+                                    |> String.contains "\"consumptions\":[]"
+                                    |> Expect.equal True
+                                )
+                            , it "should encode explicit cooling false" <|
+                                ({ emptyQuery | transportOptions = { defaultTransportOptions | cooling = Just False } }
+                                    |> Component.encodeQuery
+                                    |> Encode.encode 0
+                                    |> String.contains "\"cooling\":false"
+                                    |> Expect.equal True
+                                )
+                            ]
                         , it "should default product category consumptions to an empty list when omitted" <|
                             ("""[{
                                   "cooling": false,
@@ -2254,8 +2296,20 @@ suite =
                                     |> Expect.all
                                         [ .product >> Expect.equal Nothing
                                         , .distribution >> Expect.equal Nothing
-                                        , .consumptions >> Expect.equal []
-                                        , .transportOptions >> .cooling >> Expect.equal defaultTransportOptions.cooling
+                                        , .consumptions >> Expect.equal Nothing
+                                        , .transportOptions >> .cooling >> Expect.equal Nothing
+                                        ]
+                            )
+                        , itFromResult "should reset product category-dependent fields to Nothing when selecting a product"
+                            (findProductCategoryByLabel requirements "Charcuterie")
+                            (\categoryProduct ->
+                                emptyQuery
+                                    |> Component.updateProduct (Just categoryProduct)
+                                    |> Expect.all
+                                        [ .product >> Expect.equal (Just categoryProduct.id)
+                                        , .consumptions >> Expect.equal Nothing
+                                        , .distribution >> Expect.equal Nothing
+                                        , .transportOptions >> .cooling >> Expect.equal Nothing
                                         ]
                             )
                         , itFromResult2 "should apply category default consumptions when selecting a product"
@@ -2264,30 +2318,132 @@ suite =
                             (\categoryProduct refrigeration ->
                                 emptyQuery
                                     |> Component.updateProduct (Just categoryProduct)
-                                    |> .consumptions
+                                    |> Component.getConsumptions requirements
                                     |> List.map Component.getConsumptionProcessId
                                     |> Expect.equal [ refrigeration.id ]
                             )
-                        , itFromResult2 "should replace consumptions when selecting another product category"
+                        , itFromResult2 "should replace resolved consumptions when selecting another product category"
                             (findProductCategoryByLabel requirements "Charcuterie")
                             (findProductCategoryByLabel requirements "Produits congelés")
                             (\charcuterie frozen ->
                                 emptyQuery
                                     |> Component.updateProduct (Just charcuterie)
                                     |> Component.updateProduct (Just frozen)
-                                    |> .consumptions
+                                    |> Component.getConsumptions requirements
                                     |> List.map Component.getConsumptionProcessId
                                     |> Expect.equal (List.map .processId frozen.consumptions)
                             )
-                        , itFromResult "should not reset consumptions when re-selecting the same product"
+                        , itFromResult "should not reset explicit consumptions when re-selecting the same product"
                             (findProductCategoryByLabel requirements "Charcuterie")
                             (\categoryProduct ->
                                 emptyQuery
                                     |> Component.updateProduct (Just categoryProduct)
-                                    |> (\query -> { query | consumptions = [] })
+                                    |> (\query -> { query | consumptions = Just [] })
                                     |> Component.updateProduct (Just categoryProduct)
                                     |> .consumptions
+                                    |> Expect.equal (Just [])
+                            )
+                        , itFromResult2 "should let an explicit consumptions list take precedence over the category"
+                            (findProductCategoryByLabel requirements "Charcuterie")
+                            (findProcessByLabel requirements "Cuisson au four")
+                            (\charcuterie ovenCooking ->
+                                { emptyQuery
+                                    | consumptions = Just [ Component.consumption (Amount.fromFloat 1) ovenCooking.id ]
+                                    , product = Just charcuterie.id
+                                }
+                                    |> Component.getConsumptions requirements
+                                    |> List.map Component.getConsumptionProcessId
+                                    |> Expect.equal [ ovenCooking.id ]
+                            )
+                        , itFromResult "should let an explicit empty consumptions list take precedence over the category"
+                            (findProductCategoryByLabel requirements "Charcuterie")
+                            (\charcuterie ->
+                                { emptyQuery
+                                    | consumptions = Just []
+                                    , product = Just charcuterie.id
+                                }
+                                    |> Component.getConsumptions requirements
                                     |> Expect.equal []
+                            )
+                        , it "should resolve no consumptions when product and query are unspecified" <|
+                            (emptyQuery
+                                |> Component.getConsumptions requirements
+                                |> Expect.equal []
+                            )
+                        , itFromResult "should preserve explicit consumptions so deleting them all does not leverage category defaults"
+                            (findProductCategoryByLabel requirements "Charcuterie")
+                            (\charcuterie ->
+                                emptyQuery
+                                    |> Component.updateProduct (Just charcuterie)
+                                    |> Component.removeConsumption requirements 0
+                                    |> Expect.all
+                                        [ .consumptions >> Expect.equal (Just [])
+                                        , Component.getConsumptions requirements >> Expect.equal []
+                                        ]
+                            )
+                        , itFromResult2 "should preserve category consumptions when adding one"
+                            (findProductCategoryByLabel requirements "Charcuterie")
+                            (findProcessByLabel requirements "Cuisson au four")
+                            (\charcuterie ovenCooking ->
+                                emptyQuery
+                                    |> Component.updateProduct (Just charcuterie)
+                                    |> Component.addConsumption requirements ovenCooking.id
+                                    |> Component.getConsumptions requirements
+                                    |> List.map Component.getConsumptionProcessId
+                                    |> Expect.equal (List.map .processId charcuterie.consumptions ++ [ ovenCooking.id ])
+                            )
+                        , itFromResult2 "should update category consumption when explicitely updating its amount"
+                            (findProductCategoryByLabel requirements "Charcuterie")
+                            (findProcessByLabel requirements "Réfrigération")
+                            (\charcuterie refrigeration ->
+                                emptyQuery
+                                    |> Component.updateProduct (Just charcuterie)
+                                    |> Component.updateConsumptionAmount requirements 0 (Amount.fromFloat 3)
+                                    |> .consumptions
+                                    |> Expect.equal (Just [ Component.consumption (Amount.fromFloat 3) refrigeration.id ])
+                            )
+                        , itFromResult "should use product category cooling when the query doesn't set it"
+                            (findProductCategoryByLabel requirements "Charcuterie")
+                            (\charcuterie ->
+                                emptyQuery
+                                    |> Component.updateProduct (Just charcuterie)
+                                    |> Component.getTransportCooling requirements
+                                    |> Expect.equal True
+                            )
+                        , itFromResult "should let an explicit cooling value have precedence over product category defaults"
+                            (findProductCategoryByLabel requirements "Charcuterie")
+                            (\charcuterie ->
+                                emptyQuery
+                                    |> Component.updateProduct (Just charcuterie)
+                                    |> Component.setTransportCooling False
+                                    |> Component.getTransportCooling requirements
+                                    |> Expect.equal False
+                            )
+                        , itFromResult "should disable product category cooling when the query doesn't set it"
+                            (findProductCategoryByLabel requirements "Céréales brutes")
+                            (\cereals ->
+                                emptyQuery
+                                    |> Component.updateProduct (Just cereals)
+                                    |> Component.getTransportCooling requirements
+                                    |> Expect.equal False
+                            )
+                        , itFromResult "should resolve product category distribution when the query doesn't set it"
+                            (findProductCategoryByLabel requirements "Charcuterie")
+                            (\charcuterie ->
+                                emptyQuery
+                                    |> Component.updateProduct (Just charcuterie)
+                                    |> Component.getDistributionProcessId { requirements | scope = Scope.Generic Scope.Food2 }
+                                    |> Expect.equal charcuterie.distribution
+                            )
+                        , itFromResult2 "should let explicit distribution taking precedence over product category value"
+                            (findProductCategoryByLabel requirements "Charcuterie")
+                            (findProductCategoryByLabel requirements "Produits congelés")
+                            (\charcuterie frozen ->
+                                emptyQuery
+                                    |> Component.updateProduct (Just charcuterie)
+                                    |> Component.updateDistribution frozen.distribution
+                                    |> Component.getDistributionProcessId { requirements | scope = Scope.Generic Scope.Food2 }
+                                    |> Expect.equal frozen.distribution
                             )
                         , it "should reject a query carrying an unknown product id" <|
                             (Product.idFromString nonExistentUuid


### PR DESCRIPTION
## :wrench: Problem

Fixes #2708

Ce patch implémente la définition et l'application des consommations par défaut à la phase d'utilisation liées à une catégorie de produit.

## 🚨 Points to watch

- je n'ai pas ajouté de données de conso catégoriques pour véli et objet car je n'en dispose pas
- à ce titre, même si la gestion des quantité de consommation a été implémentée, elle n'est pas testable dans l'ui faute de données; en revanche, les tests unitaires démontrent que l'implémentation est effective

## :desert_island: How to test

Seules les catégories de produits food2 se voient attribuer des consommations par défaut, il faut donc tester la sélection et le changement de la catégorie de produit dans le simulateur food2. 

Tester la colonne "Consommations" dans l'onglet "Produits" de l'explorateur food2

Ne pas hésiter à tester l'ajout et la suppression de consommations supplémentaires et de changer la catégorie à nouveau pour bien valider que le comportement implémenté est celui désiré.