### PR TITLE
feat(generic,ui): render production item unit mass

### DIFF
--- a/e2e/object-simulator.spec.js
+++ b/e2e/object-simulator.spec.js
@@ -11,9 +11,6 @@ test("object simulator", async ({ page }) => {
   await page.getByRole("button", { name: "Ajouter un matériau" }).click();
   await page.getByRole("option", { name: "Mousse polyurethane (canapé 3p)" }).click();
 
-  await expect(page.getByRole("columnheader", { name: "Masse unitaire" }).first()).toBeVisible();
-  await expect(page.getByRole("columnheader", { name: "Masse totale" }).first()).toBeVisible();
-
   await page.getByRole("row", { name: "▶ Pied chaise acier" }).getByRole("spinbutton").fill("2");
   await page.getByRole("row", { name: "▶ Structure acier" }).getByRole("spinbutton").fill("3");
   await page.getByRole("row", { name: "▶ Mousse polyurethane" }).getByRole("spinbutton").fill("4");

--- a/e2e/object-simulator.spec.js
+++ b/e2e/object-simulator.spec.js
@@ -11,6 +11,9 @@ test("object simulator", async ({ page }) => {
   await page.getByRole("button", { name: "Ajouter un matériau" }).click();
   await page.getByRole("option", { name: "Mousse polyurethane (canapé 3p)" }).click();
 
+  await expect(page.getByRole("columnheader", { name: "Masse unitaire" }).first()).toBeVisible();
+  await expect(page.getByRole("columnheader", { name: "Masse totale" }).first()).toBeVisible();
+
   await page.getByRole("row", { name: "▶ Pied chaise acier" }).getByRole("spinbutton").fill("2");
   await page.getByRole("row", { name: "▶ Structure acier" }).getByRole("spinbutton").fill("3");
   await page.getByRole("row", { name: "▶ Mousse polyurethane" }).getByRole("spinbutton").fill("4");

--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -77,6 +77,7 @@ module Data.Component exposing
     , extractItems
     , extractMass
     , extractStage
+    , extractUnitMass
     , findById
     , getAssemblyOperations
     , getAvailableDistributionProcesses
@@ -1979,6 +1980,20 @@ extractMass (Results { mass }) =
 extractStage : Results -> Maybe Stage
 extractStage (Results { stage }) =
     stage
+
+
+{-| Extracts the unit mass of a Results item line
+
+Note: in case of a quantity of 0, the unit mass is the total mass.
+
+-}
+extractUnitMass : Results -> Mass
+extractUnitMass (Results { mass, quantity }) =
+    if quantity == 0 then
+        mass
+
+    else
+        mass |> Quantity.divideBy (toFloat quantity)
 
 
 {-| Lookup a Component from a provided Id

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -324,12 +324,13 @@ componentView config itemIndex ({ component, elements, quantity } as expandedIte
                 [ if config.scope /= Scope.Textile then
                     tr []
                         [ th [] []
-                        , th [ class "pb-0 fs-8 fw-normal text-muted" ] [ text "Quantité" ]
+                        , th [ class "pb-0 fs-8 fw-normal text-muted text-nowrap" ] [ text "Masse unitaire" ]
                         , th [ class "pb-0 fs-8 fw-normal text-muted", colspan 2 ]
                             [ span [] [ text config.labels.label ] ]
-                        , th [ class "pb-0 fs-8 fw-normal text-muted text-end" ] [ text "Masse unitaire" ]
-                        , th [ class "pb-0 fs-8 fw-normal text-muted text-end" ] [ text "Masse totale" ]
-                        , th [ colspan 2 ] []
+                        , th [ class "pb-0 fs-8 fw-normal text-muted text-nowrap text-center" ] [ text "Quantité" ]
+                        , th [ class "pb-0 fs-8 fw-normal text-muted text-nowrap text-center" ] [ text "Masse totale" ]
+                        , th [ class "pb-0 fs-8 fw-normal text-muted text-nowrap text-center" ] [ text "Impacts" ]
+                        , th [] []
                         ]
 
                   else
@@ -358,8 +359,9 @@ componentView config itemIndex ({ component, elements, quantity } as expandedIte
                           else
                             text ""
                         ]
-                    , td [ class "ps-0 pt-0 pb-2 align-middle" ]
-                        [ quantity |> quantityInput config itemIndex
+                    , td [ class "pt-0 pb-2 text-end align-middle text-nowrap fs-7" ]
+                        [ Component.extractUnitMass itemResults
+                            |> Format.kg
                         ]
                     , td [ class "pt-0 pb-2 align-middle text-truncate w-100", colspan 2 ]
                         [ if config.context == GenericContext then
@@ -379,15 +381,14 @@ componentView config itemIndex ({ component, elements, quantity } as expandedIte
                           else
                             span [ class "fw-bold" ] [ text component.name ]
                         ]
-                    , td [ class "pt-0 pb-2 text-end align-middle text-nowrap fs-7" ]
-                        [ Component.extractUnitMass itemResults
-                            |> Format.kg
+                    , td [ class "ps-0 pt-0 pb-2 align-middle" ]
+                        [ quantity |> quantityInput config itemIndex
                         ]
                     , td [ class "pt-0 pb-2 text-end align-middle text-nowrap fs-7" ]
                         [ Component.extractMass itemResults
                             |> Format.kg
                         ]
-                    , td [ class "pt-0 pb-2 text-end align-middle text-nowrap fs-7" ]
+                    , td [ class "pt-0 pb-2 text-end align-middle text-nowrap fs-7", style "min-width" "80px" ]
                         [ Component.getTotalImpacts itemResults
                             |> Format.formatImpact config.impact
                         ]
@@ -1429,7 +1430,7 @@ regionSelector config =
 
 quantityInput : Config db msg -> Index -> Quantity -> Html msg
 quantityInput config itemIndex quantity =
-    div [ class "input-group", style "width" "130px" ]
+    div [ class "input-group", style "width" "80px" ]
         [ input
             [ type_ "number"
             , class "form-control text-end"

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -327,11 +327,13 @@ componentView config itemIndex ({ component, elements, quantity } as expandedIte
                         , th [ class "pb-0 fs-8 fw-normal text-muted" ] [ text "Quantité" ]
                         , th [ class "pb-0 fs-8 fw-normal text-muted", colspan 2 ]
                             [ span [] [ text config.labels.label ] ]
-                        , th [ colspan 3 ] []
+                        , th [ class "pb-0 fs-8 fw-normal text-muted text-end" ] [ text "Masse unitaire" ]
+                        , th [ class "pb-0 fs-8 fw-normal text-muted text-end" ] [ text "Masse totale" ]
+                        , th [ colspan 2 ] []
                         ]
 
                   else
-                    tr [] [ td [ colspan 7 ] [] ]
+                    tr [] [ td [ colspan 8 ] [] ]
                 , tr [ class "border-bottom" ]
                     [ th [ class "ps-2 pt-0 pb-2 align-middle", scope "col" ]
                         [ if config.context /= TextileTrimsContext then
@@ -378,6 +380,10 @@ componentView config itemIndex ({ component, elements, quantity } as expandedIte
                             span [ class "fw-bold" ] [ text component.name ]
                         ]
                     , td [ class "pt-0 pb-2 text-end align-middle text-nowrap fs-7" ]
+                        [ Component.extractUnitMass itemResults
+                            |> Format.kg
+                        ]
+                    , td [ class "pt-0 pb-2 text-end align-middle text-nowrap fs-7" ]
                         [ Component.extractMass itemResults
                             |> Format.kg
                         ]
@@ -413,7 +419,7 @@ componentDetailedView config elements itemIndex expandedItem itemResults =
     List.concat
         [ [ tr [ class "bg-light border-bottom" ]
                 [ th [] []
-                , th [ class "pb-1", colspan 6 ] [ text "Composition" ]
+                , th [ class "pb-1", colspan 7 ] [ text "Composition" ]
                 ]
           ]
         , if List.isEmpty elements then
@@ -432,7 +438,7 @@ componentDetailedView config elements itemIndex expandedItem itemResults =
                 elements
                 (Component.extractItems itemResults)
         , [ tr [ class "border-top" ]
-                [ td [ colspan 7, class "pe-3" ]
+                [ td [ colspan 8, class "pe-3" ]
                     [ addElementButton config ( expandedItem.component, itemIndex )
                     ]
                 ]
@@ -547,7 +553,8 @@ lifeCycleView ({ db, docsUrl, explorerRoute, impact, query, scope } as config) l
                                             , th [ Attr.scope "col", colspan 2 ]
                                                 [ text config.labels.name
                                                 ]
-                                            , th [ Attr.scope "col" ] [ text "Masse" ]
+                                            , th [ Attr.scope "col" ] [ text "Masse unitaire" ]
+                                            , th [ Attr.scope "col" ] [ text "Masse totale" ]
                                             , th [ Attr.scope "col" ] [ text "Impact" ]
                                             , th [ Attr.scope "col" ] []
                                             ]
@@ -975,7 +982,7 @@ elementView config (( component, _ ) as targetItem) elementIndex { amount, mater
                         ]
                     ]
                 ]
-            , td [ class "align-middle text-end text-nowrap", colspan 2 ]
+            , td [ class "align-middle text-end text-nowrap", colspan 3 ]
                 [ Component.getTotalImpacts elementResults
                     |> Format.formatImpact config.impact
                 ]

--- a/tests/Data/ComponentTest.elm
+++ b/tests/Data/ComponentTest.elm
@@ -813,18 +813,21 @@ suite =
                                 |> toComputedResults
                             )
                             (\unitResults doubledResults ->
-                                [ ( Component.extractUnitMass doubledResults |> Mass.inKilograms
-                                  , Component.extractUnitMass unitResults |> Mass.inKilograms
-                                  )
-                                , ( Component.extractMass doubledResults |> Mass.inKilograms
-                                  , (Component.extractMass unitResults |> Mass.inKilograms) * 2
-                                  )
-                                , ( Component.getTotalImpacts doubledResults |> getEcsImpact
-                                  , (Component.getTotalImpacts unitResults |> getEcsImpact) * 2
-                                  )
-                                ]
-                                    |> List.map (\( a, b ) -> always <| Expect.within (Expect.Absolute 0.00001) a b)
-                                    |> (\expects -> Expect.all expects ())
+                                Expect.all
+                                    [ \_ ->
+                                        Expect.within (Expect.Absolute 0.00001)
+                                            (Component.extractUnitMass unitResults |> Mass.inKilograms)
+                                            (Component.extractUnitMass doubledResults |> Mass.inKilograms)
+                                    , \_ ->
+                                        Expect.within (Expect.Absolute 0.00001)
+                                            ((Component.extractMass unitResults |> Mass.inKilograms) * 2)
+                                            (Component.extractMass doubledResults |> Mass.inKilograms)
+                                    , \_ ->
+                                        Expect.within (Expect.Absolute 0.00001)
+                                            ((Component.getTotalImpacts unitResults |> getEcsImpact) * 2)
+                                            (Component.getTotalImpacts doubledResults |> getEcsImpact)
+                                    ]
+                                    ()
                             )
                          ]
                         )

--- a/tests/Data/ComponentTest.elm
+++ b/tests/Data/ComponentTest.elm
@@ -796,6 +796,36 @@ suite =
                                                 Expect.fail err
                                    )
                             )
+                         , itFromResult "should equal extractMass when quantity is 1"
+                            ("""{"id": "64fa65b3-c2df-4fd0-958b-83965bd6aa08", "quantity": 1}"""
+                                |> toComputedResults
+                            )
+                            (\results ->
+                                Expect.within (Expect.Absolute 0.00001)
+                                    (Component.extractUnitMass results |> Mass.inKilograms)
+                                    (Component.extractMass results |> Mass.inKilograms)
+                            )
+                         , itFromResult2 "should keep unit mass unchanged when quantity is scaled"
+                            ("""{"id": "64fa65b3-c2df-4fd0-958b-83965bd6aa08", "quantity": 1}"""
+                                |> toComputedResults
+                            )
+                            ("""{"id": "64fa65b3-c2df-4fd0-958b-83965bd6aa08", "quantity": 2}"""
+                                |> toComputedResults
+                            )
+                            (\unitResults doubledResults ->
+                                [ ( Component.extractUnitMass doubledResults |> Mass.inKilograms
+                                  , Component.extractUnitMass unitResults |> Mass.inKilograms
+                                  )
+                                , ( Component.extractMass doubledResults |> Mass.inKilograms
+                                  , (Component.extractMass unitResults |> Mass.inKilograms) * 2
+                                  )
+                                , ( Component.getTotalImpacts doubledResults |> getEcsImpact
+                                  , (Component.getTotalImpacts unitResults |> getEcsImpact) * 2
+                                  )
+                                ]
+                                    |> List.map (\( a, b ) -> always <| Expect.within (Expect.Absolute 0.00001) a b)
+                                    |> (\expects -> Expect.all expects ())
+                            )
                          ]
                         )
                     , describe "computePackagingImpacts"


### PR DESCRIPTION
## :wrench: Problem

Fixes #2729

## :cake: Solution

Render the mass of a single unit of component item at the production stage:

<img width="1760" height="566" alt="image" src="https://github.com/user-attachments/assets/fb090d2e-4e67-4887-b13c-0dee872a25c3" />

## :desert_island: How to test

Add a component item (matériau/ingrédient), set its quantity to 2, inspect the per-unit mass rendered.