### PR TITLE
feat(generic): render component line elements shares

### DIFF
--- a/scalingo.json
+++ b/scalingo.json
@@ -13,5 +13,5 @@
       "value": "true"
     }
   },
-  "stack": "scalingo-26"
+  "stack": "scalingo-22"
 }

--- a/scalingo.json
+++ b/scalingo.json
@@ -13,5 +13,5 @@
       "value": "true"
     }
   },
-  "stack": "scalingo-22"
+  "stack": "scalingo-26"
 }

--- a/src/Data/Component.elm
+++ b/src/Data/Component.elm
@@ -53,6 +53,7 @@ module Data.Component exposing
     , decodeQuery
     , defaultDurability
     , defaultTransportOptions
+    , elementMassShare
     , elementTransforms
     , elementsToString
     , emptyAssembly
@@ -979,13 +980,7 @@ computeMaterialResults amount process =
                 |> Maybe.withDefault Complement.emptyComplementsResultsImpacts
 
         mass =
-            Mass.kilograms <|
-                if process.unit == Process.Kilogram then
-                    Amount.toFloat amount
-
-                else
-                    -- apply mass per unit
-                    Amount.toFloat amount * Maybe.withDefault 1 process.massPerUnit
+            massFromProcess amount process
 
         materialType =
             Process.getMaterialTypes process
@@ -1472,6 +1467,24 @@ defaultTransportOptions =
     { byAir = Split.zero
     , cooling = Nothing
     }
+
+
+{-| Share of an element's mass in a component's unit mass.
+
+When the unit mass is 0, the share is 0.
+
+-}
+elementMassShare : Mass -> Mass -> Split
+elementMassShare elementMass unitMass =
+    if unitMass == Quantity.zero then
+        Split.zero
+
+    else
+        Mass.inKilograms elementMass
+            / Mass.inKilograms unitMass
+            |> clamp 0 1
+            |> Split.fromFloat
+            |> Result.withDefault Split.zero
 
 
 elementToString : List Process -> Element -> Result String String
@@ -2507,6 +2520,22 @@ loadEnergyMixes config =
 mapItems : (List Item -> List Item) -> Query -> Query
 mapItems fn query =
     setQueryItems (fn query.items) query
+
+
+{-| Converts a process amount to a mass in kilograms.
+
+  - Kilogram processes: the amount is already a mass
+  - Other units: amount × massPerUnit (density). Missing density yields 0 kg.
+
+-}
+massFromProcess : Amount -> Process -> Mass
+massFromProcess amount process =
+    Mass.kilograms <|
+        if process.unit == Process.Kilogram then
+            Amount.toFloat amount
+
+        else
+            Amount.toFloat amount * Maybe.withDefault 0 process.massPerUnit
 
 
 nonLocalizedExpandedProcess : Process -> ExpandedLocalizedProcess

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -953,25 +953,24 @@ elementView config (( component, _ ) as targetItem) itemResults elementIndex { a
                 , "(" ++ (country |> Maybe.map .name |> Maybe.withDefault "Inconnu") ++ ")"
                 ]
 
