### PR TITLE
feat(generic): handle product category default assembly operations

### DIFF
--- a/public/data/veli/categories.json
+++ b/public/data/veli/categories.json
@@ -1,53 +1,62 @@
 [
   {
+    "assembly": ["c51ab87d-f368-4704-a5ec-7ea17ba87d46"],
     "cooling": false,
     "id": "b87cbaf5-4ad5-4bc6-84b6-b63c934e1d60",
     "label": "Vélos et VAEs de moins de 100kg",
     "scope": "veli"
   },
   {
+    "assembly": ["c51ab87d-f368-4704-a5ec-7ea17ba87d46"],
     "cooling": false,
     "id": "7109cf4a-a81c-4b7b-a6fb-1e0ffdc20af1",
     "label": "VAEs de 100kg et plus et vélos à moteur (L1e-A)",
     "scope": "veli"
   },
   {
+    "assembly": ["c51ab87d-f368-4704-a5ec-7ea17ba87d46"],
     "cooling": false,
     "id": "ed3b8835-7d3d-422a-a7af-4478a2938766",
     "label": "Cyclomoteurs (L1e-B et L2e)",
     "scope": "veli"
   },
   {
+    "assembly": ["c51ab87d-f368-4704-a5ec-7ea17ba87d46"],
     "cooling": false,
     "id": "77fea635-0fca-423e-8097-05ea7c165d1b",
     "label": "Motocycles (L3e, L4e, L5e)",
     "scope": "veli"
   },
   {
+    "assembly": ["c51ab87d-f368-4704-a5ec-7ea17ba87d46"],
     "cooling": false,
     "id": "9aa6dc3a-5b0a-4721-8825-2dadab8706ab",
     "label": "Quadricycles légers (L6e)",
     "scope": "veli"
   },
   {
+    "assembly": ["c51ab87d-f368-4704-a5ec-7ea17ba87d46"],
     "cooling": false,
     "id": "bacd59a6-fdfe-4480-a6df-69f14b323857",
     "label": "Quadricycles lourd (L7e)",
     "scope": "veli"
   },
   {
+    "assembly": ["c51ab87d-f368-4704-a5ec-7ea17ba87d46"],
     "cooling": false,
     "id": "2f7f24c7-bd0f-4e68-97b7-4a5a97d5a197",
     "label": "Voitures électriques (M1)",
     "scope": "veli"
   },
   {
+    "assembly": ["c51ab87d-f368-4704-a5ec-7ea17ba87d46"],
     "cooling": false,
     "id": "6ca5d5a2-fa5d-46b5-b520-179df78046e9",
     "label": "Voitures essence (M1)",
     "scope": "veli"
   },
   {
+    "assembly": ["c51ab87d-f368-4704-a5ec-7ea17ba87d46"],
     "cooling": false,
     "id": "ee81b5d9-c6e7-45e2-ba1c-1f8cb072a224",
     "label": "Voitures diesel (M1)",

--- a/src/CheckDb.elm
+++ b/src/CheckDb.elm
@@ -250,6 +250,59 @@ checkExamplesScope db =
             )
 
 
+{-| Checks that a product category assembly process exists, is scoped, is an assembly process, and is in kg.
+-}
+checkProductCategoryAssembly : Dict String Process -> ProductCategory -> Process.Id -> List Error
+checkProductCategoryAssembly processes product processId =
+    let
+        processIdString =
+            Process.idToString processId
+    in
+    case processes |> Dict.get processIdString of
+        Just process ->
+            if process.scopes |> List.member (Scope.Generic product.scope) |> not then
+                formatError
+                    [ "Product category " ++ productCategoryLabel product
+                    , "references process " ++ processLabel process
+                    , "in assembly but isn't scoped for " ++ backtick (Scope.toStringGeneric product.scope)
+                    ]
+
+            else if not (List.member ProcessCategory.Assembly process.categories) then
+                formatError
+                    [ "Product category " ++ productCategoryLabel product
+                    , "references process " ++ processLabel process
+                    , "in assembly but the process is not an assembly process"
+                    ]
+
+            else if process.unit /= Process.Kilogram then
+                formatError
+                    [ "Product category " ++ productCategoryLabel product
+                    , "references process " ++ processLabel process
+                    , "in assembly but the process unit is not kg"
+                    ]
+
+            else
+                []
+
+        Nothing ->
+            formatError
+                [ "Product category " ++ productCategoryLabel product
+                , "references missing process " ++ processIdString ++ " in assembly"
+                ]
+
+
+{-| Validates process references used by generic product category assembly defaults.
+-}
+checkProductCategoryAssemblies : Db -> List Error
+checkProductCategoryAssemblies db =
+    db.products
+        |> List.concatMap
+            (\product ->
+                product.assembly
+                    |> List.concatMap (product |> checkProductCategoryAssembly (processById db.processes))
+            )
+
+
 {-| Checks that a product category consumption references an existing, scope-compatible process.
 When amount is omitted, the process _must_ be product-mass-dependent.
 -}
@@ -338,6 +391,7 @@ checkStaticDatabase config dbName dbResult =
             []
                 |> addGroupedErrors (section "Examples components checks") (checkExamplesComponentIds knownComponentStringIds db)
                 |> addGroupedErrors (section "Components processes checks") (checkComponentsProcessIds knownProcessStringIds db)
+                |> addGroupedErrors (section "Product category assembly checks") (checkProductCategoryAssemblies db)
                 |> addGroupedErrors (section "Product category consumptions checks") (checkProductCategoryConsumptions db)
                 |> addGroupedErrors (section "Scoping checks") (checkExamplesScope db)
                 |> addGroupedErrors (section "Component config checks") (checkComponentConfig db config)

--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -55,6 +55,7 @@ module Data.Component exposing
     , defaultTransportOptions
     , elementTransforms
     , elementsToString
+    , emptyAssembly
     , emptyComponent
     , emptyLifeCycle
     , emptyQuery
@@ -219,8 +220,12 @@ type alias Query =
     }
 
 
