### PR TITLE
chore: uv version >= 0.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,3 +107,6 @@ extend-select = ["I"]
 extra-paths = [
     "data/",
 ]
+
+[tool.uv]
+required-version =  ">=0.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,4 +109,4 @@ extra-paths = [
 ]
 
 [tool.uv]
-required-version =  ">=0.8"
+required-version =  ">=0.12"


### PR DESCRIPTION
## :wrench: Problem

issue #2789's cause is I had an older uv version (0.7)

## :cake: Solution

To avoid this kind of issue, constrain uv version to be at least >= 0.12