### PR TITLE
refactor(data): share the SimaPro strategies and linking

### DIFF
--- a/data/common/bw/strategies.py
+++ b/data/common/bw/strategies.py
@@ -1,0 +1,40 @@
+import functools
+
+from bw2io.strategies import (
+    assign_only_product_as_production,
+    change_electricity_unit_mj_to_kwh,
+    drop_unspecified_subcategories,
+    fix_zero_allocation_products,
+    migrate_datasets,
+    migrate_exchanges,
+    normalize_biosphere_categories,
+    normalize_simapro_biosphere_categories,
+    normalize_simapro_biosphere_names,
+    normalize_units,
+    set_code_by_activity_hash,
+    sp_allocate_products,
+    split_simapro_name_geo,
+    strip_biosphere_exc_locations,
+    update_ecoinvent_locations,
+)
+from bw2io.strategies.simapro import set_lognormal_loc_value_uncertainty_safe
+
+SIMAPRO_STRATEGIES = [
+    normalize_units,
+    update_ecoinvent_locations,
+    assign_only_product_as_production,
+    drop_unspecified_subcategories,
+    sp_allocate_products,
+    fix_zero_allocation_products,
+    split_simapro_name_geo,
+    strip_biosphere_exc_locations,
+    functools.partial(migrate_datasets, migration="default-units"),
+    functools.partial(migrate_exchanges, migration="default-units"),
+    functools.partial(set_code_by_activity_hash, overwrite=True),
+    change_electricity_unit_mj_to_kwh,
+    set_lognormal_loc_value_uncertainty_safe,
+    normalize_biosphere_categories,
+    normalize_simapro_biosphere_categories,
+]
+
+SIMAPRO_BIOSPHERE_NAMES = [normalize_simapro_biosphere_names]