-{-| Assembly step query, composed of an optional localization and zero, one or more successive
+{-| Assembly step query, composed of an optional localization and successive
 transformations operated on the output mass of the production stage.
+
+`operations` is `Nothing` when unspecified (product category default applies),
+`Just []` when explicitly empty, and `Just [id, …]` when explicitly set.
+
 -}
 type alias Assembly =
     { country : Maybe CountryCode.Code

--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -77,6 +77,7 @@ module Data.Component exposing
     , extractMass
     , extractStage
     , findById
+    , getAssemblyOperations
     , getAvailableDistributionProcesses
     , getConsumptionProcessId
     , getConsumptions
@@ -223,7 +224,7 @@ transformations operated on the output mass of the production stage.
 -}
 type alias Assembly =
     { country : Maybe CountryCode.Code
-    , operations : List Process.Id
+    , operations : Maybe (List Process.Id)
     }
 
 
@@ -453,12 +454,12 @@ type alias Requirements db =
 
 {-| Add a new assembly operation process to a query.
 -}
-addAssemblyOperation : Process -> Query -> Query
-addAssemblyOperation process ({ assembly } as query) =
+addAssemblyOperation : Requirements db -> Process -> Query -> Query
+addAssemblyOperation requirements process ({ assembly } as query) =
     { query
         | assembly =
             { assembly
-                | operations = assembly.operations ++ [ process.id ]
+                | operations = Just (getAssemblyOperations requirements query ++ [ process.id ])
             }
     }
 
@@ -766,12 +767,15 @@ compute requirements query =
 {-| Compute assembly stage impacts
 -}
 computeAssemblyImpacts : Requirements db -> Query -> LifeCycle -> Result String LifeCycle
-computeAssemblyImpacts requirements { assembly } lifeCycle =
+computeAssemblyImpacts requirements ({ assembly } as query) lifeCycle =
     let
         productionMass =
             extractMass lifeCycle.production
+
+        operations =
+            getAssemblyOperations requirements query
     in
-    if List.isEmpty assembly.operations then
+    if List.isEmpty operations then
         Ok
             { lifeCycle
                 | assembly = emptyResults
@@ -781,7 +785,8 @@ computeAssemblyImpacts requirements { assembly } lifeCycle =
             }
 
     else
-        expandAssembly requirements.db assembly
+        operations
+            |> expandAssembly requirements.db assembly.country
             |> Result.andThen
                 (\expandedProcesses ->
                     assemblyResultsFromMass productionMass
@@ -1434,7 +1439,7 @@ decodeAssembly =
         [ Decode.field "assembly"
             (Decode.succeed Assembly
                 |> DU.strictOptional "country" CountryCode.decode
-                |> Decode.optional "operations" (Decode.list Process.decodeId) []
+                |> DU.strictOptional "operations" (Decode.list Process.decodeId)
             )
         , Decode.field "assemblyCountry" CountryCode.decode
             |> Decode.map (\country -> { emptyAssembly | country = Just country })
@@ -1493,7 +1498,7 @@ elementsToString db component =
 emptyAssembly : Assembly
 emptyAssembly =
     { country = Nothing
-    , operations = []
+    , operations = Nothing
     }
 
 
@@ -1720,7 +1725,7 @@ encodeAssembly assembly =
     else
         EU.optionalPropertiesObject
             [ ( "country", assembly.country |> Maybe.map CountryCode.encode )
-            , ( "operations", assembly.operations |> Encode.list Process.encodeId |> Just )
+            , ( "operations", assembly.operations |> Maybe.map (Encode.list Process.encodeId) )
             ]
 
 
@@ -1806,11 +1811,11 @@ errors =
     }
 
 
-{-| Expand an assembly query into a list of ExpandedLocalizedProcess localized to the assembly
+{-| Expand assembly operations into a list of ExpandedLocalizedProcess localized to the assembly
 country when set
 -}
-expandAssembly : DataContainer db -> Assembly -> Result String (List ExpandedLocalizedProcess)
-expandAssembly { countries, processes } { country, operations } =
+expandAssembly : DataContainer db -> Maybe CountryCode.Code -> List Process.Id -> Result String (List ExpandedLocalizedProcess)
+expandAssembly { countries, processes } country operations =
     -- first retrieve the optional assembly country
     countries
         |> Country.resolveMaybe country
@@ -1976,6 +1981,31 @@ findById id =
     List.filter (.id >> (==) (Just id))
         >> List.head
         >> Result.fromMaybe ("Aucun composant avec id=" ++ idToString id)
+
+
+{-| Get the assembly operations:
+
+  - from the query itself when set (`Just`, including an explicit empty list)
+  - or the ones from the product category if not set
+  - or an empty list if product category is not set
+
+-}
+getAssemblyOperations : Requirements db -> Query -> List Process.Id
+getAssemblyOperations { db } query =
+    case query.assembly.operations of
+        Just operations ->
+            operations
+
+        Nothing ->
+            query.product
+                |> Maybe.andThen
+                    (\productId ->
+                        db.products
+                            |> ProductCategory.findById productId
+                            |> Result.toMaybe
+                            |> Maybe.map .assembly
+                    )
+                |> Maybe.withDefault []
 
 
 getAvailableDistributionProcesses : DataContainer db -> Scope -> List Process
@@ -2504,12 +2534,12 @@ quantityToInt (Quantity int) =
     int
 
 
-removeAssemblyOperation : Index -> Query -> Query
-removeAssemblyOperation index ({ assembly } as query) =
+removeAssemblyOperation : Requirements db -> Index -> Query -> Query
+removeAssemblyOperation requirements index ({ assembly } as query) =
     { query
         | assembly =
             { assembly
-                | operations = assembly.operations |> LE.removeAt index
+                | operations = Just (getAssemblyOperations requirements query |> LE.removeAt index)
             }
     }
 
@@ -2797,11 +2827,12 @@ updateDistribution maybeProcessId query =
 {-| Update the product in the query, resetting product-dependent fields along the way
 -}
 updateProduct : Maybe ProductCategory -> Query -> Query
-updateProduct maybeProduct ({ transportOptions } as query) =
+updateProduct maybeProduct ({ assembly, transportOptions } as query) =
     let
         reset maybeProductId =
             { query
-                | consumptions = Nothing
+                | assembly = { assembly | operations = Nothing }
+                , consumptions = Nothing
                 , distribution = Nothing
                 , product = maybeProductId
                 , transportOptions = { transportOptions | cooling = Nothing }
@@ -2920,11 +2951,15 @@ useProcessAmount lifeCycle process amount =
         amount
 
 
-validateAssembly : Requirements db -> Assembly -> Result String Assembly
-validateAssembly requirements assembly =
+validateAssembly : Requirements db -> Query -> Result String Assembly
+validateAssembly requirements query =
     Ok Assembly
-        |> RE.andMap (validateCountry requirements assembly.country)
-        |> RE.andMap (assembly.operations |> RE.combineMap (validateAssemblyProcessId requirements))
+        |> RE.andMap (validateCountry requirements query.assembly.country)
+        |> RE.andMap
+            (getAssemblyOperations requirements query
+                |> RE.combineMap (validateAssemblyProcessId requirements)
+                |> Result.map (always query.assembly.operations)
+            )
 
 
 validateAssemblyProcessesUnit : List ExpandedLocalizedProcess -> Result String (List ExpandedLocalizedProcess)
@@ -3074,7 +3109,7 @@ validateQuantifiedProcess requirements quantifiedProcess =
 validateQuery : Requirements db -> Query -> Result String Query
 validateQuery ({ db } as requirements) query =
     Ok Query
-        |> RE.andMap (validateAssembly requirements query.assembly)
+        |> RE.andMap (validateAssembly requirements query)
         |> RE.andMap
             (getConsumptions requirements query
                 |> RE.combineMap (validateConsumption requirements)

--- a/src/Data/Component/ProductCategory.elm
+++ b/src/Data/Component/ProductCategory.elm
@@ -39,10 +39,11 @@ type alias DefaultConsumption =
 
 
 {-| A generic product category, providing sensible defaults for common characteristics
-like transport cooling, distribution process and use-stage consumptions.
+like assembly processes, transport cooling, distribution process and use-stage consumptions.
 -}
 type alias ProductCategory =
-    { consumptions : List DefaultConsumption
+    { assembly : List Process.Id
+    , consumptions : List DefaultConsumption
     , cooling : Bool
     , distribution : Maybe Process.Id
     , id : Id
@@ -54,6 +55,7 @@ type alias ProductCategory =
 decode : Decoder ProductCategory
 decode =
     Decode.succeed ProductCategory
+        |> DU.strictOptionalWithDefault "assembly" (Decode.list Process.decodeId) []
         |> DU.strictOptionalWithDefault "consumptions" (Decode.list decodeDefaultConsumption) []
         |> Pipe.required "cooling" Decode.bool
         |> DU.strictOptional "distribution" Process.decodeId

--- a/src/Page/Explore/Components.elm
+++ b/src/Page/Explore/Components.elm
@@ -28,7 +28,7 @@ table ({ db } as session) { scope } =
     , legend = []
     , columns =
         [ { label = "Identifiant"
-          , toValue = Table.StringValue <| .id >> Maybe.map Component.idToString >> Maybe.withDefault "N/A"
+          , toValue = Table.StringValue <| .id >> Maybe.map Component.idToString >> Maybe.withDefault Table.emptyLabel
           , toCell =
                 \component ->
                     case component.id of
@@ -36,7 +36,7 @@ table ({ db } as session) { scope } =
                             code [] [ text (Component.idToString id) ]
 
                         Nothing ->
-                            text "N/A"
+                            text Table.emptyLabel
           }
         , { label = "Nom"
           , toValue = Table.StringValue .name
@@ -90,15 +90,15 @@ table ({ db } as session) { scope } =
                                 |> ul [ class "m-0 px-2" ]
           }
         , { label = "Commentaire"
-          , toValue = Table.StringValue <| .comment >> Maybe.withDefault "N/A"
-          , toCell = .comment >> Maybe.withDefault "N/A" >> text
+          , toValue = Table.StringValue <| .comment >> Maybe.withDefault Table.emptyLabel
+          , toCell = .comment >> Maybe.withDefault Table.emptyLabel >> text
           }
         , { label = "Coût environnemental"
           , toValue = Table.FloatValue <| getComponentEcoscore session scope >> Result.withDefault 0
           , toCell =
                 getComponentEcoscore session scope
                     >> Result.map (Format.formatImpactFloat { decimals = 2, unit = "Pts par composant" })
-                    >> Result.withDefault (text "N/A")
+                    >> Result.withDefault (text Table.emptyLabel)
           }
         ]
     }

--- a/src/Page/Explore/Countries.elm
+++ b/src/Page/Explore/Countries.elm
@@ -126,7 +126,7 @@ transportToRow countryCode countries transport =
     let
         formatDistance length =
             if length == Quantity.zero then
-                span [ title "Non-applicable" ] [ text "N/A" ]
+                text Table.emptyLabel
 
             else
                 Format.km length

--- a/src/Page/Explore/FoodIngredients.elm
+++ b/src/Page/Explore/FoodIngredients.elm
@@ -122,7 +122,7 @@ table { detailed, scope } =
           , toCell = .process >> .source >> text
           }
         , { label = "Services écosystémiques"
-          , toValue = Table.StringValue <| always "N/A"
+          , toValue = Table.StringValue <| always Table.emptyLabel
           , toCell =
                 \{ ecosystemicServices } ->
                     div [ class "overflow-scroll" ]

--- a/src/Page/Explore/Impacts.elm
+++ b/src/Page/Explore/Impacts.elm
@@ -51,7 +51,7 @@ table { detailed, scope } =
                 \def ->
                     def.ecoscoreData
                         |> Maybe.map (.normalization >> Unit.impactToFloat >> Format.formatRichFloat 2 def.unit)
-                        |> Maybe.withDefault (text "N/A")
+                        |> Maybe.withDefault (text Table.emptyLabel)
           }
         , { label = "Pondération (Coût Evt)"
           , toValue =
@@ -59,7 +59,7 @@ table { detailed, scope } =
                     .ecoscoreData
                         >> Maybe.map (.weighting >> Split.toFloat)
                         >> Maybe.withDefault 0
-          , toCell = .ecoscoreData >> Maybe.map (.weighting >> Format.splitAsPercentage 2) >> Maybe.withDefault (text "N/A")
+          , toCell = .ecoscoreData >> Maybe.map (.weighting >> Format.splitAsPercentage 2) >> Maybe.withDefault (text Table.emptyLabel)
           }
         , { label = "Description"
           , toValue = Table.StringValue .description

--- a/src/Page/Explore/Processes.elm
+++ b/src/Page/Explore/Processes.elm
@@ -31,7 +31,7 @@ table session { scope } =
         , Table.Facet "Région"
             (.location
                 >> Maybe.map (resolveRegionName session)
-                >> Maybe.withDefault "N/A"
+                >> Maybe.withDefault Table.emptyLabel
                 >> List.singleton
             )
         ]
@@ -67,8 +67,8 @@ baseColumns session =
       , toCell = .source >> text
       }
     , { label = "Région"
-      , toValue = Table.StringValue <| .location >> Maybe.withDefault "N/A"
-      , toCell = .location >> Maybe.map (resolveRegionName session) >> Maybe.withDefault "N/A" >> text
+      , toValue = Table.StringValue <| .location >> Maybe.withDefault Table.emptyLabel
+      , toCell = .location >> Maybe.map (resolveRegionName session) >> Maybe.withDefault Table.emptyLabel >> text
       }
     , { label = "Catégories"
       , toValue =
@@ -99,7 +99,7 @@ baseColumns session =
       , toCell = .qtyVariationRatio >> Format.qtyVariationRatio
       }
     , { label = "Masse par unité"
-      , toValue = Table.StringValue <| .massPerUnit >> Maybe.map String.fromFloat >> Maybe.withDefault "N/A"
+      , toValue = Table.StringValue <| .massPerUnit >> Maybe.map String.fromFloat >> Maybe.withDefault Table.emptyLabel
       , toCell = Format.massPerUnit
       }
     , { label = "Commentaire"
@@ -129,7 +129,7 @@ complementsColumns { db } =
             , toCell =
                 complementToMaybeFloat a
                     >> Maybe.map (Format.formatImpactFloat (Definition.get Definition.Ecs db.definitions))
-                    >> Maybe.withDefault (text "N/A")
+                    >> Maybe.withDefault (text Table.emptyLabel)
             }
         )
         Complement.allComplementsFields

--- a/src/Page/Explore/ProductCategories.elm
+++ b/src/Page/Explore/ProductCategories.elm
@@ -77,7 +77,7 @@ assemblyFacetValues processes product =
 
     else
         product.assembly
-            |> List.map (assemblyProcessName processes)
+            |> List.map (processDisplayName processes)
 
 
 assemblyLabel : List Process.Process -> ProductCategory -> String
@@ -87,28 +87,8 @@ assemblyLabel processes product =
 
     else
         product.assembly
-            |> List.map (assemblyProcessName processes)
+            |> List.map (processDisplayName processes)
             |> String.join ", "
-
-
-assemblyProcessName : List Process.Process -> Process.Id -> String
-assemblyProcessName processes processId =
-    case processes |> Process.findById processId |> Result.map Process.getDisplayName of
-        Err err ->
-            "Erreur\u{00A0}: " ++ err
-
-        Ok displayName ->
-            displayName
-
-
-consumptionProcessName : List Process.Process -> ProductCategory.DefaultConsumption -> String
-consumptionProcessName processes { processId } =
-    case processes |> Process.findById processId |> Result.map Process.getDisplayName of
-        Err err ->
-            "Erreur\u{00A0}: " ++ err
-
-        Ok displayName ->
-            displayName
 
 
 consumptionsFacetValues : List Process.Process -> ProductCategory -> List String
@@ -118,7 +98,7 @@ consumptionsFacetValues processes product =
 
     else
         product.consumptions
-            |> List.map (consumptionProcessName processes)
+            |> List.map (.processId >> processDisplayName processes)
 
 
 consumptionsLabel : List Process.Process -> ProductCategory -> String
@@ -128,7 +108,7 @@ consumptionsLabel processes product =
 
     else
         product.consumptions
-            |> List.map (consumptionProcessName processes)
+            |> List.map (.processId >> processDisplayName processes)
             |> String.join ", "
 
 
@@ -136,12 +116,17 @@ distributionLabel : List Process.Process -> ProductCategory -> String
 distributionLabel processes product =
     case product.distribution of
         Just processId ->
-            case processes |> Process.findById processId |> Result.map Process.getDisplayName of
-                Err err ->
-                    "Erreur\u{00A0}: " ++ err
-
-                Ok displayName ->
-                    displayName
+            processDisplayName processes processId
 
         Nothing ->
             emptyLabel
+
+
+processDisplayName : List Process.Process -> Process.Id -> String
+processDisplayName processes processId =
+    case processes |> Process.findById processId |> Result.map Process.getDisplayName of
+        Err err ->
+            "Erreur\u{00A0}: " ++ err
+
+        Ok displayName ->
+            displayName

--- a/src/Page/Explore/ProductCategories.elm
+++ b/src/Page/Explore/ProductCategories.elm
@@ -22,9 +22,7 @@ table { db } genericScope _ =
           , toValues = assemblyFacetValues db.processes
           }
         , { key = "Transport réfrigéré"
-          , toValues =
-                \{ cooling } ->
-                    [ Text.yesNo cooling ]
+          , toValues = \{ cooling } -> [ Text.yesNo cooling ]
           }
         , { key = "Distribution"
           , toValues = distributionLabel db.processes >> List.singleton
@@ -73,7 +71,7 @@ emptyLabel =
 assemblyFacetValues : List Process.Process -> ProductCategory -> List String
 assemblyFacetValues processes product =
     if List.isEmpty product.assembly then
-        [ emptyLabel ]
+        []
 
     else
         product.assembly
@@ -94,7 +92,7 @@ assemblyLabel processes product =
 consumptionsFacetValues : List Process.Process -> ProductCategory -> List String
 consumptionsFacetValues processes product =
     if List.isEmpty product.consumptions then
-        [ emptyLabel ]
+        []
 
     else
         product.consumptions

--- a/src/Page/Explore/ProductCategories.elm
+++ b/src/Page/Explore/ProductCategories.elm
@@ -63,11 +63,6 @@ table { db } genericScope _ =
     }
 
 
-emptyLabel : String
-emptyLabel =
-    "—"
-
-
 assemblyFacetValues : List Process.Process -> ProductCategory -> List String
 assemblyFacetValues processes product =
     if List.isEmpty product.assembly then
@@ -81,7 +76,7 @@ assemblyFacetValues processes product =
 assemblyLabel : List Process.Process -> ProductCategory -> String
 assemblyLabel processes product =
     if List.isEmpty product.assembly then
-        emptyLabel
+        Table.emptyLabel
 
     else
         product.assembly
@@ -102,7 +97,7 @@ consumptionsFacetValues processes product =
 consumptionsLabel : List Process.Process -> ProductCategory -> String
 consumptionsLabel processes product =
     if List.isEmpty product.consumptions then
-        emptyLabel
+        Table.emptyLabel
 
     else
         product.consumptions
@@ -117,7 +112,7 @@ distributionLabel processes product =
             processDisplayName processes processId
 
         Nothing ->
-            emptyLabel
+            Table.emptyLabel
 
 
 processDisplayName : List Process.Process -> Process.Id -> String

--- a/src/Page/Explore/ProductCategories.elm
+++ b/src/Page/Explore/ProductCategories.elm
@@ -18,7 +18,10 @@ table { db } genericScope _ =
     , toRoute = \{ id } -> Route.Explore (Scope.Generic genericScope) (Dataset.ProductCategory genericScope (Just id))
     , toSearchableWords = ProductCategory.toSearchableString >> Text.toWords
     , facets =
-        [ { key = "Transport réfrigéré"
+        [ { key = "Assemblage"
+          , toValues = assemblyFacetValues db.processes
+          }
+        , { key = "Transport réfrigéré"
           , toValues =
                 \{ cooling } ->
                     [ Text.yesNo cooling ]
@@ -42,6 +45,10 @@ table { db } genericScope _ =
           , toValue = Table.StringValue .label
           , toCell = .label >> text
           }
+        , { label = "Assemblage"
+          , toValue = Table.StringValue <| assemblyLabel db.processes
+          , toCell = assemblyLabel db.processes >> text
+          }
         , { label = "Transport réfrigéré"
           , toValue = Table.StringValue <| .cooling >> Text.yesNo
           , toCell = .cooling >> Text.yesNo >> text
@@ -61,6 +68,37 @@ table { db } genericScope _ =
 emptyLabel : String
 emptyLabel =
     "—"
+
+
+assemblyFacetValues : List Process.Process -> ProductCategory -> List String
+assemblyFacetValues processes product =
+    if List.isEmpty product.assembly then
+        [ emptyLabel ]
+
+    else
+        product.assembly
+            |> List.map (assemblyProcessName processes)
+
+
+assemblyLabel : List Process.Process -> ProductCategory -> String
+assemblyLabel processes product =
+    if List.isEmpty product.assembly then
+        emptyLabel
+
+    else
+        product.assembly
+            |> List.map (assemblyProcessName processes)
+            |> String.join ", "
+
+
+assemblyProcessName : List Process.Process -> Process.Id -> String
+assemblyProcessName processes processId =
+    case processes |> Process.findById processId |> Result.map Process.getDisplayName of
+        Err err ->
+            "Erreur\u{00A0}: " ++ err
+
+        Ok displayName ->
+            displayName
 
 
 consumptionProcessName : List Process.Process -> ProductCategory.DefaultConsumption -> String

--- a/src/Page/Explore/Table.elm
+++ b/src/Page/Explore/Table.elm
@@ -381,7 +381,7 @@ valueToString item toValue =
             getInt item |> String.fromInt
 
         NoValue ->
-            "N/A"
+            emptyLabel
 
         StringValue getString ->
             getString item

--- a/src/Page/Explore/Table.elm
+++ b/src/Page/Explore/Table.elm
@@ -5,6 +5,7 @@ module Page.Explore.Table exposing
     , Facets
     , Table
     , Value(..)
+    , emptyLabel
     , updateFacets
     , viewDetails
     , viewList
@@ -223,6 +224,11 @@ applyFiltersAndSearch config facets toSearchableWords =
         >> searchItems config toSearchableWords
 
 
+emptyLabel : String
+emptyLabel =
+    "—"
+
+
 viewFacet : Config data msg -> List data -> Facet data -> Html msg
 viewFacet ({ selectedFacets } as config) items { key, toValues } =
     let
@@ -245,18 +251,22 @@ viewFacet ({ selectedFacets } as config) items { key, toValues } =
                     )
                     ( [], [] )
                 |> Tuple.mapBoth Text.sortI18nStrings Text.sortI18nStrings
-    in
-    div [ class "FacetCard card" ]
-        [ div [ class "card-header fw-bold py-2" ] [ text key ]
-        , div
-            [ class "FacetCardBody card-body d-flex flex-column gap-1 p-2 no-scroll-chaining"
-            , attribute "data-scroll-id" key
-            ]
-            (if List.isEmpty (selectedOptions ++ availableOptions) then
-                [ em [ class "text-muted small" ] [ text "Aucune valeur disponible" ] ]
 
-             else
-                List.concat
+        allOptions =
+            selectedOptions ++ availableOptions
+    in
+    -- hide facet entirely when no usable options are available
+    if List.isEmpty allOptions || allOptions == [ emptyLabel ] then
+        text ""
+
+    else
+        div [ class "FacetCard card" ]
+            [ div [ class "card-header fw-bold py-2" ] [ text key ]
+            , div
+                [ class "FacetCardBody card-body d-flex flex-column gap-1 p-2 no-scroll-chaining"
+                , attribute "data-scroll-id" key
+                ]
+                (List.concat
                     [ selectedOptions |> List.map (viewFacetOption config True key)
                     , if not (List.isEmpty selectedOptions) then
                         [ div [ class "FacetCardSeparator border-bottom" ] [] ]
@@ -265,8 +275,8 @@ viewFacet ({ selectedFacets } as config) items { key, toValues } =
                         []
                     , availableOptions |> List.map (viewFacetOption config False key)
                     ]
-            )
-        ]
+                )
+            ]
 
 
 viewFacetOption : Config data msg -> Bool -> String -> String -> Html msg

--- a/src/Page/Explore/TextileMaterials.elm
+++ b/src/Page/Explore/TextileMaterials.elm
@@ -59,7 +59,7 @@ table db { detailed, scope } =
             (.defaultCountry
                 >> (\code -> Country.findByCode code db.countries)
                 >> Result.map (\{ code, name } -> name ++ " (" ++ CountryCode.toString code ++ ")")
-                >> Result.withDefault "N/A"
+                >> Result.withDefault Table.emptyLabel
                 >> List.singleton
             )
         ]
@@ -109,8 +109,8 @@ table db { detailed, scope } =
                     >> withPill Gitbook.TextileSpinning
           }
         , { label = "Procédé de recyclage"
-          , toValue = Table.StringValue <| getRecycledProcess db.textile.materials >> Maybe.map Process.getDisplayName >> Maybe.withDefault "N/A"
-          , toCell = getRecycledProcess db.textile.materials >> Maybe.map (Process.getDisplayName >> text) >> Maybe.withDefault (text "N/A")
+          , toValue = Table.StringValue <| getRecycledProcess db.textile.materials >> Maybe.map Process.getDisplayName >> Maybe.withDefault Table.emptyLabel
+          , toCell = getRecycledProcess db.textile.materials >> Maybe.map (Process.getDisplayName >> text) >> Maybe.withDefault (text Table.emptyLabel)
           }
         , { label = "Origine géographique"
           , toValue = Table.StringValue .geographicOrigin
@@ -152,7 +152,7 @@ table db { detailed, scope } =
                             >> Format.splitAsFloat 1
                             >> withPill Gitbook.TextileCircularFootprintFormula
                         )
-                    >> Maybe.withDefault (text "N/A")
+                    >> Maybe.withDefault (text Table.emptyLabel)
           }
         , { label = "CFF: Rapport de qualité"
           , toValue =
@@ -167,7 +167,7 @@ table db { detailed, scope } =
                             >> Format.splitAsFloat 1
                             >> withPill Gitbook.TextileCircularFootprintFormula
                         )
-                    >> Maybe.withDefault (text "N/A")
+                    >> Maybe.withDefault (text Table.emptyLabel)
           }
         ]
     }

