### PR TITLE
fix(scalingo): enforce git compat with scalingo-22

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,2 @@
+[http "https://github.com"]
+version = HTTP/1.1


### PR DESCRIPTION
## :wrench: Problem

Il est impossible de déployer en production ou en review app depuis hier. Réponse du support Scalingo&nbsp;:

> Bonjour,
>
>En effet, nous avons identifié la cause de problème. Il s'agit d'une incompatibilité des anciennes stacks Scalingo (scalingo-22 et scalingo-24) avec des changements récemment opéré par GitHub
>
>La solution est de passer sur la stack scalingo-26.
>
>Si ce n'est pas possible immédiatement, un workaround semble possible&nbsp;: ajouter un fichier `.gitconfig` à la racine de votre projet avec le contenu suivant :
>
> ```ini
> [http "https://github.com"]
> version = HTTP/1.1
> ```

## :cake: Solution

J'ai essayé de passer en scalingo-26, le build échoue avec trop d'erreurs difficiles à investiguer dans le laps de temps dont nous disposons pour rétablir les déploiements. J'ai donc appliqué la solution alternative du `.gitconfig` à la racine.

## :desert_island: How to test

Review app should be built and deployed just fine.