-        originalUnitAmount =
-            if material.process.unit /= Process.Kilogram then
-                span [ class "text-muted fs-8" ]
-                    [ Format.amount material.process amount ]
+        amountInfo =
+            span [ class "d-flex text-muted fs-8" ]
+                [ if material.process.unit /= Process.Kilogram then
+                    span [] [ text "(", Format.amount material.process amount, text ")\u{00A0}" ]
 
-            else
-                text ""
+                  else
+                    text ""
+                , Format.kg elementMass
+                ]
     in
     tbody []
         [ tr [ class "fs-7 border-top" ]
             [ td [] []
-            , td [ class "ps-0 align-start text-end text-nowrap" ]
-                [ div [ class "d-flex flex-column" ]
-                    [ -- FIXME: move share to its own column
-                      Component.elementMassShare elementMass (Component.extractUnitMass itemResults)
-                        |> Format.splitAsPercentage 1
-                    , Format.kg elementMass
-                    , originalUnitAmount
-                    ]
+            , td [ class "d-flex flex-column align-items-end" ]
+                [ Component.extractUnitMass itemResults
+                    |> Component.elementMassShare elementMass
+                    |> Format.splitAsPercentage 1
+                , amountInfo
                 ]
             , td
                 [ colspan 2

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -420,7 +420,7 @@ componentDetailedView config elements itemIndex expandedItem itemResults =
     List.concat
         [ [ tr [ class "bg-light border-bottom" ]
                 [ th [] []
-                , th [ class "pb-1", colspan 7 ] [ text "Composition" ]
+                , th [ class "pb-1", colspan 8 ] [ text "Composition" ]
                 ]
           ]
         , if List.isEmpty elements then
@@ -952,31 +952,28 @@ elementView config (( component, _ ) as targetItem) itemResults elementIndex { a
                 [ Process.getDisplayName process
                 , "(" ++ (country |> Maybe.map .name |> Maybe.withDefault "Inconnu") ++ ")"
                 ]
-
-        originalUnitAmount =
-            if material.process.unit /= Process.Kilogram then
-                span [ class "text-muted fs-8" ]
-                    [ Format.amount material.process amount ]
-
-            else
-                text ""
     in
     tbody []
         [ tr [ class "fs-7 border-top" ]
             [ td [] []
             , td [ class "ps-0 align-start text-end text-nowrap" ]
+                [ Component.elementMassShare elementMass (Component.extractUnitMass itemResults)
+                    |> Format.splitAsPercentage 1
+                ]
+            , td [ class "align-start text-end text-nowrap" ]
                 [ div [ class "d-flex flex-column" ]
-                    [ -- FIXME: move share to its own column
-                      Component.elementMassShare elementMass (Component.extractUnitMass itemResults)
-                        |> Format.splitAsPercentage 1
-                    , Format.kg elementMass
-                    , originalUnitAmount
+                    [ Format.kg elementMass
+                    , if material.process.unit /= Process.Kilogram then
+                        span [ class "text-muted fs-8 cursor-help", title "Quantité initiale dans l’unité d’origine" ]
+                            [ Format.amount material.process amount ]
+
+                      else
+                        text ""
                     ]
                 ]
             , td
                 [ colspan 2
                 , class "align-middle text-truncate"
-                , style "max-width" "10vw"
                 ]
                 [ div [ class "d-flex flex-column" ]
                     [ button

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -321,20 +321,16 @@ componentView config itemIndex ({ component, elements, quantity } as expandedIte
                  else
                     []
                 )
-                [ if config.scope /= Scope.Textile then
-                    tr []
-                        [ th [] []
-                        , th [ class "pb-0 fs-8 fw-normal text-muted text-nowrap" ] [ text "Masse unitaire" ]
-                        , th [ class "pb-0 fs-8 fw-normal text-muted", colspan 3 ]
-                            [ span [] [ text config.labels.label ] ]
-                        , th [ class "pb-0 fs-8 fw-normal text-muted text-nowrap text-center" ] [ text "Quantité" ]
-                        , th [ class "pb-0 fs-8 fw-normal text-muted text-nowrap text-center" ] [ text "Masse totale" ]
-                        , th [ class "pb-0 fs-8 fw-normal text-muted text-nowrap text-center" ] [ text "Impacts" ]
-                        , th [] []
-                        ]
-
-                  else
-                    tr [] [ td [ colspan 8 ] [] ]
+                [ tr []
+                    [ th [] []
+                    , th [ class "pb-0 fs-8 fw-normal text-muted text-nowrap" ] [ text "Masse unitaire" ]
+                    , th [ class "pb-0 fs-8 fw-normal text-muted", colspan 3 ]
+                        [ span [] [ text config.labels.label ] ]
+                    , th [ class "pb-0 fs-8 fw-normal text-muted text-nowrap text-center" ] [ text "Quantité" ]
+                    , th [ class "pb-0 fs-8 fw-normal text-muted text-nowrap text-center" ] [ text "Masse totale" ]
+                    , th [ class "pb-0 fs-8 fw-normal text-muted text-nowrap text-center" ] [ text "Impacts" ]
+                    , th [] []
+                    ]
                 , tr [ class "border-bottom" ]
                     [ th [ class "ps-2 pt-0 pb-2 align-middle", scope "col" ]
                         [ if config.context /= TextileTrimsContext then

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -420,7 +420,7 @@ componentDetailedView config elements itemIndex expandedItem itemResults =
     List.concat
         [ [ tr [ class "bg-light border-bottom" ]
                 [ th [] []
-                , th [ class "pb-1", colspan 8 ] [ text "Composition" ]
+                , th [ class "pb-1", colspan 7 ] [ text "Composition" ]
                 ]
           ]
         , if List.isEmpty elements then
@@ -952,28 +952,31 @@ elementView config (( component, _ ) as targetItem) itemResults elementIndex { a
                 [ Process.getDisplayName process
                 , "(" ++ (country |> Maybe.map .name |> Maybe.withDefault "Inconnu") ++ ")"
                 ]
+
+        originalUnitAmount =
+            if material.process.unit /= Process.Kilogram then
+                span [ class "text-muted fs-8" ]
+                    [ Format.amount material.process amount ]
+
+            else
+                text ""
     in
     tbody []
         [ tr [ class "fs-7 border-top" ]
             [ td [] []
             , td [ class "ps-0 align-start text-end text-nowrap" ]
-                [ Component.elementMassShare elementMass (Component.extractUnitMass itemResults)
-                    |> Format.splitAsPercentage 1
-                ]
-            , td [ class "align-start text-end text-nowrap" ]
                 [ div [ class "d-flex flex-column" ]
-                    [ Format.kg elementMass
-                    , if material.process.unit /= Process.Kilogram then
-                        span [ class "text-muted fs-8 cursor-help", title "Quantité initiale dans l’unité d’origine" ]
-                            [ Format.amount material.process amount ]
-
-                      else
-                        text ""
+                    [ -- FIXME: move share to its own column
+                      Component.elementMassShare elementMass (Component.extractUnitMass itemResults)
+                        |> Format.splitAsPercentage 1
+                    , Format.kg elementMass
+                    , originalUnitAmount
                     ]
                 ]
             , td
                 [ colspan 2
                 , class "align-middle text-truncate"
+                , style "max-width" "10vw"
                 ]
                 [ div [ class "d-flex flex-column" ]
                     [ button

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -325,7 +325,7 @@ componentView config itemIndex ({ component, elements, quantity } as expandedIte
                     tr []
                         [ th [] []
                         , th [ class "pb-0 fs-8 fw-normal text-muted text-nowrap" ] [ text "Masse unitaire" ]
-                        , th [ class "pb-0 fs-8 fw-normal text-muted", colspan 2 ]
+                        , th [ class "pb-0 fs-8 fw-normal text-muted", colspan 3 ]
                             [ span [] [ text config.labels.label ] ]
                         , th [ class "pb-0 fs-8 fw-normal text-muted text-nowrap text-center" ] [ text "Quantité" ]
                         , th [ class "pb-0 fs-8 fw-normal text-muted text-nowrap text-center" ] [ text "Masse totale" ]
@@ -363,7 +363,7 @@ componentView config itemIndex ({ component, elements, quantity } as expandedIte
                         [ Component.extractUnitMass itemResults
                             |> Format.kg
                         ]
-                    , td [ class "pt-0 pb-2 align-middle text-truncate w-100", colspan 2 ]
+                    , td [ class "pt-0 pb-2 align-middle text-truncate w-100", colspan 3 ]
                         [ if config.context == GenericContext then
                             div [ class "d-flex flex-column gap-1" ]
                                 [ div [ class "d-flex gap-2" ]
@@ -392,7 +392,7 @@ componentView config itemIndex ({ component, elements, quantity } as expandedIte
                         [ Component.getTotalImpacts itemResults
                             |> Format.formatImpact config.impact
                         ]
-                    , td [ class "pe-3 pt-0 pb-2 text-end align-middle text-nowrap" ]
+                    , td [ class "pe-3 pt-0 pb-2 text-end align-end text-nowrap" ]
                         [ if config.context == AdminContext then
                             text ""
 
@@ -420,7 +420,7 @@ componentDetailedView config elements itemIndex expandedItem itemResults =
     List.concat
         [ [ tr [ class "bg-light border-bottom" ]
                 [ th [] []
-                , th [ class "pb-1", colspan 7 ] [ text "Composition" ]
+                , th [ class "pb-1", colspan 8 ] [ text "Composition" ]
                 ]
           ]
         , if List.isEmpty elements then
@@ -973,9 +973,9 @@ elementView config (( component, _ ) as targetItem) itemResults elementIndex { a
                 , amountInfo
                 ]
             , td
-                [ colspan 2
+                [ colspan 3
                 , class "align-middle text-truncate"
-                , style "max-width" "10vw"
+                , style "max-width" "0"
                 ]
                 [ div [ class "d-flex flex-column" ]
                     [ button

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -434,7 +434,7 @@ componentDetailedView config elements itemIndex expandedItem itemResults =
 
           else
             List.map3
-                (elementView config ( expandedItem.component, itemIndex ))
+                (elementView config ( expandedItem.component, itemIndex ) itemResults)
                 (List.range 0 (List.length elements - 1))
                 elements
                 (Component.extractItems itemResults)
@@ -941,20 +941,38 @@ countrySelector config =
             )
 
 
-elementView : Config db msg -> TargetItem -> Index -> ExpandedElement -> Results -> Html msg
-elementView config (( component, _ ) as targetItem) elementIndex { amount, material, transforms } elementResults =
+elementView : Config db msg -> TargetItem -> Results -> Index -> ExpandedElement -> Results -> Html msg
+elementView config (( component, _ ) as targetItem) itemResults elementIndex { amount, material, transforms } elementResults =
     let
+        elementMass =
+            Component.extractMass elementResults
+
         materialLabel { country, process } =
             String.join " "
                 [ Process.getDisplayName process
                 , "(" ++ (country |> Maybe.map .name |> Maybe.withDefault "Inconnu") ++ ")"
                 ]
+
+        originalUnitAmount =
+            if material.process.unit /= Process.Kilogram then
+                span [ class "text-muted fs-8" ]
+                    [ Format.amount material.process amount ]
+
+            else
+                text ""
     in
     tbody []
         [ tr [ class "fs-7 border-top" ]
             [ td [] []
             , td [ class "ps-0 align-start text-end text-nowrap" ]
-                [ Format.amount material.process amount ]
+                [ div [ class "d-flex flex-column" ]
+                    [ -- FIXME: move share to its own column
+                      Component.elementMassShare elementMass (Component.extractUnitMass itemResults)
+                        |> Format.splitAsPercentage 1
+                    , Format.kg elementMass
+                    , originalUnitAmount
+                    ]
+                ]
             , td
                 [ colspan 2
                 , class "align-middle text-truncate"

--- a/src/Views/Component.elm
+++ b/src/Views/Component.elm
@@ -439,7 +439,7 @@ componentDetailedView config elements itemIndex expandedItem itemResults =
                 elements
                 (Component.extractItems itemResults)
         , [ tr [ class "border-top" ]
-                [ td [ colspan 8, class "pe-3" ]
+                [ td [ colspan 9, class "pe-3" ]
                     [ addElementButton config ( expandedItem.component, itemIndex )
                     ]
                 ]

--- a/tests/Data/ComponentTest.elm
+++ b/tests/Data/ComponentTest.elm
@@ -36,7 +36,8 @@ import Result.Extra as RE
 import Test exposing (..)
 import TestUtils
     exposing
-        ( expectFloatDifferent
+        ( expectAllSucceed
+        , expectFloatDifferent
         , expectFloatMostlyEqual
         , expectResultErrorContains
         , it
@@ -835,21 +836,17 @@ suite =
                                 |> toComputedResults
                             )
                             (\unitResults doubledResults ->
-                                Expect.all
-                                    [ \_ ->
-                                        expectFloatMostlyEqual
-                                            (Component.extractUnitMass unitResults |> Mass.inKilograms)
-                                            (Component.extractUnitMass doubledResults |> Mass.inKilograms)
-                                    , \_ ->
-                                        expectFloatMostlyEqual
-                                            ((Component.extractMass unitResults |> Mass.inKilograms) * 2)
-                                            (Component.extractMass doubledResults |> Mass.inKilograms)
-                                    , \_ ->
-                                        expectFloatMostlyEqual
-                                            ((Component.getTotalImpacts unitResults |> getEcsImpact) * 2)
-                                            (Component.getTotalImpacts doubledResults |> getEcsImpact)
+                                expectAllSucceed
+                                    [ expectFloatMostlyEqual
+                                        (Component.extractUnitMass unitResults |> Mass.inKilograms)
+                                        (Component.extractUnitMass doubledResults |> Mass.inKilograms)
+                                    , expectFloatMostlyEqual
+                                        ((Component.extractMass unitResults |> Mass.inKilograms) * 2)
+                                        (Component.extractMass doubledResults |> Mass.inKilograms)
+                                    , expectFloatMostlyEqual
+                                        ((Component.getTotalImpacts unitResults |> getEcsImpact) * 2)
+                                        (Component.getTotalImpacts doubledResults |> getEcsImpact)
                                     ]
-                                    ()
                             )
                          , itFromResult "should split unit mass evenly across two 1kg elements"
                             ("""{ "id": "ad9d7f23-076b-49c5-93a4-ee1cd7b53973",
@@ -876,13 +873,15 @@ suite =
                                                         |> Component.elementMassShare (Component.extractMass elementResults)
                                                 )
                                 in
-                                Expect.all
-                                    [ \_ -> Mass.inKilograms unitMass |> expectFloatMostlyEqual 2
-                                    , \_ -> Expect.equal [ Split.half, Split.half ] elementShares
+                                expectAllSucceed
+                                    [ Mass.inKilograms unitMass
+                                        |> expectFloatMostlyEqual 2
+                                    , elementShares
+                                        |> Expect.equal [ Split.half, Split.half ]
                                     ]
-                                    ()
                             )
                          , itFromResult2 "should keep element mass shares unchanged when quantity is scaled"
+                            -- initial quantity
                             ("""{ "id": "ad9d7f23-076b-49c5-93a4-ee1cd7b53973",
                                   "quantity": 1,
                                   "custom": {
@@ -894,6 +893,7 @@ suite =
                                 }"""
                                 |> toComputedResults
                             )
+                            -- doubled quantity
                             ("""{ "id": "ad9d7f23-076b-49c5-93a4-ee1cd7b53973",
                                   "quantity": 2,
                                   "custom": {
@@ -907,7 +907,7 @@ suite =
                             )
                             (\unitResults doubledResults ->
                                 let
-                                    shares results =
+                                    extractShares results =
                                         let
                                             unitMass =
                                                 Component.extractUnitMass results
@@ -919,15 +919,15 @@ suite =
                                                         |> Component.elementMassShare (Component.extractMass elementResults)
                                                 )
                                 in
-                                Expect.all
-                                    [ \_ -> shares doubledResults |> Expect.equal (shares unitResults)
-                                    , \_ -> shares doubledResults |> Expect.equal [ Split.half, Split.half ]
-                                    , \_ ->
-                                        Component.extractUnitMass doubledResults
-                                            |> Mass.inKilograms
-                                            |> expectFloatMostlyEqual (Component.extractUnitMass unitResults |> Mass.inKilograms)
+                                expectAllSucceed
+                                    [ extractShares doubledResults
+                                        |> Expect.equal (extractShares unitResults)
+                                    , extractShares doubledResults
+                                        |> Expect.equal [ Split.half, Split.half ]
+                                    , Component.extractUnitMass doubledResults
+                                        |> Mass.inKilograms
+                                        |> expectFloatMostlyEqual (Component.extractUnitMass unitResults |> Mass.inKilograms)
                                     ]
-                                    ()
                             )
                          ]
                         )

--- a/tests/Data/ComponentTest.elm
+++ b/tests/Data/ComponentTest.elm
@@ -206,22 +206,22 @@ suite =
                           describe "qtyVariationRatio"
                             [ it "should not apply any quantity variation ratio when no transforms are passed"
                                 (getTestMass []
-                                    |> Expect.within (Expect.Absolute 0.00001) 1
+                                    |> expectFloatMostlyEqual 1
                                 )
                             , it "should apply quantity variation ratio when one transform is passed"
                                 (getTestMass [ { weaving | qtyVariationRatio = Unit.qtyVariationRatio 0.2 } ]
-                                    |> Expect.within (Expect.Absolute 0.00001) 0.2
+                                    |> expectFloatMostlyEqual 0.2
                                 )
                             , it "should apply quantity variation superior to 1"
                                 (getTestMass [ { weaving | qtyVariationRatio = Unit.qtyVariationRatio 2 } ]
-                                    |> Expect.within (Expect.Absolute 0.00001) 2
+                                    |> expectFloatMostlyEqual 2
                                 )
                             , it "should apply quantity variation ratio sequentially when multiple transforms are passed"
                                 (getTestMass
                                     [ { weaving | qtyVariationRatio = Unit.qtyVariationRatio 0.5 }
                                     , { weaving | qtyVariationRatio = Unit.qtyVariationRatio 0.5 }
                                     ]
-                                    |> Expect.within (Expect.Absolute 0.00001) 0.25
+                                    |> expectFloatMostlyEqual 0.25
                                 )
                             ]
                         , let
@@ -248,7 +248,7 @@ suite =
                           describe "impacts"
                             [ it "should not add impacts when no transforms are passed"
                                 (getTestEcsImpact []
-                                    |> Expect.within (Expect.Absolute 0.00001) 0
+                                    |> expectFloatMostlyEqual 0
                                 )
                             , it "should add impacts when one transform is passed (no elec, no heat)"
                                 (getTestEcsImpact
@@ -496,7 +496,7 @@ suite =
                                     -- forcing air transport ratio to full must not change the result, as it's always
                                     -- reset to zero at the transform step level
                                     getEcsForByAir Split.full
-                                        |> Expect.within (Expect.Absolute 0.00001) (getEcsForByAir Split.zero)
+                                        |> expectFloatMostlyEqual (getEcsForByAir Split.zero)
                                 )
                             ]
                         ]
@@ -700,6 +700,28 @@ suite =
                                     )
                                 ]
                             )
+                        , suiteFromResult "missing massPerUnit defaults to 0"
+                            (wood
+                                |> Result.andThen
+                                    (\woodProcess ->
+                                        { amount = Amount.fromFloat 1
+                                        , material = { country = Nothing, id = woodProcess.id }
+                                        , transforms = []
+                                        }
+                                            |> Component.computeElementResults
+                                                (updateRequirementsProcess woodProcess (\p -> { p | massPerUnit = Nothing }) requirements)
+                                                defaultTransportOptions
+                                    )
+                            )
+                            (\results ->
+                                [ it "should compute mass as 0 when a non-kg process features an unknown massPerUnit"
+                                    (results
+                                        |> Component.extractMass
+                                        |> Mass.inKilograms
+                                        |> Expect.equal 0
+                                    )
+                                ]
+                            )
                         , suiteFromResult2 "compute metadata complements"
                             wood
                             sawing
@@ -716,7 +738,7 @@ suite =
                                     (results
                                         |> Result.map extractComplementEcsImpact
                                         |> Result.withDefault 0
-                                        |> Expect.within (Expect.Absolute 0.00001) 1.41462
+                                        |> expectFloatMostlyEqual 1.41462
                                     )
                                 ]
                             )
@@ -790,7 +812,7 @@ suite =
                                 |> (\result ->
                                         case result of
                                             Ok ( a, b ) ->
-                                                Expect.within (Expect.Absolute 0.00001) b (a * 2)
+                                                expectFloatMostlyEqual b (a * 2)
 
                                             Err err ->
                                                 Expect.fail err
@@ -801,7 +823,7 @@ suite =
                                 |> toComputedResults
                             )
                             (\results ->
-                                Expect.within (Expect.Absolute 0.00001)
+                                expectFloatMostlyEqual
                                     (Component.extractUnitMass results |> Mass.inKilograms)
                                     (Component.extractMass results |> Mass.inKilograms)
                             )
@@ -815,22 +837,118 @@ suite =
                             (\unitResults doubledResults ->
                                 Expect.all
                                     [ \_ ->
-                                        Expect.within (Expect.Absolute 0.00001)
+                                        expectFloatMostlyEqual
                                             (Component.extractUnitMass unitResults |> Mass.inKilograms)
                                             (Component.extractUnitMass doubledResults |> Mass.inKilograms)
                                     , \_ ->
-                                        Expect.within (Expect.Absolute 0.00001)
+                                        expectFloatMostlyEqual
                                             ((Component.extractMass unitResults |> Mass.inKilograms) * 2)
                                             (Component.extractMass doubledResults |> Mass.inKilograms)
                                     , \_ ->
-                                        Expect.within (Expect.Absolute 0.00001)
+                                        expectFloatMostlyEqual
                                             ((Component.getTotalImpacts unitResults |> getEcsImpact) * 2)
                                             (Component.getTotalImpacts doubledResults |> getEcsImpact)
                                     ]
                                     ()
                             )
+                         , itFromResult "should split unit mass evenly across two 1kg elements"
+                            ("""{ "id": "ad9d7f23-076b-49c5-93a4-ee1cd7b53973",
+                                  "quantity": 1,
+                                  "custom": {
+                                    "elements": [
+                                      { "amount": 1, "material": "6527710e-2434-5347-9bef-2205e0aa4f66" },
+                                      { "amount": 1, "material": "59b42284-3e45-5343-8a20-1d7d66137461" }
+                                    ]
+                                  }
+                                }"""
+                                |> toComputedResults
+                            )
+                            (\results ->
+                                let
+                                    unitMass =
+                                        Component.extractUnitMass results
+
+                                    elementShares =
+                                        Component.extractItems results
+                                            |> List.map
+                                                (\elementResults ->
+                                                    unitMass
+                                                        |> Component.elementMassShare (Component.extractMass elementResults)
+                                                )
+                                in
+                                Expect.all
+                                    [ \_ -> Mass.inKilograms unitMass |> expectFloatMostlyEqual 2
+                                    , \_ -> Expect.equal [ Split.half, Split.half ] elementShares
+                                    ]
+                                    ()
+                            )
+                         , itFromResult2 "should keep element mass shares unchanged when quantity is scaled"
+                            ("""{ "id": "ad9d7f23-076b-49c5-93a4-ee1cd7b53973",
+                                  "quantity": 1,
+                                  "custom": {
+                                    "elements": [
+                                      { "amount": 1, "material": "6527710e-2434-5347-9bef-2205e0aa4f66" },
+                                      { "amount": 1, "material": "59b42284-3e45-5343-8a20-1d7d66137461" }
+                                    ]
+                                  }
+                                }"""
+                                |> toComputedResults
+                            )
+                            ("""{ "id": "ad9d7f23-076b-49c5-93a4-ee1cd7b53973",
+                                  "quantity": 2,
+                                  "custom": {
+                                    "elements": [
+                                      { "amount": 1, "material": "6527710e-2434-5347-9bef-2205e0aa4f66" },
+                                      { "amount": 1, "material": "59b42284-3e45-5343-8a20-1d7d66137461" }
+                                    ]
+                                  }
+                                }"""
+                                |> toComputedResults
+                            )
+                            (\unitResults doubledResults ->
+                                let
+                                    shares results =
+                                        let
+                                            unitMass =
+                                                Component.extractUnitMass results
+                                        in
+                                        Component.extractItems results
+                                            |> List.map
+                                                (\elementResults ->
+                                                    unitMass
+                                                        |> Component.elementMassShare (Component.extractMass elementResults)
+                                                )
+                                in
+                                Expect.all
+                                    [ \_ -> shares doubledResults |> Expect.equal (shares unitResults)
+                                    , \_ -> shares doubledResults |> Expect.equal [ Split.half, Split.half ]
+                                    , \_ ->
+                                        Component.extractUnitMass doubledResults
+                                            |> Mass.inKilograms
+                                            |> expectFloatMostlyEqual (Component.extractUnitMass unitResults |> Mass.inKilograms)
+                                    ]
+                                    ()
+                            )
                          ]
                         )
+                    , describe "elementMassShare"
+                        [ it "should be 50% when element mass is half of unit mass"
+                            (Component.elementMassShare (Mass.kilograms 1) (Mass.kilograms 2)
+                                |> Expect.equal Split.half
+                            )
+                        , it "should be 0 when unit mass is 0"
+                            (Component.elementMassShare (Mass.kilograms 1) Quantity.zero
+                                |> Expect.equal Split.zero
+                            )
+                        , it "should be 0 when element mass is 0"
+                            (Component.elementMassShare Quantity.zero (Mass.kilograms 2)
+                                |> Expect.equal Split.zero
+                            )
+                        , it "should be 100% when element mass equals unit mass"
+                            (Component.elementMassShare (Mass.kilograms 2) (Mass.kilograms 2)
+                                |> Expect.equal Split.full
+                            )
+                        ]
                     , describe "computePackagingImpacts"
                         (let
                             computePackagingEcsImpacts packagings =
@@ -884,9 +1002,9 @@ suite =
                             )
                             (\( productionMass, productMass, assemblyImpact ) ->
                                 [ it "should keep product mass unchanged" <|
-                                    Expect.within (Expect.Absolute 0.00001) productionMass productMass
+                                    expectFloatMostlyEqual productionMass productMass
                                 , it "should keep assembly impacts unchanged" <|
-                                    Expect.within (Expect.Absolute 0.00001) assemblyImpact 0
+                                    expectFloatMostlyEqual assemblyImpact 0
                                 ]
                             )
                         , itFromResult "should apply category default assembly operations when computing results"
@@ -947,16 +1065,16 @@ suite =
                                 in
                                 [ itFromResult "should halve mass after the first 50% waste operation"
                                     firstMass
-                                    (Expect.within (Expect.Absolute 0.00001)
+                                    (expectFloatMostlyEqual
                                         (productionMass * qtyVariationRatioFloat)
                                     )
                                 , it "should reduce end product mass to a quarter after two 50% waste operations" <|
-                                    Expect.within (Expect.Absolute 0.00001)
+                                    expectFloatMostlyEqual
                                         (productionMass * qtyVariationRatioFloat * qtyVariationRatioFloat)
                                         (Mass.inKilograms lifeCycle.productMass)
                                 , itFromResult "should apply the second 50% waste ratio on the remaining mass"
                                     secondMass
-                                    (Expect.within (Expect.Absolute 0.00001)
+                                    (expectFloatMostlyEqual
                                         (productionMass * qtyVariationRatioFloat * qtyVariationRatioFloat)
                                     )
                                 ]
@@ -2007,7 +2125,7 @@ suite =
                                     |> List.filterMap identity
                                     |> Impact.sumImpacts
                                     |> getEcsImpact
-                                    |> Expect.within (Expect.Absolute 0.00001)
+                                    |> expectFloatMostlyEqual
                                         ([ Component.extractImpacts lifeCycle.production
                                          , lifeCycle.transports.toAssembly.impacts
                                          , lifeCycle.transports.toDistribution.impacts
@@ -2132,12 +2250,12 @@ suite =
                             [ it "should ignore provided amount and use product mass when using a mass-dependent process"
                                 (Component.useProcessAmount lifeCycle massDependentProcess (Amount.fromFloat 999)
                                     |> Amount.toFloat
-                                    |> Expect.within (Expect.Absolute 0.00001) productMassInKg
+                                    |> expectFloatMostlyEqual productMassInKg
                                 )
                             , it "should return the given amount for a regular, non-mass-dependent process"
                                 (Component.useProcessAmount lifeCycle lowVoltageElecProcess (Amount.fromFloat 3)
                                     |> Amount.toFloat
-                                    |> Expect.within (Expect.Absolute 0.00001) 3
+                                    |> expectFloatMostlyEqual 3
                                 )
                             ]
                         )

--- a/tests/TestUtils.elm
+++ b/tests/TestUtils.elm
@@ -2,6 +2,7 @@ module TestUtils exposing
     ( asTest
     , componentConfig
     , createServerRequest
+    , expectAllSucceed
     , expectFloatDifferent
     , expectFloatMostlyEqual
     , expectImpactsEqual
@@ -48,6 +49,11 @@ asTest =
 componentConfig : Db -> Result String Component.Config
 componentConfig db =
     Component.parseConfig db StaticJson.componentConfigJson
+
+
+expectAllSucceed : List Expectation -> Expectation
+expectAllSucceed expectations =
+    Expect.all (expectations |> List.map always) ()
 
 
 expectFloatDifferent : Float -> Float -> Expectation


### PR DESCRIPTION
## :wrench: Problem

Fixes #2730

## :cake: Solution

<img width="1758" height="980" alt="image" src="https://github.com/user-attachments/assets/c9ed9f1f-abbe-493f-9c3b-258983de5799" />

## :desert_island: How to test

Go to the food2 simulator:

- Add an ingredient, remove all its elements, then add one: its share should be 100%
- Add a second element to it: the two elements should be 50%-50%
- Update the second element mass or volume: elements shares should have been recomputed accordingly