--- a/src/Page/Generic.elm
+++ b/src/Page/Generic.elm
@@ -483,7 +483,7 @@ update ({ navKey } as session) msg model =
 
         ( OnAutocompleteSelectAssemblyOperation, (SelectAssemblyOperationModal autocompleteState) :: _ ) ->
             createPageUpdate session model
-                |> selectAssemblyOperation query autocompleteState
+                |> selectAssemblyOperation requirements query autocompleteState
 
         ( OnAutocompleteSelectAssemblyOperation, _ ) ->
             createPageUpdate session model
@@ -558,7 +558,7 @@ update ({ navKey } as session) msg model =
 
         ( RemoveAssemblyOperation index, _ ) ->
             createPageUpdate session model
-                |> updateQuery (query |> Component.removeAssemblyOperation index)
+                |> updateQuery (query |> Component.removeAssemblyOperation requirements index)
 
         ( RemoveConsumption index, _ ) ->
             createPageUpdate session model
@@ -904,12 +904,12 @@ selectProductionItem query autocompleteState ({ model, session } as pageUpdate) 
             pageUpdate |> App.notifyWarning "Aucun composant sélectionné"
 
 
-selectAssemblyOperation : Component.Query -> Autocomplete Process -> PageUpdate Model Msg -> PageUpdate Model Msg
-selectAssemblyOperation query autocompleteState pageUpdate =
+selectAssemblyOperation : Component.Requirements Db -> Component.Query -> Autocomplete Process -> PageUpdate Model Msg -> PageUpdate Model Msg
+selectAssemblyOperation requirements query autocompleteState pageUpdate =
     case Autocomplete.selectedValue autocompleteState of
         Just process ->
             pageUpdate
