### PR TITLE
fix(generic,ui): hide tabs and categ selector on empty query

### DIFF
--- a/src/Page/Generic.elm
+++ b/src/Page/Generic.elm
@@ -1086,10 +1086,14 @@ simulatorView ({ componentConfig } as session) ({ genericScope } as model) =
 
                 -- Impacts tabs
                 , impactTabsConfig =
-                    SwitchImpactsTab
-                        |> ImpactTabs.createConfig session model.impact model.activeImpactsTab (always NoOp)
-                        |> ImpactTabs.forGeneric session.db.definitions lifeCycle
-                        |> Just
+                    if not <| List.isEmpty currentQuery.items then
+                        SwitchImpactsTab
+                            |> ImpactTabs.createConfig session model.impact model.activeImpactsTab (always NoOp)
+                            |> ImpactTabs.forGeneric session.db.definitions lifeCycle
+                            |> Just
+
+                    else
+                        Nothing
 
                 -- Bookmarks
                 , activeBookmarkTab = model.bookmarkTab

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -1862,7 +1862,7 @@ productCategorySelectorView { onSelect, products, query, scope } =
                 |> ProductCategory.findByScope scope
                 |> List.sortBy .label
     in
-    if List.isEmpty scopedProducts || query == Component.emptyQuery then
+    if List.isEmpty scopedProducts || List.isEmpty query.items then
         text ""
 
     else


### PR DESCRIPTION
## :wrench: Problem

Fixes #2749

## :cake: Solution

Hide sidebar indicator tabs when the query is empty

Also hide product category selector when the query is empty