--- a/data/common/import_.py
+++ b/data/common/import_.py
@@ -430,9 +430,9 @@ def add_unlinked_flows_to_biosphere_database(
     data = {(biosphere_name, exc["code"]): exc for exc in new_data}
     # then deduplicate/overwrite them with original data
     # still using the activity_hash as a key but the uuis as internal code
-    data.update({
-        (biosphere_name, activity_hash(exc)): exc for exc in bio.load().values()
-    })
+    data.update(
+        {(biosphere_name, activity_hash(exc)): exc for exc in bio.load().values()}
+    )
     # then reconstruct data with the uuid
     data = {(biosphere_name, exc["code"]): exc for exc in data.values()}
     bio.write(data)
@@ -507,7 +507,7 @@ def import_simapro_csv(
 
 def link_and_write(database, external_db=None, biosphere="biosphere3") -> None:
     for other_database in [None, external_db] if external_db else [None]:
-        for fields in (("name", "unit", "location"), ("name", "unit")):
+        for fields in (["name", "unit", "location"], ["name", "unit"]):
             database.apply_strategy(
                 functools.partial(
                     link_technosphere_by_activity_hash_ref_product,

--- a/data/common/import_.py
+++ b/data/common/import_.py
@@ -430,9 +430,9 @@ def add_unlinked_flows_to_biosphere_database(
     data = {(biosphere_name, exc["code"]): exc for exc in new_data}
     # then deduplicate/overwrite them with original data
     # still using the activity_hash as a key but the uuis as internal code
-    data.update(
-        {(biosphere_name, activity_hash(exc)): exc for exc in bio.load().values()}
-    )
+    data.update({
+        (biosphere_name, activity_hash(exc)): exc for exc in bio.load().values()
+    })
     # then reconstruct data with the uuid
     data = {(biosphere_name, exc["code"]): exc for exc in data.values()}
     bio.write(data)
@@ -501,32 +501,20 @@ def import_simapro_csv(
     database.apply_strategies()
     database.statistics()
 
-    # try to link remaining unlinked technosphere activities
-    database.apply_strategy(
-        functools.partial(
-            link_technosphere_by_activity_hash_ref_product,
-            fields=["name", "unit", "location"],
-        )
-    )
-    database.apply_strategy(
-        functools.partial(
-            link_technosphere_by_activity_hash_ref_product, fields=["name", "unit"]
-        )
-    )
-    database.apply_strategy(
-        functools.partial(
-            link_technosphere_by_activity_hash_ref_product,
-            external_db_name=external_db,
-            fields=["name", "unit", "location"],
-        )
-    )
-    database.apply_strategy(
-        functools.partial(
-            link_technosphere_by_activity_hash_ref_product,
-            external_db_name=external_db,
-            fields=["name", "unit"],
-        )
-    )
+    link_and_write(database, external_db=external_db, biosphere=biosphere)
+    logger.info(f"🟢 Finished importing {database_s3_key}")
+
+
+def link_and_write(database, external_db=None, biosphere="biosphere3") -> None:
+    for other_database in [None, external_db] if external_db else [None]:
+        for fields in (("name", "unit", "location"), ("name", "unit")):
+            database.apply_strategy(
+                functools.partial(
+                    link_technosphere_by_activity_hash_ref_product,
+                    external_db_name=other_database,
+                    fields=fields,
+                )
+            )
     database.apply_strategy(
         functools.partial(
             link_iterable_by_fields,
@@ -557,8 +545,6 @@ def import_simapro_csv(
     database.statistics()
     bw2data.Database(biosphere).register()
     database.write_database()
-
-    logger.info(f"🟢 Finished importing {database_s3_key}")
 
 
 def add_missing_substances(project, biosphere):

--- a/data/import_ecoinvent.py
+++ b/data/import_ecoinvent.py
@@ -6,7 +6,7 @@ from bw2io.strategies import (
     normalize_biosphere_names,
 )
 
-from common import brightway_patch as brightway_patch
+from common import brightway_patch as brightway_patch  # noqa: PLC0414
 from common.bw.strategies import SIMAPRO_BIOSPHERE_NAMES, SIMAPRO_STRATEGIES
 from common.import_ import (
     import_simapro_csv,

--- a/data/import_ecoinvent.py
+++ b/data/import_ecoinvent.py
@@ -1,33 +1,13 @@
 #!/usr/bin/env python3
 
-# from bw2io.migrations import create_core_migrations
-import functools
-
 import bw2data
 from bw2io.strategies import (
-    assign_only_product_as_production,
-    change_electricity_unit_mj_to_kwh,
     convert_activity_parameters_to_list,
-    drop_unspecified_subcategories,
-    # fix_localized_water_flows,
-    fix_zero_allocation_products,
-    # link_technosphere_based_on_name_unit_location,
-    migrate_datasets,
-    migrate_exchanges,
-    normalize_biosphere_categories,
     normalize_biosphere_names,
-    normalize_simapro_biosphere_categories,
-    normalize_simapro_biosphere_names,
-    normalize_units,
-    set_code_by_activity_hash,
-    sp_allocate_products,
-    split_simapro_name_geo,
-    strip_biosphere_exc_locations,
-    update_ecoinvent_locations,
 )
-from bw2io.strategies.simapro import set_lognormal_loc_value_uncertainty_safe
 
-from common import brightway_patch as brightway_patch  # noqa: PLC0414
+from common import brightway_patch as brightway_patch
+from common.bw.strategies import SIMAPRO_BIOSPHERE_NAMES, SIMAPRO_STRATEGIES
 from common.import_ import (
     import_simapro_csv,
     setup_project,
@@ -47,29 +27,12 @@ from ecobalyse_data.bw.strategy import (
 )
 from ecobalyse_data.logging import logger
 
-STRATEGIES = [
-    normalize_units,
-    update_ecoinvent_locations,
-    assign_only_product_as_production,
-    drop_unspecified_subcategories,
-    sp_allocate_products,
-    fix_zero_allocation_products,
-    split_simapro_name_geo,
-    strip_biosphere_exc_locations,
-    functools.partial(migrate_datasets, migration="default-units"),
-    functools.partial(migrate_exchanges, migration="default-units"),
-    functools.partial(set_code_by_activity_hash, overwrite=True),
-    change_electricity_unit_mj_to_kwh,
-    # link_technosphere_based_on_name_unit_location,  # link is done in common.import_ at the end
-    set_lognormal_loc_value_uncertainty_safe,
-    normalize_biosphere_categories,
-    normalize_simapro_biosphere_categories,
-    normalize_biosphere_names,
-    normalize_simapro_biosphere_names,
-    # functools.partial(migrate_exchanges, migration="simapro-water"),
-    # fix_localized_water_flows,
-    convert_activity_parameters_to_list,
-]
+STRATEGIES = (
+    SIMAPRO_STRATEGIES
+    + [normalize_biosphere_names]
+    + SIMAPRO_BIOSPHERE_NAMES
+    + [convert_activity_parameters_to_list]
+)
 ECOINVENT_STRATEGIES = [
     extract_simapro_metadata,
     # extract_simapro_location,

--- a/data/import_food.py
+++ b/data/import_food.py
@@ -3,7 +3,7 @@ import argparse
 
 import bw2data
 
-from common import brightway_patch as brightway_patch
+from common import brightway_patch as brightway_patch  # noqa: PLC0414
 from common.bw.strategies import SIMAPRO_BIOSPHERE_NAMES, SIMAPRO_STRATEGIES
 from common.import_ import (
     import_simapro_csv,

--- a/data/import_food.py
+++ b/data/import_food.py
@@ -1,32 +1,10 @@
 #!/usr/bin/env python3
 import argparse
-import functools
 
 import bw2data
-from bw2io.strategies import (
-    assign_only_product_as_production,
-    change_electricity_unit_mj_to_kwh,
-    # convert_activity_parameters_to_list,
-    drop_unspecified_subcategories,
-    # fix_localized_water_flows,
-    fix_zero_allocation_products,
-    # link_technosphere_based_on_name_unit_location,
-    migrate_datasets,
-    migrate_exchanges,
-    normalize_biosphere_categories,
-    # normalize_biosphere_names,
-    normalize_simapro_biosphere_categories,
-    normalize_simapro_biosphere_names,
-    normalize_units,
-    set_code_by_activity_hash,
-    sp_allocate_products,
-    split_simapro_name_geo,
-    strip_biosphere_exc_locations,
-    update_ecoinvent_locations,
-)
-from bw2io.strategies.simapro import set_lognormal_loc_value_uncertainty_safe
 
-from common import brightway_patch as brightway_patch  # noqa: PLC0414
+from common import brightway_patch as brightway_patch
+from common.bw.strategies import SIMAPRO_BIOSPHERE_NAMES, SIMAPRO_STRATEGIES
 from common.import_ import (
     import_simapro_csv,
     setup_project,
@@ -55,28 +33,7 @@ PROJECT = "ecobalyse"
 BIOSPHERE = "biosphere3"
 
 
-STRATEGIES = [
-    normalize_units,
-    update_ecoinvent_locations,
-    assign_only_product_as_production,
-    drop_unspecified_subcategories,
-    sp_allocate_products,
-    fix_zero_allocation_products,
-    split_simapro_name_geo,
-    strip_biosphere_exc_locations,
-    functools.partial(migrate_datasets, migration="default-units"),
-    functools.partial(migrate_exchanges, migration="default-units"),
-    functools.partial(set_code_by_activity_hash, overwrite=True),
-    change_electricity_unit_mj_to_kwh,
-    # link_technosphere_based_on_name_unit_location,
-    set_lognormal_loc_value_uncertainty_safe,
-    normalize_biosphere_categories,
-    normalize_simapro_biosphere_categories,
-    # normalize_biosphere_names,
-    normalize_simapro_biosphere_names,
-    # functools.partial(migrate_exchanges, migration="simapro-water"),
-    # fix_localized_water_flows,
-]
+STRATEGIES = SIMAPRO_STRATEGIES + SIMAPRO_BIOSPHERE_NAMES
 
 
 GINKO_STRATEGIES = [


### PR DESCRIPTION
## :wrench: Problem

brightway strategies may diverge between different databases, though they are all exported from simapro.

## :cake: Solution

refactor and share them in a common file

## :desert_island: How to test

delete your $BRIGHTWAY2_DIR then run again a full import/export. `just import-all && just export-all` →no diff 