-                |> updateQuery (query |> Component.addAssemblyOperation process)
+                |> updateQuery (query |> Component.addAssemblyOperation requirements process)
                 |> App.apply update (SetModals [])
 
         Nothing ->

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -1474,7 +1474,11 @@ assemblyView ({ db, impact, query, scope } as config) lifeCycle =
                     , selected = query.assembly.country
                     }
                 ]
-            , case Component.expandAssembly db query.assembly of
+            , case
+                query
+                    |> Component.getAssemblyOperations (requirementsFromConfig config)
+                    |> Component.expandAssembly db query.assembly.country
+              of
                 Err error ->
                     div [ class "px-3 pb-3" ] [ error |> simpleError (Just "Erreur") ]
 
@@ -1546,7 +1550,8 @@ addAssemblyOperationButton ({ openSelectAssemblyOperationModal, query } as confi
                 |> List.filter
                     (\{ id } ->
                         -- prevent adding the same operation twice
-                        query.assembly.operations
+                        query
+                            |> Component.getAssemblyOperations (requirementsFromConfig config)
                             |> List.member id
                             |> not
                     )

--- a/tests/Data/ComponentTest.elm
+++ b/tests/Data/ComponentTest.elm
@@ -860,7 +860,7 @@ suite =
                             (findProductCategoryByLabel requirements "Vélos et VAEs de moins de 100kg"
                                 |> Result.andThen
                                     (\categoryProduct ->
-                                        """{ "components": [{ "id": "64fa65b3-c2df-4fd0-958b-83965bd6aa08", "quantity": 1 }] }"""
+                                        """{ "components": [{ "id": "9178fe2e-6944-41d5-ad1b-7abbe8905c48", "quantity": 1 }] }"""
                                             |> decodeJsonThen Component.decodeQuery
                                                 (\query ->
                                                     query

--- a/tests/Data/ComponentTest.elm
+++ b/tests/Data/ComponentTest.elm
@@ -8,6 +8,7 @@ import Data.Component as Component
         , LifeCycle
         , Requirements
         , defaultTransportOptions
+        , emptyAssembly
         , emptyQuery
         )
 import Data.Component.Amount as Amount
@@ -853,6 +854,24 @@ suite =
                                     Expect.within (Expect.Absolute 0.00001) productionMass productMass
                                 , it "should keep assembly impacts unchanged" <|
                                     Expect.within (Expect.Absolute 0.00001) assemblyImpact 0
+                                ]
+                            )
+                        , itFromResult "should apply category default assembly operations when computing results"
+                            (findProductCategoryByLabel requirements "Vélos et VAEs de moins de 100kg"
+                                |> Result.andThen
+                                    (\categoryProduct ->
+                                        """{ "components": [{ "id": "64fa65b3-c2df-4fd0-958b-83965bd6aa08", "quantity": 1 }] }"""
+                                            |> decodeJsonThen Component.decodeQuery
+                                                (\query ->
+                                                    query
+                                                        |> Component.updateProduct (Just categoryProduct)
+                                                        |> Component.compute requirements
+                                                )
+                                    )
+                            )
+                            (Expect.all
+                                [ .assembly >> Component.extractItems >> List.length >> Expect.equal 1
+                                , .assembly >> Component.extractImpacts >> getEcsImpact >> Expect.greaterThan 0
                                 ]
                             )
                         , suiteFromResult "should apply 50% waste ratios sequentially"
@@ -2221,7 +2240,7 @@ suite =
                                     |> Expect.equal True
                                 )
                             , it "should encode an explicit empty assembly operations list" <|
