### PR TITLE
fix: always reset processes

### DIFF
--- a/backend/src/app/cli/commands.py
+++ b/backend/src/app/cli/commands.py
@@ -420,3 +420,62 @@ def load_processes_json(json_file: click.File) -> None:
 
     console.rule("Loading processes file.")
     anyio.run(_load_processes_json, json_data)
+
+
+async def reset_processes_fixtures(
+    db_session, processes_service, processes_data: list[dict[str, Any]]
+) -> None:
+    """Import/Synchronize Database Fixtures."""
+
+    from structlog import get_logger
+
+    logger = get_logger()
+
+    user = await get_or_create_default_user(db_session)
+
+    for process in processes_data:
+        process["id"] = UUID(process["id"])
+        process["owner"] = user
+
+    existing_processes = await processes_service.get_many()
+    existing_processes_ids = [process.id for process in existing_processes]
+
+    await processes_service.delete_many(
+        item_ids=existing_processes_ids,
+        auto_commit=False,
+    )
+    await processes_service.create_many(
+        data=processes_data,
+        auto_commit=False,
+    )
+
+    await db_session.commit()
+
+    await logger.ainfo(f"Deleted {len(existing_processes_ids)} existing processes")
+    await logger.ainfo(f"Loaded {len(processes_data)} processes fixtures")
+
+
+@fixtures_management_group.command(
+    name="reset-processes", help="Reset (delete and load) processes from JSON file."
+)
+@click.argument("json_file", type=click.File("rb"), nargs=1)
+def reset_processes_json(json_file: click.File) -> None:
+    """Reset processes from a json file.
+
+    Args:
+        processes json file (Path): The path to the JSON file to load.
+    """
+
+    console = get_console()
+
+    json_data = orjson.loads(json_file.read())  # ty: ignore[unresolved-attribute]
+
+    async def _reset_processes_json(components_data) -> None:
+        async with alchemy.get_session() as db_session:
+            processes_service = await anext(provide_processes_service(db_session))
+            await reset_processes_fixtures(
+                db_session, processes_service, components_data
+            )
+
+    console.rule("Resetting processes from file.")
+    anyio.run(_reset_processes_json, json_data)

--- a/backend/src/app/cli/commands.py
+++ b/backend/src/app/cli/commands.py
@@ -9,6 +9,7 @@ import click
 import orjson
 from advanced_alchemy.utils.fixtures import open_fixture_async
 from rich import get_console
+from sqlalchemy.sql import text
 from structlog import get_logger
 
 from app.config import get_settings
@@ -436,14 +437,7 @@ async def reset_processes_fixtures(
     for process in processes_data:
         process["id"] = UUID(process["id"])
         process["owner"] = user
-
-    existing_processes = await processes_service.get_many()
-    existing_processes_ids = [process.id for process in existing_processes]
-
-    await processes_service.delete_many(
-        item_ids=existing_processes_ids,
-        auto_commit=False,
-    )
+    await db_session.execute(text("""TRUNCATE PROCESS CASCADE"""))
     await processes_service.create_many(
         data=processes_data,
         auto_commit=False,
@@ -451,7 +445,6 @@ async def reset_processes_fixtures(
 
     await db_session.commit()
 
-    await logger.ainfo(f"Deleted {len(existing_processes_ids)} existing processes")
     await logger.ainfo(f"Loaded {len(processes_data)} processes fixtures")
 
 

--- a/bin/load-fixtures.sh
+++ b/bin/load-fixtures.sh
@@ -17,8 +17,11 @@ if [ "$IS_REVIEW_APP" == "true" ]; then
    uv run backend database upgrade --no-prompt
 fi
 
-# Always update the processes with the latest data, even on staging or production
-uv run backend fixtures load-processes public/data/processes_impacts.json
+# Always reset the processes with the latest data, even on production
+# As we don’t use FK to processes anymore, we decided to stop updating
+# the processes and instead just delete and add again
+# (Updates were taking ages and was blocking scalingo deploy)
+uv run backend fixtures reset-processes public/data/processes_impacts.json
 
 if [ "$IS_REVIEW_APP" == "true" ]; then
    # We want to keep the staging components as they are, so we only load the default ones on review apps

--- a/bin/load-fixtures.sh
+++ b/bin/load-fixtures.sh
@@ -21,6 +21,7 @@ fi
 # As we don’t use FK to processes anymore, we decided to stop updating
 # the processes and instead just delete and add again
 # (Updates were taking ages and was blocking scalingo deploy)
+# https://github.com/MTES-MCT/ecobalyse/pull/2785
 uv run backend fixtures reset-processes public/data/processes_impacts.json
 
 if [ "$IS_REVIEW_APP" == "true" ]; then


### PR DESCRIPTION
## :wrench: Problem

Updating processes on scalingo takes ages and prevent the app from being deployed.

## :cake: Solution

Always remove and then readd all the processes as we don’t need/use components anymore (that could have FK to the processes)

## :desert_island: How to test

The review app should have processes in the admin. We will need to wait for the prod deploy to test in real conditions.
