### PR TITLE
fix(generic): apply item qty to assembly transports

### DIFF
--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -1229,8 +1229,10 @@ computeTransports ({ config, db } as requirements) ({ assembly, transportOptions
                     )
                     -- toAssembly
                     (transportElements <|
-                        \( expandedElement, elementResults ) ->
+                        \( quantity, expandedElement, elementResults ) ->
+                            -- element masses are per unit; scale by the parent item quantity
                             extractMass elementResults
+                                |> Quantity.multiplyBy (toFloat (quantityToInt quantity))
                                 |> computeTransportedMassImpacts requirements
                                     -- Notes:
                                     --   - air transport is always disabled before assembly
@@ -2292,9 +2294,9 @@ getResultedElement ( itemIndex, elementIndex ) productionResults expandedItems =
         (getElementResult ( itemIndex, elementIndex ) productionResults)
 
 
-{-| Create a list of expanded elements with their associated results from a list of items and production results.
+{-| Create a list of expanded elements with their associated results and parent item quantity.
 -}
-getResultedElementList : Results -> List ExpandedItem -> Result String (List ResultedElement)
+getResultedElementList : Results -> List ExpandedItem -> Result String (List ( Quantity, ExpandedElement, Results ))
 getResultedElementList productionResults =
     List.indexedMap
         (\itemIndex expandedItem ->
@@ -2303,7 +2305,7 @@ getResultedElementList productionResults =
                     (\elementIndex expandedElement ->
                         productionResults
                             |> getElementResult ( itemIndex, elementIndex )
-                            |> Result.map (\results -> ( expandedElement, results ))
+                            |> Result.map (\results -> ( expandedItem.quantity, expandedElement, results ))
                     )
         )
         >> List.concat

--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -2279,7 +2279,7 @@ getMaterialDistribution (Results results) =
             (AnyDict.empty Category.materialTypeToString)
 
 
-{-| Get an expanded element and its results at a given location in the elements tree.
+{-| Get an expanded element, its results, and the parent item quantity at a given location in the elements tree.
 -}
 getResultedElement : ( Index, Index ) -> Results -> List ExpandedItem -> Result String ResultedElement
 getResultedElement ( itemIndex, elementIndex ) productionResults expandedItems =

--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -355,10 +355,10 @@ type alias ExpandedQuantifiedProcess =
     }
 
 
-{-| An expanded element and its results
+{-| An expanded element, its results, and the parent item quantity
 -}
 type alias ResultedElement =
-    ( ExpandedElement, Results )
+    ( Quantity, ExpandedElement, Results )
 
 
 {-| Index of an item element and associated source component
@@ -2279,24 +2279,27 @@ getMaterialDistribution (Results results) =
             (AnyDict.empty Category.materialTypeToString)
 
 
-{-| Get the an expanded element and its results at a given location in the elements tree.
+{-| Get an expanded element and its results at a given location in the elements tree.
 -}
 getResultedElement : ( Index, Index ) -> Results -> List ExpandedItem -> Result String ResultedElement
 getResultedElement ( itemIndex, elementIndex ) productionResults expandedItems =
-    Result.map2 Tuple.pair
-        -- Expanded element
-        (expandedItems
-            |> LE.getAt itemIndex
-            |> Result.fromMaybe errors.itemNotFound
-            |> Result.andThen (.elements >> LE.getAt elementIndex >> Result.fromMaybe errors.elementNotFound)
-        )
-        -- Element results
-        (getElementResult ( itemIndex, elementIndex ) productionResults)
+    expandedItems
+        |> LE.getAt itemIndex
+        |> Result.fromMaybe errors.itemNotFound
+        |> Result.andThen
+            (\{ elements, quantity } ->
+                Result.map2 (\expandedElement results -> ( quantity, expandedElement, results ))
+                    (elements
+                        |> LE.getAt elementIndex
+                        |> Result.fromMaybe errors.elementNotFound
+                    )
+                    (getElementResult ( itemIndex, elementIndex ) productionResults)
+            )
 
 
 {-| Create a list of expanded elements with their associated results and parent item quantity.
 -}
-getResultedElementList : Results -> List ExpandedItem -> Result String (List ( Quantity, ExpandedElement, Results ))
+getResultedElementList : Results -> List ExpandedItem -> Result String (List ResultedElement)
 getResultedElementList productionResults =
     List.indexedMap
         (\itemIndex expandedItem ->

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -1015,7 +1015,7 @@ elementEditModalView ({ query } as config) (( _, elementIndex ) as targetElement
         Err error ->
             div [ class "alert alert-danger" ] [ text error ]
 
-        Ok ( { amount, material, transforms } as expandedElement, elementResults ) ->
+        Ok ( _, { amount, material, transforms } as expandedElement, elementResults ) ->
             let
                 elementCooling =
                     Process.isTransportedCooled material.process

--- a/tests/Data/ComponentTest.elm
+++ b/tests/Data/ComponentTest.elm
@@ -1006,6 +1006,9 @@ suite =
                                     baseEndOfLifeImpact =
                                         getEcsImpact lifeCycle.endOfLife
 
+                                    baseToAssemblyImpact =
+                                        getEcsImpact lifeCycle.transports.toAssembly.impacts
+
                                     baseToDistributionImpact =
                                         getEcsImpact lifeCycle.transports.toDistribution.impacts
                                 in
@@ -1028,6 +1031,11 @@ suite =
                                     (withAssemblyWaste.transports.toDistribution.impacts
                                         |> getEcsImpact
                                         |> expectFloatMostlyEqual (baseToDistributionImpact * massScaleRatio)
+                                    )
+                                , it "should keep transport to assembly stage impacts unchanged with assembly waste"
+                                    (withAssemblyWaste.transports.toAssembly.impacts
+                                        |> getEcsImpact
+                                        |> expectFloatMostlyEqual baseToAssemblyImpact
                                     )
                                 , it "should keep EoL stage masses consistent with product mass"
                                     (withAssemblyWaste
@@ -1139,25 +1147,31 @@ suite =
                             ("""{"components": [{ "id": "64fa65b3-c2df-4fd0-958b-83965bd6aa08", "quantity": 2 }]}"""
                                 |> decodeJsonThen Component.decodeQuery (Component.compute requirements)
                             )
-                            -- tests
-                            (\singleItemProduct doubleQuantityProduct ->
-                                [ it "should double transport to assembly impacts when quantity doubles"
-                                    (doubleQuantityProduct.transports.toAssembly.impacts
-                                        |> getEcsImpact
-                                        |> expectFloatMostlyEqual (getEcsImpact singleItemProduct.transports.toAssembly.impacts * 2)
-                                    )
-                                , it "should keep distances to assembly unchanged when quantity doubles"
-                                    (doubleQuantityProduct.transports.toAssembly
-                                        |> Expect.all
-                                            [ .air >> Expect.equal singleItemProduct.transports.toAssembly.air
-                                            , .road >> Expect.equal singleItemProduct.transports.toAssembly.road
-                                            , .roadCooled >> Expect.equal singleItemProduct.transports.toAssembly.roadCooled
-                                            , .sea >> Expect.equal singleItemProduct.transports.toAssembly.sea
-                                            , .seaCooled >> Expect.equal singleItemProduct.transports.toAssembly.seaCooled
-                                            ]
-                                    )
-                                ]
+                            doubledQuantitiesExpectations
+                        , suiteFromResult2 "single item quantity scaling with assembly country"
+                            -- setup
+                            ("""{
+                                  "assembly": { "country": "FR" },
+                                  "components": [{ "id": "64fa65b3-c2df-4fd0-958b-83965bd6aa08", "quantity": 1 }]
+                                }"""
+                                |> decodeJsonThen Component.decodeQuery (Component.compute requirements)
                             )
+                            ("""{
+                                  "assembly": { "country": "FR" },
+                                  "components": [{ "id": "64fa65b3-c2df-4fd0-958b-83965bd6aa08", "quantity": 2 }]
+                                }"""
+                                |> decodeJsonThen Component.decodeQuery (Component.compute requirements)
+                            )
+                            doubledQuantitiesExpectations
+                        , suiteFromResult2 "multi-element item quantity scaling"
+                            -- setup
+                            ("""{"components": [{ "id": "8ca2ca05-8aec-4121-acaa-7cdcc03150a9", "quantity": 1 }]}"""
+                                |> decodeJsonThen Component.decodeQuery (Component.compute requirements)
+                            )
+                            ("""{"components": [{ "id": "8ca2ca05-8aec-4121-acaa-7cdcc03150a9", "quantity": 2 }]}"""
+                                |> decodeJsonThen Component.decodeQuery (Component.compute requirements)
+                            )
+                            doubledQuantitiesExpectations
                         , it "should reject an empty component list with an assembly country"
                             ("""{
                                   "assembly": { "country": "FR" },
@@ -2672,6 +2686,41 @@ suite =
                     ]
                 )
             ]
+
+
+doubledQuantitiesExpectations : LifeCycle -> LifeCycle -> List Test
+doubledQuantitiesExpectations base doubled =
+    let
+        expectDoubledImpacts a b =
+            getEcsImpact b
+                |> expectFloatMostlyEqual (getEcsImpact a * 2)
+
+        expectDistancesUntouched expected =
+            Expect.all
+                [ .air >> Expect.equal expected.air
+                , .road >> Expect.equal expected.road
+                , .roadCooled >> Expect.equal expected.roadCooled
+                , .sea >> Expect.equal expected.sea
+                , .seaCooled >> Expect.equal expected.seaCooled
+                ]
+    in
+    [ it "should double transport to assembly impacts when quantity doubles"
+        (doubled.transports.toAssembly.impacts
+            |> expectDoubledImpacts base.transports.toAssembly.impacts
+        )
+    , it "should keep distances to assembly unchanged when quantity doubles"
+        (doubled.transports.toAssembly
+            |> expectDistancesUntouched base.transports.toAssembly
+        )
+    , it "should double transport to distribution impacts when quantity doubles"
+        (doubled.transports.toDistribution.impacts
+            |> expectDoubledImpacts base.transports.toDistribution.impacts
+        )
+    , it "should keep distances to distribution unchanged when quantity doubles"
+        (doubled.transports.toDistribution
+            |> expectDistancesUntouched base.transports.toDistribution
+        )
+    ]
 
 
 {-| A test uuid we're pretty sure that doesn't exist in our datasets

--- a/tests/Data/ComponentTest.elm
+++ b/tests/Data/ComponentTest.elm
@@ -1131,6 +1131,33 @@ suite =
                                     )
                                 ]
                             )
+                        , suiteFromResult2 "single item quantity scaling"
+                            -- setup
+                            ("""{"components": [{ "id": "64fa65b3-c2df-4fd0-958b-83965bd6aa08", "quantity": 1 }]}"""
+                                |> decodeJsonThen Component.decodeQuery (Component.compute requirements)
+                            )
+                            ("""{"components": [{ "id": "64fa65b3-c2df-4fd0-958b-83965bd6aa08", "quantity": 2 }]}"""
+                                |> decodeJsonThen Component.decodeQuery (Component.compute requirements)
+                            )
+                            -- tests
+                            (\singleItemProduct doubleQuantityProduct ->
+                                [ it "should double transport to assembly impacts when quantity doubles"
+                                    (doubleQuantityProduct.transports.toAssembly.impacts
+                                        |> getEcsImpact
+                                        |> expectFloatMostlyEqual (getEcsImpact singleItemProduct.transports.toAssembly.impacts * 2)
+                                    )
+                                , it "should keep distances to assembly unchanged when quantity doubles"
+                                    (doubleQuantityProduct.transports.toAssembly
+                                        |> Expect.all
+                                            [ .air >> Expect.equal singleItemProduct.transports.toAssembly.air
+                                            , .road >> Expect.equal singleItemProduct.transports.toAssembly.road
+                                            , .roadCooled >> Expect.equal singleItemProduct.transports.toAssembly.roadCooled
+                                            , .sea >> Expect.equal singleItemProduct.transports.toAssembly.sea
+                                            , .seaCooled >> Expect.equal singleItemProduct.transports.toAssembly.seaCooled
+                                            ]
+                                    )
+                                ]
+                            )
                         , it "should reject an empty component list with an assembly country"
                             ("""{
                                   "assembly": { "country": "FR" },
@@ -1276,6 +1303,25 @@ suite =
                                             heavierProductAssembledInUnknownCountry
                                                 |> .transports
                                                 |> .toDistribution
+                                                |> .impacts
+                                                |> getEcsImpact
+                                     in
+                                     heavierProductAssembledInUnknownCountryImpacts
+                                        |> Expect.greaterThan productAssembledInUnknownCountryImpacts
+                                    )
+                                , it "should increase assembly transport impacts when total transported mass increases"
+                                    (let
+                                        productAssembledInUnknownCountryImpacts =
+                                            productAssembledInUnknownCountry
+                                                |> .transports
+                                                |> .toAssembly
+                                                |> .impacts
+                                                |> getEcsImpact
+
+                                        heavierProductAssembledInUnknownCountryImpacts =
+                                            heavierProductAssembledInUnknownCountry
+                                                |> .transports
+                                                |> .toAssembly
                                                 |> .impacts
                                                 |> getEcsImpact
                                      in


### PR DESCRIPTION
## :wrench: Problem

Fixes #2333

Item quantity wasn't applied when computing transports to assembly stage.

## :cake: Solution

Ensure multiplying element impacts according to parent element quantity.

## :desert_island: How to test

Set the quantity of a component to 2: the transport impacts to assembly should be doubled.