-                                ({ emptyQuery | assembly = { country = Nothing, operations = Just [] } }
+                                ({ emptyQuery | assembly = { emptyAssembly | operations = Just [] } }
                                     |> Component.encodeQuery
                                     |> Encode.encode 0
                                     |> String.contains "\"operations\":[]"
@@ -2477,8 +2496,8 @@ suite =
                             (\categoryProduct ->
                                 emptyQuery
                                     |> Component.updateProduct (Just categoryProduct)
-                                    |> (\query ->
-                                            { query | assembly = { country = Nothing, operations = Just [] } }
+                                    |> (\({ assembly } as query) ->
+                                            { query | assembly = { assembly | operations = Just [] } }
                                        )
                                     |> Component.updateProduct (Just categoryProduct)
                                     |> .assembly
@@ -2490,7 +2509,7 @@ suite =
                             (findProcessByLabel requirements "Assemblage - calcul réglementaire Score Environnemental VE")
                             (\bikes regulatoryAssemblage ->
                                 { emptyQuery
-                                    | assembly = { country = Nothing, operations = Just [ regulatoryAssemblage.id ] }
+                                    | assembly = { emptyAssembly | operations = Just [ regulatoryAssemblage.id ] }
                                     , product = Just bikes.id
                                 }
                                     |> Component.getAssemblyOperations requirements
@@ -2500,7 +2519,7 @@ suite =
                             (findProductCategoryByLabel requirements "Vélos et VAEs de moins de 100kg")
                             (\bikes ->
                                 { emptyQuery
-                                    | assembly = { country = Nothing, operations = Just [] }
+                                    | assembly = { emptyAssembly | operations = Just [] }
                                     , product = Just bikes.id
                                 }
                                     |> Component.getAssemblyOperations requirements

--- a/tests/Data/ComponentTest.elm
+++ b/tests/Data/ComponentTest.elm
@@ -1712,7 +1712,7 @@ suite =
                             { emptyQuery
                                 | assembly =
                                     { country = Just CountryCode.france
-                                    , operations = []
+                                    , operations = Nothing
                                     }
                             }
                       in
@@ -1816,7 +1816,7 @@ suite =
                             { emptyQuery
                                 | assembly =
                                     { country = Just CountryCode.france
-                                    , operations = []
+                                    , operations = Nothing
                                     }
                             }
                       in
@@ -2171,16 +2171,28 @@ suite =
                                     |> Result.map .product
                                     |> Expect.equal (Ok Nothing)
                                 )
-                            , it "should decode omitted consumptions and cooling as unspecified" <|
+                            , it "should decode omitted consumptions, cooling, and assembly operations as unspecified" <|
                                 ("""{"components":[]}"""
                                     |> decodeJson Component.decodeQuery
-                                    |> Result.map (\query -> ( query.consumptions, query.transportOptions.cooling ))
-                                    |> Expect.equal (Ok ( Nothing, Nothing ))
+                                    |> Result.map
+                                        (\query ->
+                                            ( query.consumptions
+                                            , query.transportOptions.cooling
+                                            , query.assembly.operations
+                                            )
+                                        )
+                                    |> Expect.equal (Ok ( Nothing, Nothing, Nothing ))
                                 )
                             , it "should decode an explicit empty consumptions list" <|
                                 ("""{"components":[],"consumptions":[]}"""
                                     |> decodeJson Component.decodeQuery
                                     |> Result.map .consumptions
+                                    |> Expect.equal (Ok (Just []))
+                                )
+                            , it "should decode an explicit empty assembly operations list" <|
+                                ("""{"components":[],"assembly":{"operations":[]}}"""
+                                    |> decodeJson Component.decodeQuery
+                                    |> Result.map (.assembly >> .operations)
                                     |> Expect.equal (Ok (Just []))
                                 )
                             , it "should decode explicitly disabled cooling" <|
@@ -2191,13 +2203,14 @@ suite =
                                 )
                             ]
                         , describe "encoding"
-                            [ it "should omit unspecified consumptions and cooling when encoding" <|
+                            [ it "should omit unspecified consumptions, cooling, and assembly operations when encoding" <|
                                 (emptyQuery
                                     |> Component.encodeQuery
                                     |> Encode.encode 0
                                     |> Expect.all
                                         [ String.contains "\"consumptions\"" >> Expect.equal False
                                         , String.contains "\"cooling\"" >> Expect.equal False
+                                        , String.contains "\"operations\"" >> Expect.equal False
                                         ]
                                 )
                             , it "should encode an explicit empty consumptions list" <|
@@ -2205,6 +2218,13 @@ suite =
                                     |> Component.encodeQuery
                                     |> Encode.encode 0
                                     |> String.contains "\"consumptions\":[]"
+                                    |> Expect.equal True
+                                )
+                            , it "should encode an explicit empty assembly operations list" <|
+                                ({ emptyQuery | assembly = { country = Nothing, operations = Just [] } }
+                                    |> Component.encodeQuery
+                                    |> Encode.encode 0
+                                    |> String.contains "\"operations\":[]"
                                     |> Expect.equal True
                                 )
                             , it "should encode explicit cooling false" <|
@@ -2215,6 +2235,17 @@ suite =
                                     |> Expect.equal True
                                 )
                             ]
+                        , it "should default product category assembly to an empty list when omitted" <|
+                            ("""[{
+                                  "cooling": false,
+                                  "id": "5fad4e70-5736-552d-a686-97e4fb627c37",
+                                  "label": "Test",
+                                  "scope": "food2"
+                                }]"""
+                                |> Product.decodeListFromJsonString
+                                |> Result.map (List.head >> Maybe.map .assembly)
+                                |> Expect.equal (Ok (Just []))
+                            )
                         , it "should default product category consumptions to an empty list when omitted" <|
                             ("""[{
                                   "cooling": false,
@@ -2287,7 +2318,23 @@ suite =
                                             )
                                         )
                             )
-                        , itFromResult "should clear product, distribution, consumptions, and category cooling when unset"
+                        , itFromResult "should decode product category assembly from process ids"
+                            (findProcessByLabel requirements "Assemblage")
+                            (\assemblage ->
+                                ("""[{
+                                      "assembly": ["{{assemblageId}}"],
+                                      "cooling": false,
+                                      "id": "5fad4e70-5736-552d-a686-97e4fb627c37",
+                                      "label": "Test category",
+                                      "scope": "veli"
+                                    }]"""
+                                    |> String.replace "{{assemblageId}}" (Process.idToString assemblage.id)
+                                )
+                                    |> Product.decodeListFromJsonString
+                                    |> Result.map (List.head >> Maybe.map .assembly)
+                                    |> Expect.equal (Ok (Just [ assemblage.id ]))
+                            )
+                        , itFromResult "should clear product, distribution, consumptions, assembly operations, and category cooling when unset"
                             (requirements.db.products |> List.head |> Result.fromMaybe "no product categories in test db")
                             (\categoryProduct ->
                                 emptyQuery
@@ -2295,6 +2342,7 @@ suite =
                                     |> Component.updateProduct Nothing
                                     |> Expect.all
                                         [ .product >> Expect.equal Nothing
+                                        , .assembly >> .operations >> Expect.equal Nothing
                                         , .distribution >> Expect.equal Nothing
                                         , .consumptions >> Expect.equal Nothing
                                         , .transportOptions >> .cooling >> Expect.equal Nothing
@@ -2307,6 +2355,7 @@ suite =
                                     |> Component.updateProduct (Just categoryProduct)
                                     |> Expect.all
                                         [ .product >> Expect.equal (Just categoryProduct.id)
+                                        , .assembly >> .operations >> Expect.equal Nothing
                                         , .consumptions >> Expect.equal Nothing
                                         , .distribution >> Expect.equal Nothing
                                         , .transportOptions >> .cooling >> Expect.equal Nothing
@@ -2401,6 +2450,87 @@ suite =
                                     |> Component.updateConsumptionAmount requirements 0 (Amount.fromFloat 3)
                                     |> .consumptions
                                     |> Expect.equal (Just [ Component.consumption (Amount.fromFloat 3) refrigeration.id ])
+                            )
+                        , itFromResult2 "should apply category default assembly operations when selecting a product"
+                            (findProductCategoryByLabel requirements "Vélos et VAEs de moins de 100kg")
+                            (findProcessByLabel requirements "Assemblage")
+                            (\categoryProduct assemblage ->
+                                emptyQuery
+                                    |> Component.updateProduct (Just categoryProduct)
+                                    |> Component.getAssemblyOperations requirements
+                                    |> Expect.equal [ assemblage.id ]
+                            )
+                        , itFromResult2 "should replace resolved assembly operations when selecting another product category"
+                            (findProductCategoryByLabel requirements "Vélos et VAEs de moins de 100kg")
+                            (findProductCategoryByLabel requirements "Charcuterie")
+                            (\bikes charcuterie ->
+                                emptyQuery
+                                    |> Component.updateProduct (Just bikes)
+                                    |> Component.updateProduct (Just charcuterie)
+                                    |> Expect.all
+                                        [ .assembly >> .operations >> Expect.equal Nothing
+                                        , Component.getAssemblyOperations requirements >> Expect.equal []
+                                        ]
+                            )
+                        , itFromResult "should not reset explicit assembly operations when re-selecting the same product"
+                            (findProductCategoryByLabel requirements "Vélos et VAEs de moins de 100kg")
+                            (\categoryProduct ->
+                                emptyQuery
+                                    |> Component.updateProduct (Just categoryProduct)
+                                    |> (\query ->
+                                            { query | assembly = { country = Nothing, operations = Just [] } }
+                                       )
+                                    |> Component.updateProduct (Just categoryProduct)
+                                    |> .assembly
+                                    |> .operations
+                                    |> Expect.equal (Just [])
+                            )
+                        , itFromResult2 "should let an explicit assembly operations list take precedence over the category"
+                            (findProductCategoryByLabel requirements "Vélos et VAEs de moins de 100kg")
+                            (findProcessByLabel requirements "Assemblage - calcul réglementaire Score Environnemental VE")
+                            (\bikes regulatoryAssemblage ->
+                                { emptyQuery
+                                    | assembly = { country = Nothing, operations = Just [ regulatoryAssemblage.id ] }
+                                    , product = Just bikes.id
+                                }
+                                    |> Component.getAssemblyOperations requirements
+                                    |> Expect.equal [ regulatoryAssemblage.id ]
+                            )
+                        , itFromResult "should let an explicit empty assembly operations list take precedence over the category"
+                            (findProductCategoryByLabel requirements "Vélos et VAEs de moins de 100kg")
+                            (\bikes ->
+                                { emptyQuery
+                                    | assembly = { country = Nothing, operations = Just [] }
+                                    , product = Just bikes.id
+                                }
+                                    |> Component.getAssemblyOperations requirements
+                                    |> Expect.equal []
+                            )
+                        , it "should resolve no assembly operations when product and query are unspecified" <|
+                            (emptyQuery
+                                |> Component.getAssemblyOperations requirements
+                                |> Expect.equal []
+                            )
+                        , itFromResult "should preserve explicit assembly operations so deleting them all does not leverage category defaults"
+                            (findProductCategoryByLabel requirements "Vélos et VAEs de moins de 100kg")
+                            (\bikes ->
+                                emptyQuery
+                                    |> Component.updateProduct (Just bikes)
+                                    |> Component.removeAssemblyOperation requirements 0
+                                    |> Expect.all
+                                        [ .assembly >> .operations >> Expect.equal (Just [])
+                                        , Component.getAssemblyOperations requirements >> Expect.equal []
+                                        ]
+                            )
+                        , itFromResult2 "should preserve category assembly operations when adding one"
+                            (findProductCategoryByLabel requirements "Vélos et VAEs de moins de 100kg")
+                            (findProcessByLabel requirements "Assemblage - calcul réglementaire Score Environnemental VE")
+                            (\bikes regulatoryAssemblage ->
+                                emptyQuery
+                                    |> Component.updateProduct (Just bikes)
+                                    |> Component.addAssemblyOperation requirements regulatoryAssemblage
+                                    |> Component.getAssemblyOperations requirements
+                                    |> Expect.equal (bikes.assembly ++ [ regulatoryAssemblage.id ])
                             )
                         , itFromResult "should use product category cooling when the query doesn't set it"
                             (findProductCategoryByLabel requirements "Charcuterie")

--- a/tests/Data/ComponentTest.elm
+++ b/tests/Data/ComponentTest.elm
@@ -11,7 +11,7 @@ import Data.Component as Component
         , emptyQuery
         )
 import Data.Component.Amount as Amount
-import Data.Component.ProductCategory as Product
+import Data.Component.ProductCategory as Product exposing (ProductCategory)
 import Data.Country as Country
 import Data.Country.Code as CountryCode
 import Data.Db exposing (Db)
@@ -2659,7 +2659,7 @@ findProcessByLabel { db } label =
         |> Result.fromMaybe ("Procédé introuvable label=" ++ label)
 
 
-findProductCategoryByLabel : Requirements db -> String -> Result String Product.ProductCategory
+findProductCategoryByLabel : Requirements db -> String -> Result String ProductCategory
 findProductCategoryByLabel { db } label =
     db.products
         |> List.filter (.label >> (==) label)


### PR DESCRIPTION
## :wrench: Problem

Fixes #2709

## :cake: Solution

Allow defining default assembly operations in product categories. This is basically the same implementation strategy that has been leveraged in #2744.

## :rotating_light:  Points to watch/comments

- default assembly operations have only been added to the veli product categories

## :desert_island: How to test

In Veli section, add some materials then pick a product category: an assembly operation should be automatically added at the assembly stage